### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration timing attack in authentication

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-19 - User Enumeration Timing Attack
+**Vulnerability:** The authentication service `authenticate_user` returned early when a user was not found or lacked a password hash. Attackers could measure the response time to determine if an email address was registered in the system (timing attack), since checking an invalid user took significantly less time than verifying a password hash with Argon2.
+**Learning:** Returning early to avoid expensive cryptographic operations (like Argon2 hashing) creates a timing discrepancy that leaks user existence.
+**Prevention:** Ensure consistent execution time regardless of user existence by performing a dummy password hash (`hash_password(password)`) when the user is not found or lacks a password.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -73,12 +73,16 @@ async def register_user(
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
-    _hash, verify_password = _require_password_extra()
+    hash_password, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    # 🛡️ Sentinel: Mitigate user enumeration timing attack by performing a dummy hash
+    # when the user is missing or has no password (e.g. passkey only).
+    if user is None or not user.password_hash:
+        hash_password(password)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User enumeration via timing attack. Returning early without performing password hashing allows attackers to measure response times and determine if an email address exists in the system.
🎯 Impact: Attackers can compile a list of valid user accounts, which can be used for targeted phishing or credential stuffing attacks.
🔧 Fix: Add a dummy `hash_password(password)` call when the user is not found or has no password hash to normalize response times and obscure user existence.
✅ Verification: Ran `pytest` locally to ensure authentication logic still functions correctly. Also verified the change directly by reading the updated `service.py`.

---
*PR created automatically by Jules for task [5131512675640231574](https://jules.google.com/task/5131512675640231574) started by @ToolchainLab*