### PR TITLE
🎨 Palette: Add missing ARIA labels to mobile navigation buttons

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/.Jules/palette.md
+++ b/packages/create-h4ckath0n/templates/fullstack/web/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-18 - Accessibility for Responsive Duplicates
+**Learning:** Adding `aria-label` to duplicate responsive elements (like desktop and mobile theme toggles) causes tests using `getByRole` to fail.
+**Action:** When adding accessibility features to responsive duplicates, update tests to use `getAllByRole(...)[0]!` to prevent "multiple elements found" errors while satisfying strict TypeScript checks.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0]!,
       ).toBeInTheDocument();
     });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -192,6 +192,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +208,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label="Toggle mobile menu"
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />


### PR DESCRIPTION
💡 What: Added missing `aria-label` to the mobile theme toggle and an `aria-label` and `aria-expanded` to the mobile menu toggle button in `Layout.tsx`. Updated `Layout.test.tsx` to use `getAllByRole` to prevent test failures due to duplicate labels on desktop and mobile variants. Created a journal entry.
🎯 Why: Icon-only buttons in the mobile navigation lacked context for screen readers. This improves accessibility.
📸 Before/After: Visuals are unchanged. This is an accessibility improvement for screen readers.
♿ Accessibility: Added descriptive ARIA labels to two icon-only buttons, and an `aria-expanded` state to the mobile menu toggle to indicate its state to screen readers.

---
*PR created automatically by Jules for task [736276524909767756](https://jules.google.com/task/736276524909767756) started by @ToolchainLab*