### PR TITLE
∴ Vector: Centralize and fix scope string normalization

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Centralize comma-separated string parsing (Scopes)
+**Learning:** The codebase heavily relies on comma-separated strings for things like scopes. Ad-hoc implementations to parse, trim, deduplicate, and format these strings are bug-prone and non-deterministic when using sets. Python's `dict.fromkeys()` is more idiomatic for order-preserving deduplication than a manual `set()`.
+**Action:** Centralize string parsing and formatting into pure helpers (e.g. `parse_scopes`, `format_scopes`, `normalize_scopes` in `src/h4ckath0n/auth/scopes.py`). Always use these utilities instead of manually splitting (`.split(",")`) or creating sets.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -86,7 +87,7 @@ def require_scopes(*scopes: str) -> Any:
     needed: set[str] = set(filter(None, map(str.strip, scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,19 @@
+"""Scope normalization and formatting utilities."""
+
+from collections.abc import Iterable
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a deduplicated list of scopes."""
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of scopes into a comma-separated string."""
+    return ",".join(scopes)
+
+
+def normalize_scopes(raw: str) -> str:
+    """Normalize a comma-separated scopes string (deduplicated, order-preserving)."""
+    return format_scopes(parse_scopes(raw))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, normalize_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,11 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                if (s := scope.strip()) and s not in existing:
+                    existing.append(s)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +475,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +504,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = normalize_scopes(args.scopes)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,8 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
+from h4ckath0n.auth.scopes import normalize_scopes
 from tests.conftest import run_cli as _run_cli
 
 # ---------------------------------------------------------------------------
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert normalize_scopes("a,b,c") == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert normalize_scopes("a,b,a") == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert normalize_scopes(" a , b , c ") == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert normalize_scopes("a,,b,,") == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,12 +9,12 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.scopes import normalize_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
 )
-from h4ckath0n.auth.scopes import normalize_scopes
 from tests.conftest import run_cli as _run_cli
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 **What**: Extracted repeated ad-hoc string parsing logic for "scopes" into pure functional utilities (`parse_scopes`, `format_scopes`, `normalize_scopes`) inside `src/h4ckath0n/auth/scopes.py`. Updated `cli.py`, `dependencies.py`, and `session_router.py` to use these centralized helpers.

🎯 **Why**: The codebase relied on manual `.split(",")`, `strip()`, and `set()` operations across multiple files to handle comma-separated scope strings. This scattered implementation was bug-prone (e.g., in `cli.py` during removal, spaces weren't reliably stripped leading to match failures) and relying on sets destroyed deterministic ordering. Centralizing this logic into a single source of truth eliminates duplication and enforces consistency.

🧠 **Design**: The new `parse_scopes` function uses Python's `dict.fromkeys()` to achieve deterministic, order-preserving deduplication while parsing the string into a list. This provides an `O(1)` deduplication mechanism without the unpredictable iteration order of a `set`.

λ **FP Angle**: Replaced scattered, mutation-heavy local tracking sets with pure transformation pipelines (string -> explicit data structure -> normalized string) and centralized normalization semantics.

✅ **Verification**:
- Executed `uv run ruff format .` and `uv run ruff check .`
- Executed full test suite via `uv run pytest tests/ -v`, including the `TestNormalizeScopes` test suite ported over to validate the new helper methods.
- Requested code review resulting in a `#Correct#` rating.

🧪 **Edge cases**: Now handles whitespace padding, repeated commas, empty strings, and internal duplicate scopes perfectly deterministically across all usage sites. 

⚠️ **Risk**: Very low. Behavioral changes are strictly additive bug-fixes (preventing whitespace comparison failures in `cli.py`). The use of `dict.fromkeys()` correctly maintains backwards compatibility.

---
*PR created automatically by Jules for task [1027665793520429640](https://jules.google.com/task/1027665793520429640) started by @ToolchainLab*