### PR TITLE
🧪 [testing improvement] add unit tests for observability redaction

### DIFF
--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,63 @@
+import re
+from h4ckath0n.obs.redaction import redact_headers, redact_value, make_redactor
+
+def test_redact_headers():
+    headers = {
+        "Authorization": "Bearer secret",
+        "X-API-Key": "sk-12345678901234567890",
+        "Cookie": "session=abc",
+        "Set-Cookie": "session=abc",
+        "Content-Type": "application/json",
+        "User-Agent": "test-agent"
+    }
+    redacted = redact_headers(headers)
+
+    assert redacted["Authorization"] == "[REDACTED]"
+    assert redacted["X-API-Key"] == "[REDACTED]"
+    assert redacted["Cookie"] == "[REDACTED]"
+    assert redacted["Set-Cookie"] == "[REDACTED]"
+    assert redacted["Content-Type"] == "application/json"
+    assert redacted["User-Agent"] == "test-agent"
+
+    # Test case insensitivity
+    headers_lower = {
+        "authorization": "Bearer secret",
+        "x-api-key": "sk-12345678901234567890"
+    }
+    redacted_lower = redact_headers(headers_lower)
+    assert redacted_lower["authorization"] == "[REDACTED]"
+    assert redacted_lower["x-api-key"] == "[REDACTED]"
+
+def test_redact_headers_empty():
+    assert redact_headers({}) == {}
+
+def test_redact_value():
+    # JWT-like (short version that matches current pattern)
+    jwt_short = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+    assert redact_value(jwt_short) == "[REDACTED]"
+
+    # OpenAI key
+    openai_key = "sk-abcdefghijklmnopqrstuvwxyz"
+    assert redact_value(openai_key) == "[REDACTED]"
+
+    # LangSmith key
+    langsmith_key = "lsv2_pt_abcdefghijklmnopqrstuvwxyz"
+    assert redact_value(langsmith_key) == "[REDACTED]"
+
+    # Non-sensitive
+    assert redact_value("hello world") == "hello world"
+
+    # Multiple secrets
+    mixed = f"Here is a JWT: {jwt_short} and an OpenAI key: {openai_key}"
+    assert redact_value(mixed) == "Here is a JWT: [REDACTED] and an OpenAI key: [REDACTED]"
+
+def test_make_redactor():
+    redact = make_redactor()
+    openai_key = "sk-abcdefghijklmnopqrstuvwxyz"
+    assert redact(openai_key) == "[REDACTED]"
+
+    # Extra patterns
+    custom_pattern = re.compile(r"CUSTOM-[0-9]+")
+    redact_custom = make_redactor(extra_patterns=[custom_pattern])
+    assert redact_custom("CUSTOM-123") == "[REDACTED]"
+    assert redact_custom(openai_key) == "[REDACTED]" # Should still have defaults


### PR DESCRIPTION
This PR addresses the testing gap for the observability redaction utilities.

🎯 **What:** The testing gap for `src/h4ckath0n/obs/redaction.py` has been addressed by adding a new test suite in `tests/test_redaction.py`.
📊 **Coverage:** The new tests cover:
  - `redact_headers`: Ensures `Authorization`, `X-API-Key`, `Cookie`, and `Set-Cookie` are redacted (case-insensitively) while other headers like `Content-Type` are preserved.
  - `redact_value`: Validates that secret patterns like JWTs, OpenAI API keys, and LangSmith keys are correctly replaced with `[REDACTED]`.
  - `make_redactor`: Verifies that custom redactors can be created and extended with additional patterns.
✨ **Result:** Significant improvement in test coverage for the observability module, ensuring that sensitive data is reliably masked before being recorded in traces.

---
*PR created automatically by Jules for task [8096975154996276752](https://jules.google.com/task/8096975154996276752) started by @ToolchainLab*