### PR TITLE
🎨 Palette: Add required field indicators to form inputs

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Input.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Input.tsx
@@ -15,7 +15,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     return (
       <div className="space-y-2">
-        {label && <Label htmlFor={inputId}>{label}</Label>}
+        {label && (
+          <Label htmlFor={inputId}>
+            {label}
+            {props.required && <span className="text-danger ml-1">*</span>}
+          </Label>
+        )}
         <input
           id={inputId}
           type={type}

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -68,7 +68,12 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
 
     return (
       <div className="space-y-2">
-        {label && <Label htmlFor={inputId}>{label}</Label>}
+        {label && (
+          <Label htmlFor={inputId}>
+            {label}
+            {props.required && <span className="text-danger ml-1">*</span>}
+          </Label>
+        )}
         <div className="relative">
           <input
             id={inputId}

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ForgotPassword.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ForgotPassword.tsx
@@ -96,6 +96,7 @@ export function ForgotPassword() {
                 autoComplete="email"
                 autoCapitalize="none"
                 autoFocus
+                required
               />
               <Button
                 type="submit"

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Login.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Login.test.tsx
@@ -31,7 +31,7 @@ vi.mock("react-router", () => ({
 describe("Login page", () => {
   it("renders Email label instead of Username", () => {
     render(<Login />);
-    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Email/)).toBeInTheDocument();
     expect(screen.queryByLabelText("Username")).not.toBeInTheDocument();
   });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Login.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Login.tsx
@@ -111,6 +111,7 @@ export function Login() {
               autoComplete="email"
               autoCapitalize="none"
               autoFocus
+              required
             />
             <div className="space-y-2">
               <div className="flex items-center justify-between">
@@ -119,6 +120,7 @@ export function Login() {
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 >
                   Password
+                  <span className="text-danger ml-1">*</span>
                 </label>
                 <Link
                   to="/forgot-password"
@@ -134,6 +136,7 @@ export function Login() {
                 disabled={isLoading}
                 data-testid="login-password-input"
                 autoComplete="current-password"
+                required
               />
             </div>
             <Button

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.test.tsx
@@ -31,7 +31,7 @@ vi.mock("react-router", () => ({
 describe("Register page", () => {
   it("renders Display Name label instead of Username", () => {
     render(<Register />);
-    expect(screen.getByLabelText("Display Name")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Display Name/)).toBeInTheDocument();
     expect(screen.queryByLabelText("Username")).not.toBeInTheDocument();
   });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.tsx
@@ -93,6 +93,7 @@ export function Register() {
               autoComplete="name"
               maxLength={DISPLAY_NAME_MAX_LENGTH}
               autoFocus
+              required
             />
 
             <Button
@@ -134,6 +135,7 @@ export function Register() {
               data-testid="register-email-input"
               autoComplete="email"
               autoCapitalize="none"
+              required
             />
             <PasswordField
               id="password"
@@ -143,6 +145,7 @@ export function Register() {
               disabled={isLoading}
               data-testid="register-password-input"
               autoComplete="new-password"
+              required
             />
             <Button
               type="submit"

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ResetPassword.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ResetPassword.tsx
@@ -130,6 +130,7 @@ export function ResetPassword() {
                 data-testid="reset-password-input"
                 autoComplete="new-password"
                 autoFocus
+                required
               />
               <Button
                 type="submit"


### PR DESCRIPTION
This PR introduces a micro-UX enhancement by adding visual "required" indicators (a red `*`) to standard form fields across the authentication flows.

**Changes made:**
- Updated `Input.tsx` and `PasswordField.tsx` to conditionally render a `<span className="text-danger ml-1">*</span>` next to the label if the `required` prop is `true`.
- Added the `required` prop to the necessary fields in `Register.tsx`, `Login.tsx`, `ForgotPassword.tsx`, and `ResetPassword.tsx`.
- Updated corresponding unit tests (`Login.test.tsx`, `Register.test.tsx`) to use regex matching for labels to account for the new visual decorator, preventing brittle tests.

**Verification:**
- Ran `npm test`, `npm run lint`, `npm run typecheck`, and `npm run build` locally in the web template directory. All checks pass.
- Visually verified the changes using Playwright screenshots.

---
*PR created automatically by Jules for task [11949898130395523762](https://jules.google.com/task/11949898130395523762) started by @ToolchainLab*