### PR TITLE
🧭 Atlas: auto-generate config documentation from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-19 - Configuration documentation drift prevention
+**Learning:** Hard-coded configuration tables in READMEs quickly drift from the code's truth.
+**Action:** Always generate configuration documentation directly from the code source of truth (e.g. `pydantic.Field` descriptions) and use HTML comment markers (`<!-- CONFIG_TABLE_START -->`) to inject the generated output into markdown documents. Pair this with a CI check (`--check`) to fail builds if the generated documentation is out-of-sync.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -174,7 +175,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (dependency only) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default From address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode constraints (read-only profiles) |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: generate the configuration table in README.md from config.py.
+
+Usage (from repo root):
+    uv run scripts/generate_doc_config.py [--check]
+
+Reads Settings from src/h4ckath0n/config.py and injects a markdown table between
+<!-- CONFIG_TABLE_START --> and <!-- CONFIG_TABLE_END --> markers in README.md.
+If --check is provided, it fails if the README needs to be updated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- CONFIG_TABLE_START -->"
+END_MARKER = "<!-- CONFIG_TABLE_END -->"
+
+
+def format_default(val: Any) -> str:
+    """Format default value for markdown table."""
+    if val == "":
+        return "empty"
+    if isinstance(val, bool):
+        return f"`{'true' if val else 'false'}`"
+    if isinstance(val, list):
+        if not val:
+            return "`[]`"
+        return f"`{val}`"
+    return f"`{val}`"
+
+
+def generate_table() -> str:
+    """Generate the markdown table for configuration settings."""
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+    for name, field in Settings.model_fields.items():
+        var_name = f"`H4CKATH0N_{name.upper()}`"
+        # Special cases that don't have the H4CKATH0N_ prefix
+        if name == "openai_api_key":
+            var_name = "`OPENAI_API_KEY`"
+        default_val = format_default(field.default)
+        # Note: Some default logic in README.md doesn't map perfectly to python default values.
+        # e.g., rp_id and origin, which have logic in the methods.
+        if name == "rp_id":
+            default_val = "`localhost` in development"
+        elif name == "origin":
+            default_val = "`http://localhost:8000` in development"
+
+        desc = field.description or ""
+        lines.append(f"| {var_name} | {default_val} | {desc} |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update or check README config table.")
+    parser.add_argument("--check", action="store_true", help="Fail if update is required")
+    args = parser.parse_args()
+
+    table_md = generate_table()
+    readme_text = README.read_text(encoding="utf-8")
+
+    if START_MARKER not in readme_text or END_MARKER not in readme_text:
+        print(f"Error: {START_MARKER} and {END_MARKER} must exist in README.md", file=sys.stderr)
+        return 1
+
+    start_idx = readme_text.find(START_MARKER) + len(START_MARKER)
+    end_idx = readme_text.find(END_MARKER)
+
+    new_readme_text = readme_text[:start_idx] + "\n" + table_md + "\n" + readme_text[end_idx:]
+
+    if readme_text == new_readme_text:
+        print("✅ Configuration table is up to date.")
+        return 0
+
+    if args.check:
+        print(
+            "❌ README out of date. Run 'uv run scripts/generate_doc_config.py'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    README.write_text(new_readme_text, encoding="utf-8")
+    print("📝 Updated configuration table in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,84 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection string (dependency only)")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run background jobs inline in development"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL for email links"
+    )
+    email_backend: str = Field(default="file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(
+        default="noreply@localhost", description="Default From address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file email backend"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(
+        default=False, description="Enable demo mode constraints (read-only profiles)"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 **What:** Adds a generation script `scripts/generate_doc_config.py` that reads the Pydantic `Settings` model in `src/h4ckath0n/config.py` and injects an accurate configuration table into `README.md` using HTML comment markers.
🎯 **Why:** To prevent documentation drift. Previously, the README configuration section was hard-coded and missing several environment variables that existed in the codebase.
🧪 **Verification:** Run `uv run scripts/generate_doc_config.py` to test locally.
🔒 **Drift Prevention:** Added a CI check to `.github/workflows/ci.yml` using `uv run --locked scripts/generate_doc_config.py --check` which will fail the build if the README table is out of sync with the Python code.
🗺️ **Evidence:** `src/h4ckath0n/config.py` serves as the authoritative source of truth.

---
*PR created automatically by Jules for task [8493355545192531550](https://jules.google.com/task/8493355545192531550) started by @ToolchainLab*