### PR TITLE
⚡ Bolt: [performance improvement] Optimize verify_device_jwt hot path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,8 @@
 
 **Learning:** When retrieving a single field (like a primary key ID) from the database, querying for the full ORM object using `db.execute(select(Model)).scalars().first()` forces SQLAlchemy to parse, allocate, and hydrate the entire model instance, including potentially large fields like JSON blocks or long texts.
 **Action:** Always use `db.scalar(select(Model.id)...)` when only the identifier is needed. This avoids the ORM overhead and significantly reduces database bandwidth and memory allocation.
+
+## 2026-03-15 - Optimize Hot Paths by Using db.get and Avoiding Full ORM Hydration
+
+**Learning:** In highly-frequented paths like `verify_device_jwt` (which runs on every authenticated request), querying for the full ORM object using `db.execute(select(Model)).scalars().first()` forces SQLAlchemy to parse, allocate, and hydrate the entire model instance. Furthermore, for primary keys, it bypasses the session identity map.
+**Action:** Always use `db.get(Model, primary_key)` for primary key lookups to hit the session identity map. When only checking for existence or fetching a single field (like `User.id`), use `db.scalar(select(Model.id).filter(...))` to bypass unnecessary ORM hydration overhead.

--- a/src/h4ckath0n/realtime/auth.py
+++ b/src/h4ckath0n/realtime/auth.py
@@ -82,8 +82,8 @@ async def verify_device_jwt(
     if not kid:
         raise AuthError("Missing kid in JWT header")
 
-    result = await db.execute(select(Device).filter(Device.id == kid))
-    device = result.scalars().first()
+    # ⚡ Bolt: Use primary key lookup to hit the session identity map.
+    device = await db.get(Device, kid)
     if not device:
         raise AuthError("Unknown device")
 
@@ -114,12 +114,12 @@ async def verify_device_jwt(
         raise AuthError(f"Invalid aud: expected {expected_aud}")
 
     # ── user lookup ───────────────────────────────────────────────────
-    result = await db.execute(select(User).filter(User.id == claims.sub))
-    user = result.scalars().first()
-    if user is None:
+    # ⚡ Bolt: Fetch only the ID to avoid instantiating the full User ORM object.
+    user_id = await db.scalar(select(User.id).filter(User.id == claims.sub))
+    if user_id is None:
         raise AuthError("User not found")
 
-    return AuthContext(user_id=user.id, device_id=device.id)
+    return AuthContext(user_id=user_id, device_id=device.id)
 
 
 # ── Transport helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
**💡 What**
Optimized the `device` and `user` lookups in `verify_device_jwt` by replacing full ORM `db.execute(select(Model)).scalars().first()` fetches with `await db.get(Device, kid)` and `await db.scalar(select(User.id).filter(...))`.

**🎯 Why**
`verify_device_jwt` is a hot path executed on every authenticated request. Fetching full ORM objects forces SQLAlchemy to parse, allocate, and hydrate the entire model instance, including potentially large fields. For primary keys, `db.execute` bypasses the session identity map. This change reduces unnecessary overhead.

**📊 Impact**
Reduces database roundtrips for already-cached devices (via `db.get` and session identity map) and significantly reduces database bandwidth and memory allocation overhead for user lookups by only fetching the `id` field.

**🔬 Measurement**
Run backend tests to ensure functionality remains unchanged (`uv run --extra password pytest tests/`). Compare memory and execution time profiles of repeated authenticated requests with and without the change.

---
*PR created automatically by Jules for task [12160197617886606241](https://jules.google.com/task/12160197617886606241) started by @ToolchainLab*