### PR TITLE
🎨 Palette: Add ARIA labels to mobile toggles in Layout

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-17 - Add aria-labels to duplicate responsive elements in Layout
+**Learning:** When using responsive layouts (like desktop/mobile toolbars), visual hiding (Tailwind `md:hidden` / `hidden md:flex`) doesn't hide elements from the testing library query `getByRole`. If `aria-label`s are added for accessibility on both duplicates, React Testing Library `getByRole` calls will throw a multiple elements error.
+**Action:** When adding accessibility features like `aria-label` to duplicate responsive components (e.g. mobile toggles), ensure corresponding unit tests are updated to use `screen.getAllByRole` and index the results to avoid "Found multiple elements" failures.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0],
       ).toBeInTheDocument();
     });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -192,6 +192,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +208,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only mobile Theme toggle and mobile Menu toggle buttons in the `Layout` component, along with `aria-expanded` state.
🎯 Why: Without ARIA labels, screen readers announce these crucial navigation buttons merely as "button" or by reading the inner SVG paths, confusing users who rely on assistive technologies.
📸 Before/After: Verified visual layout and component render.
♿ Accessibility: Improved keyboard/screen-reader navigation by explicitly naming the mobile "Theme" toggle and "Open menu"/"Close menu" toggle elements. Tests were safely updated to use `getAllByRole` to prevent ambiguity.

---
*PR created automatically by Jules for task [1002739539513008286](https://jules.google.com/task/1002739539513008286) started by @ToolchainLab*