### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration via timing attack in login

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Fix User Enumeration via Timing Attack in Login
+**Vulnerability:** The login endpoint in `authenticate_user` returned early without hashing the password if the user did not exist or had no password set. This allowed an attacker to enumerate valid email addresses by measuring the response time, since hashing is a time-consuming operation.
+**Learning:** Even when failing an authentication attempt early (e.g., user not found), it's crucial to perform a dummy hashing operation of similar computational cost to prevent timing attacks.
+**Prevention:** Always ensure a consistent execution time path for authentication endpoints. For login, perform a dummy password hashing (`hash_password(password)`) when a user is not found or when they don't have a password.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -73,11 +73,16 @@ async def register_user(
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
-    _hash, verify_password = _require_password_extra()
+    hash_password, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
+
+    # 🛡️ Sentinel: Prevent user enumeration via timing attacks
+    # Always perform a hashing operation even if the user is not found
     if (user := result.scalars().first()) is None:
+        hash_password(password)
         return None
     if not user.password_hash:
+        hash_password(password)
         return None
     if not verify_password(password, user.password_hash):
         return None


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The login endpoint returned early without performing a password hash if the user was not found or had no password set. Since hashing is a time-consuming operation, an attacker could enumerate valid email addresses by measuring the response time.
🎯 Impact: Attackers could build a list of valid user emails by brute-forcing the login endpoint and analyzing response times.
🔧 Fix: Introduced a dummy `hash_password(password)` call in the early return paths (`user is None` and `not user.password_hash`) to ensure a consistent execution time path for all authentication attempts.
✅ Verification: Ran `uv run --extra password pytest tests/` to confirm that the changes did not break any existing functionality.

---
*PR created automatically by Jules for task [12711245811177735008](https://jules.google.com/task/12711245811177735008) started by @ToolchainLab*