### PR TITLE
∴ Vector: Centralize scope parsing and formatting

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Centralize scope parsing and formatting
+**Learning:** The database model `user.scopes` (a comma-separated string) is repeatedly parsed using manual pipelines like `filter(None, map(str.strip, scopes.split(",")))` across the repository (e.g., CLI tools, endpoint dependencies, routing). This risks subtle bugs with whitespace, empties, duplicates, and ordering.
+**Action:** Centralized the logic into pure functions `parse_scopes` and `format_scopes` within `src/h4ckath0n/auth/scopes.py`. This ensures one single source of truth for semantic boundaries and clarifies the FP transformation pipeline without mutating `user.scopes` in place or dealing with ad-hoc list comprehension scattered across multiple files.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -83,10 +84,10 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[str] = set(filter(None, map(str.strip, scopes)))
+    needed: set[str] = set(parse_scopes(",".join(scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,12 @@
+"""Scope normalization and validation utilities."""
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a deduplicated list of scopes."""
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: list[str]) -> str:
+    """Format a list of scopes into a comma-separated string."""
+    return ",".join(scopes)

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,11 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                if (stripped := scope.strip()) and stripped not in existing:
+                    existing.append(stripped)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +475,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +504,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_auth_scopes.py
+++ b/tests/test_auth_scopes.py
@@ -1,0 +1,24 @@
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+
+def test_parse_scopes_empty():
+    assert parse_scopes("") == []
+    assert parse_scopes("   ") == []
+    assert parse_scopes(",,") == []
+
+
+def test_parse_scopes_whitespace():
+    assert parse_scopes(" a , b  ,  c ") == ["a", "b", "c"]
+
+
+def test_parse_scopes_deduplication():
+    assert parse_scopes("a,b,a,c,b") == ["a", "b", "c"]
+
+
+def test_parse_scopes_mixed():
+    assert parse_scopes("  admin,  user ,,, admin, test ") == ["admin", "user", "test"]
+
+
+def test_format_scopes():
+    assert format_scopes(["a", "b", "c"]) == "a,b,c"
+    assert format_scopes([]) == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,11 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert format_scopes(parse_scopes("a,b,c")) == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert format_scopes(parse_scopes("a,b,a")) == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert format_scopes(parse_scopes(" a , b , c ")) == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert format_scopes(parse_scopes("a,,b,,")) == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert format_scopes(parse_scopes("")) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Extracted repeated `scopes.split(",")` and `filter(None, map(str.strip))` logic into centralized pure helper functions (`parse_scopes` and `format_scopes`) within `src/h4ckath0n/auth/scopes.py`. Replaced all ad-hoc local mutation pipelines in `cli.py`, `dependencies.py`, and `session_router.py` with these utilities.

🎯 Why: The database model for `user.scopes` relies on comma-separated strings. The logic to safely parse this into an iterable (handling empties, whitespace, duplicates, and order preservation) was duplicated in at least 4 places. This created semantic drift and mutation-heavy code locally (e.g. converting to sets, converting back, stripping).

🧠 Design: The smallest correct cleanup is centralizing the logic in one place (`scopes.py`) as pure functions, establishing a single source of truth for semantic boundaries and parsing behavior.

λ FP Angle: Transforms multiple instances of localized manual state transitions and ad-hoc list comprehensions into a clear `string -> list -> string` transformation pipeline. It cleanly separates the data shaping behavior from the side-effecting contexts (like SQLAlchemy commits).

✅ Verification: Re-ran the full `pytest` suite and explicitly created new test cases in `tests/test_auth_scopes.py`. Linting and formatting via `ruff` passed. 

🧪 Edge cases: Fixes an implicit issue in the CLI `grant-scope` where casting to `set()` destroyed the initial order of the scopes. `parse_scopes` uses `dict.fromkeys` to maintain deterministic order and drops duplicates.

⚠️ Risk: Very low. It strictly replaces isomorphic mapping logic with a proven shared function and does not alter underlying framework behavior.

---
*PR created automatically by Jules for task [8007501585212928604](https://jules.google.com/task/8007501585212928604) started by @ToolchainLab*