### PR TITLE
∴ Vector: Centralize scope string normalization and deduplication

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Centralize scope string parsing and formatting
+**Learning:** Comma-separated scope strings were being manually parsed (split, strip, filter) across `auth.dependencies`, `auth.session_router`, and `cli.py`, leading to duplicated normalization logic and potential drift.
+**Action:** Created centralized functional-style utilities `parse_scopes` and `format_scopes` in `h4ckath0n.auth.scopes` to ensure a single source of truth for deduplicating, trimming, and normalizing scope strings across the API and CLI boundaries.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -83,10 +84,10 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[str] = set(filter(None, map(str.strip, scopes)))
+    needed: set[str] = set(parse_scopes(",".join(scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,22 @@
+"""Utilities for managing user scopes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def parse_scopes(raw: str | None) -> list[str]:
+    """Parse a comma-separated scopes string into a list of normalized, unique scopes.
+
+    Preserves order while deduplicating. Trims whitespace and removes empty segments.
+    """
+    if not raw:
+        return []
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of scopes into a normalized, comma-separated string."""
+    parts = filter(None, map(str.strip, scopes))
+    return ",".join(dict.fromkeys(parts))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,11 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                if scope.strip() not in existing:
+                    existing.append(scope.strip())
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +475,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +504,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -129,26 +128,6 @@ class TestAlembicUrlNormalization:
 
 # ---------------------------------------------------------------------------
 # Scopes normalization
-# ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
-
-
 # ---------------------------------------------------------------------------
 # CLI integration (using subprocess to avoid sys.exit leaking)
 # ---------------------------------------------------------------------------

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,0 +1,26 @@
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+
+class TestScopesParsing:
+    def test_basic(self):
+        assert parse_scopes("a,b,c") == ["a", "b", "c"]
+        assert format_scopes(["a", "b", "c"]) == "a,b,c"
+
+    def test_dedup(self):
+        assert parse_scopes("a,b,a") == ["a", "b"]
+        assert format_scopes(["a", "b", "a"]) == "a,b"
+
+    def test_trim(self):
+        assert parse_scopes(" a , b , c ") == ["a", "b", "c"]
+        assert format_scopes([" a ", " b ", " c "]) == "a,b,c"
+
+    def test_empty_segments(self):
+        assert parse_scopes("a,,b,,") == ["a", "b"]
+        assert format_scopes(["a", "", "b", "", ""]) == "a,b"
+
+    def test_empty_string(self):
+        assert parse_scopes("") == []
+        assert format_scopes([]) == ""
+
+    def test_none_parsing(self):
+        assert parse_scopes(None) == []


### PR DESCRIPTION
- 💡 **What:** Extracted duplicated comma-separated scope parsing (split, strip, filter, dedupe) into centralized pure helper functions (`parse_scopes` and `format_scopes`) within `src/h4ckath0n/auth/scopes.py`. Updated `dependencies.py`, `session_router.py`, and `cli.py` to use these helpers instead of implementing ad-hoc logic.
- 🎯 **Why:** To improve code quality by removing repeated normalization logic, creating a single source of truth for scope string manipulation, reducing edge-case bugs, and making code more maintainable across CLI and API boundaries.
- 🧠 **Design:** Created a new module specifically for pure transformation helpers related to scopes. Replaced redundant mutation-heavy string building in CLI with simple list appends and formats. Migrated and expanded test coverage for these explicit pure functions in `tests/test_scopes.py`. 
- λ **FP Angle:** Transforms scattered `split()`, `strip()`, and `filter()` logic into composable, pure functions (`parse_scopes` and `format_scopes`) that explicitly model the transformation of a raw string to a clean list and back. Eliminates implicit side effects and local temporary mutable staging.
- ✅ **Verification:** Re-ran all tests via `uv run --locked pytest tests/ -v`, including a new dedicated test suite (`test_scopes.py`). Ran formatter and type checker.
- 🧪 **Edge cases:** Explicitly handled and tested `None` inputs, empty strings, consecutive commas, duplicate entries, and arbitrary whitespace wrapping scope strings.
- ⚠️ **Risk:** Extremely low. The transformations are logically equivalent and highly tested. There are no changes to existing database schema or external API contracts.

---
*PR created automatically by Jules for task [6445177312403052262](https://jules.google.com/task/6445177312403052262) started by @ToolchainLab*