### PR TITLE
🧭 Atlas: Automatically generate and verify the config table in README.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Environment variable configuration drift is preventable
+
+**Learning:** Manually keeping a markdown table of environment variables in sync with an app's configuration model (`src/h4ckath0n/config.py`) is error-prone and leads to missing or inaccurate settings descriptions. By defining `pydantic` fields (`Field(default=..., description="...")`), the codebase itself acts as the single source of truth.
+
+**Action:** Add drift-prevention scripts (e.g. `scripts/generate_doc_config.py --check`) to verify configuration documentation against `pydantic-settings` classes. Use markers like `<!-- CONFIG_TABLE_START -->` to safely generate and inject documentation automatically.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (e.g. read-only capabilities) |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check and generator: update README.md config table.
+
+Usage (from repo root):
+    uv run scripts/generate_doc_config.py          # Updates README.md
+    uv run scripts/generate_doc_config.py --check  # Fails if README.md is out of sync
+
+The script imports the h4ckath0n app Settings, builds a markdown table using pydantic
+Field descriptions, and injects it into README.md between <!-- CONFIG_TABLE_START -->
+and <!-- CONFIG_TABLE_END --> markers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+MARKER_START = "<!-- CONFIG_TABLE_START -->"
+MARKER_END = "<!-- CONFIG_TABLE_END -->"
+
+
+def build_config_table() -> str:
+    """Generate the markdown table for configuration settings."""
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    # We want to format the list defaults as `[]` instead of `[]` (they should be strings)
+    # Actually, pydantic field.default or field.default_factory are used
+    for field_name, field_info in Settings.model_fields.items():
+        env_var_name = f"H4CKATH0N_{field_name.upper()}"
+
+        # Determine the default value presentation
+        if field_info.default_factory is not None:
+            # Special handling for default_factory=list
+            if field_info.default_factory is list:
+                default_str = "`[]`"
+            elif field_info.default_factory is dict:
+                default_str = "`{}`"
+            else:
+                default_str = "empty"
+        elif field_info.default is not None and field_info.default != "":
+            if isinstance(field_info.default, bool):
+                default_str = f"`{'true' if field_info.default else 'false'}`"
+            else:
+                default_str = f"`{field_info.default}`"
+        else:
+            default_str = "empty"
+
+        description = field_info.description or ""
+
+        lines.append(f"| `{env_var_name}` | {default_str} | {description} |")
+
+    return "\n".join(lines)
+
+
+def get_readme_parts(readme_text: str) -> tuple[str, str, str]:
+    """Split the README into pre, table, and post parts based on markers."""
+    start_idx = readme_text.find(MARKER_START)
+    end_idx = readme_text.find(MARKER_END)
+
+    if start_idx == -1 or end_idx == -1:
+        print("❌ Could not find CONFIG_TABLE_START or CONFIG_TABLE_END markers in README.md.")
+        sys.exit(1)
+
+    end_idx += len(MARKER_END)
+
+    pre = readme_text[: start_idx + len(MARKER_START)]
+    table = readme_text[start_idx + len(MARKER_START) : end_idx - len(MARKER_END)].strip()
+    post = readme_text[end_idx - len(MARKER_END) :]
+
+    return pre, table, post
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate or check README.md configuration table."
+    )
+    parser.add_argument("--check", action="store_true", help="Fail if README.md needs updating")
+    args = parser.parse_args()
+
+    readme_text = README.read_text()
+    pre, current_table, post = get_readme_parts(readme_text)
+
+    new_table = build_config_table()
+
+    # Make sure we add a newline before and after the table to keep things clean
+    new_content = f"{pre}\n{new_table}\n{post}"
+
+    if args.check:
+        if current_table != new_table:
+            print(
+                "❌ The configuration table in README.md is out of sync with "
+                "src/h4ckath0n/config.py."
+            )
+            print("Run `uv run scripts/generate_doc_config.py` to update it.")
+            return 1
+        print("✅ The configuration table in README.md is up to date.")
+        return 0
+
+    if current_table != new_table:
+        README.write_text(new_content)
+        print("✅ README.md configuration table updated.")
+    else:
+        print("✅ README.md configuration table is already up to date.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,81 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run background jobs inline in development mode"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(default="./.h4ckath0n_storage", description="Local storage directory")
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes (default 50 MB)"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL for email links"
+    )
+    email_backend: str = Field(default="file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(default="noreply@localhost", description="Default sender address")
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file-based email backend"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use implicit SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(
+        default=False, description="Enable demo mode (e.g. read-only capabilities)"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
* 💡 What: Replaced the static, handwritten configuration environment variable table in `README.md` with a dynamically generated table sourced from `pydantic` Fields in `src/h4ckath0n/config.py`.
* 🎯 Why: Hand-written configuration tables are highly susceptible to drift, leading to outdated defaults, missing variables, or incorrect descriptions. This reduces user "time-to-understanding".
* 🧪 Verification: Locally validated by running `uv run scripts/generate_doc_config.py --check` and testing against `README.md`. Tests (`uv run --locked pytest -v`) and linters pass cleanly.
* 🔒 Drift Prevention: Added a CI workflow job (`Check doc config`) in `.github/workflows/ci.yml` that invokes `scripts/generate_doc_config.py --check`. This ensures that any update to the config schema must be accompanied by a generated docs update.
* 🗺️ Evidence: Codebase relies entirely on `src/h4ckath0n/config.py` for its configuration loading via `pydantic-settings`. Using it directly as the source of truth eliminates drift.

---
*PR created automatically by Jules for task [2043389649429364961](https://jules.google.com/task/2043389649429364961) started by @ToolchainLab*