### PR TITLE
🧭 Atlas: Auto-generate configuration docs from source of truth and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/check_doc_config.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-16 - Configuration docs drift when decoupled from source of truth
+
+**Learning:** Manually listing configuration variables (e.g. env vars in README.md) inevitably drifts as the codebase evolves (e.g. Pydantic Settings models change). Using a programmatic drift check (e.g. reflecting over `Settings.model_fields.keys()`) against the docs string is an effective verification technique to catch missing variables.
+
+**Action:** Whenever generating lists of configuration options, env vars, or similar attributes, write a drift check script that dynamically introspects the source of truth (e.g. the Pydantic model) and verifies each variable exists in the documentation string.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs synchronously in development without a worker |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend, e.g., `local` or `s3` |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend, e.g., `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_config.py
+++ b/scripts/check_doc_config.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S uv run python
+"""Drift check: verify that all configuration variables are documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_config.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_config_vars() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    vars_list = []
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            vars_list.append("OPENAI_API_KEY")
+            vars_list.append("H4CKATH0N_OPENAI_API_KEY")
+        else:
+            vars_list.append(f"H4CKATH0N_{field_name.upper()}")
+    return sorted(vars_list)
+
+
+def check_vars_in_readme(vars_list: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing = []
+    for var in vars_list:
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    vars_list = get_config_vars()
+    missing = check_vars_in_readme(vars_list)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration section in README.md.")
+        return 1
+
+    print(f"✅ All {len(vars_list)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: The static configuration table in `README.md` was updated to be automatically verifiable and match the `h4ckath0n.config.Settings` pydantic model. Added a Python script `scripts/check_doc_config.py` and a new CI job to enforce this parity.
🎯 Why: The previous handwritten table had drifted significantly from the actual source of truth (the Pydantic `Settings` model), hiding many operational configuration variables from developers.
🧪 Verification: Run `uv run scripts/check_doc_config.py` locally to verify that all config fields are documented in the `README.md`.
🔒 Drift Prevention: Added `scripts/check_doc_config.py` which reflects over `Settings.model_fields.keys()` and asserts each appears in `README.md`. The CI workflow `.github/workflows/ci.yml` was updated to run this check on every pull request.
🗺️ Evidence: `src/h4ckath0n/config.py`


---
*PR created automatically by Jules for task [8537870850245036577](https://jules.google.com/task/8537870850245036577) started by @ToolchainLab*