### PR TITLE
∴ Vector: Centralize scope parsing and normalization logic

### DIFF
--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -86,7 +86,9 @@ def require_scopes(*scopes: str) -> Any:
     needed: set[str] = set(filter(None, map(str.strip, scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        from h4ckath0n.auth.scopes import parse_scopes
+
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,13 @@
+from collections.abc import Sequence
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a deduplicated, order-preserved list."""
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: Sequence[str]) -> str:
+    """Format a sequence of scopes into a comma-separated string."""
+    parts = filter(None, map(str.strip, scopes))
+    return ",".join(dict.fromkeys(parts))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -22,7 +22,9 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    from h4ckath0n.auth.scopes import parse_scopes
+
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -126,9 +126,9 @@ def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
 
 def _normalize_scopes(raw: str) -> str:
     """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
+    from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+    return format_scopes(parse_scopes(raw))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +451,14 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                parsed_scope = scope.strip()
+                if parsed_scope and parsed_scope not in existing:
+                    existing.append(parsed_scope)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +484,12 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,4 +1,5 @@
-from h4ckath0n.auth.scopes import parse_scopes, format_scopes
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
 
 def test_parse_scopes():
     assert parse_scopes("") == []
@@ -8,6 +9,7 @@ def test_parse_scopes():
     assert parse_scopes("a, b,  c  ") == ["a", "b", "c"]
     assert parse_scopes("a,,b, ,c") == ["a", "b", "c"]
     assert parse_scopes("a,b,a,c,b") == ["a", "b", "c"]
+
 
 def test_format_scopes():
     assert format_scopes([]) == ""

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,0 +1,18 @@
+from h4ckath0n.auth.scopes import parse_scopes, format_scopes
+
+def test_parse_scopes():
+    assert parse_scopes("") == []
+    assert parse_scopes("   ") == []
+    assert parse_scopes("a") == ["a"]
+    assert parse_scopes("a,b,c") == ["a", "b", "c"]
+    assert parse_scopes("a, b,  c  ") == ["a", "b", "c"]
+    assert parse_scopes("a,,b, ,c") == ["a", "b", "c"]
+    assert parse_scopes("a,b,a,c,b") == ["a", "b", "c"]
+
+def test_format_scopes():
+    assert format_scopes([]) == ""
+    assert format_scopes(["a"]) == "a"
+    assert format_scopes(["a", "b", "c"]) == "a,b,c"
+    assert format_scopes(["a ", " b", "  c  "]) == "a,b,c"
+    assert format_scopes(["a", "", "b", " ", "c"]) == "a,b,c"
+    assert format_scopes(["a", "b", "a", "c", "b"]) == "a,b,c"


### PR DESCRIPTION
- 💡 What: Extracted scope parsing logic into a central `src/h4ckath0n/auth/scopes.py` module with `parse_scopes` and `format_scopes`. Refactored `dependencies.py`, `session_router.py`, and `cli.py` to use these helpers instead of inline `.split()` and `filter()`.
- 🎯 Why: Scope strings were manually split, stripped, and filtered in multiple places. Extracting this removes duplicated logic, provides a single tested source of truth, and fixes an edge case in `cli.py` where adding scopes using sets could alter their original ordering.
- 🧠 Design: By defining pure helper functions (`parse_scopes`, `format_scopes`) that rely on order-preserving `dict.fromkeys`, we centralize the behavior completely without requiring architectural rewrites.
- λ FP Angle: Transitioned from scattered, mutation-heavy local operations to a clear, composable transformation pipeline using pure helpers, promoting single-source-of-truth normalization and determinism.
- ✅ Verification: Added explicit tests for the new helpers in `tests/test_scopes.py`. Ran the repo's full backend quality suite using `uv run --locked pytest tests/ -v`, `uv run --locked ruff format .`, `uv run --locked ruff check .`, and `uv run --locked mypy src`.
- 🧪 Edge cases: `tests/test_scopes.py` verifies behavior handling null, empty strings, pure whitespace, duplicates, and order preservation.
- ⚠️ Risk: Very low. This introduces tested, predictable semantics for scope string normalization and replaces ad-hoc logic gracefully. Local imports were used at the call sites to prevent any potential circular import scenarios.

---
*PR created automatically by Jules for task [5157585464221707061](https://jules.google.com/task/5157585464221707061) started by @ToolchainLab*