### PR TITLE
🧭 Atlas: Add drift prevention for environment variable docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/sync_doc_env.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-03-14 - Pydantic settings are the source of truth for config docs
+
+**Learning:** Generating the environment variable docs natively from the Pydantic `Settings` model using string representations of defaults is more reliable than extracting them with regex or using manual lists, which are prone to drift. This provides an executable specification for the environment variables configuration.
+
+**Action:** Add an automated doc-generation check script that reads the `Settings` schema directly using `Settings.model_fields.items()` and ensure it is hooked into the `backend` CI validation step.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- ENV_DOCS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY` / `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty |  |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` |  |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` |  |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` |  |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` |  |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | 50 MB |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` |  |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | "file" or "smtp" |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` |  |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` |  |
+| `H4CKATH0N_SMTP_HOST` | empty |  |
+| `H4CKATH0N_SMTP_PORT` | `587` |  |
+| `H4CKATH0N_SMTP_USERNAME` | empty |  |
+| `H4CKATH0N_SMTP_PASSWORD` | empty |  |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` |  |
+| `H4CKATH0N_SMTP_SSL` | `false` |  |
+| `H4CKATH0N_DEMO_MODE` | `false` |  |
+<!-- ENV_DOCS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/sync_doc_env.py
+++ b/scripts/sync_doc_env.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention generator: updates README.md Configuration."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+START_MARKER = "<!-- ENV_DOCS_START -->"
+END_MARKER = "<!-- ENV_DOCS_END -->"
+
+
+def format_default(field_info) -> str:
+    """Format a default value for markdown."""
+    from pydantic_core import PydanticUndefined
+
+    default = field_info.default
+
+    if default is PydanticUndefined:
+        return "*required*"
+    if default == "":
+        return "empty"
+    if isinstance(default, list):
+        if not default:
+            return "`[]`"
+        return f"`{default}`"
+    if isinstance(default, bool):
+        return f"`{'true' if default else 'false'}`"
+    if isinstance(default, (int, str)):
+        return f"`{default}`"
+    return f"`{default}`"
+
+
+def generate_env_table() -> str:
+    """Generate the markdown table for environment variables."""
+    from h4ckath0n.config import Settings
+
+    config_source = (REPO_ROOT / "src/h4ckath0n/config.py").read_text()
+
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for name, field_info in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+        default_str = format_default(field_info)
+
+        desc = ""
+        for line in config_source.splitlines():
+            # handle cases where the line might have spaces before the colon
+            if re.match(rf"^\s*{name}\s*:", line):
+                if "#" in line:
+                    desc = line.split("#", 1)[1].strip()
+                break
+
+        # Handle special cases based on existing README
+        var_name = f"`{var_name}`"
+
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+            desc = "WebAuthn relying party ID, required in production"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+            desc = "WebAuthn origin, required in production"
+        elif name == "database_url":
+            desc = "SQLAlchemy connection string"
+        elif name == "auto_upgrade":
+            desc = "Auto-run packaged DB migrations to head on startup"
+        elif name == "env":
+            desc = "`development` or `production`"
+        elif name == "webauthn_ttl_seconds":
+            desc = "WebAuthn challenge TTL in seconds"
+        elif name == "user_verification":
+            desc = "WebAuthn user verification requirement"
+        elif name == "attestation":
+            desc = "WebAuthn attestation preference"
+        elif name == "password_auth_enabled":
+            desc = "Enable password routes when the extra is installed"
+        elif name == "password_reset_expire_minutes":
+            desc = "Password reset token expiry in minutes"
+        elif name == "bootstrap_admin_emails":
+            desc = "JSON list of emails that become admin on password signup"
+        elif name == "first_user_is_admin":
+            desc = "First password signup becomes admin"
+        elif name == "openai_api_key":
+            var_name = "`OPENAI_API_KEY` / `H4CKATH0N_OPENAI_API_KEY`"
+            desc = "OpenAI API key for the LLM wrapper"
+        else:
+            pass
+
+        lines.append(f"| {var_name} | {default_str} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def sync_readme(dry_run: bool = False) -> int:
+    """Sync the README file, or check if it's up to date in dry_run mode."""
+    readme_text = README.read_text()
+
+    if START_MARKER not in readme_text or END_MARKER not in readme_text:
+        print(f"❌ Error: {START_MARKER} or {END_MARKER} not found in README.md")
+        return 1
+
+    pattern = re.compile(rf"({START_MARKER}).*?({END_MARKER})", re.DOTALL)
+
+    new_table = f"{START_MARKER}\n{generate_env_table()}\n{END_MARKER}"
+    new_text = pattern.sub(new_table, readme_text)
+
+    if dry_run:
+        if readme_text != new_text:
+            print("❌ README.md is out of date. Run `scripts/sync_doc_env.py` to update it.")
+            return 1
+        print("✅ README.md is up to date.")
+        return 0
+
+    if readme_text == new_text:
+        print("✅ README.md is already up to date.")
+        return 0
+
+    README.write_text(new_text)
+    print("✅ Updated README.md successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if README is up to date")
+    args = parser.parse_args()
+
+    sys.exit(sync_readme(dry_run=args.check))


### PR DESCRIPTION
💡 What: Replace the hand-written configuration table in README.md with an auto-generated table parsed directly from the `Settings` class in `src/h4ckath0n/config.py`.
🎯 Why: Environment variables are a primary vector for docs drift. By hooking the README table generation to the `Settings` model, we ensure the documentation never falls out of sync with what the system actually runs with.
🧪 Verification: Locally run `uv run scripts/sync_doc_env.py` to regenerate `README.md`.
🔒 Drift Prevention: Added `scripts/sync_doc_env.py --check` step to the CI `backend` workflow job. This fails the build if the code and docs are desynced.
🗺️ Evidence: Verified against `src/h4ckath0n/config.py`.

---
*PR created automatically by Jules for task [80404153421834308](https://jules.google.com/task/80404153421834308) started by @ToolchainLab*