### PR TITLE
⚡ Bolt: Use db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize the session identity map.
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize the session identity map.
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 
@@ -217,8 +217,8 @@ async def finish_authentication(
     stored.last_used_at = datetime.now(UTC)
     await db.commit()
 
-    user_result = await db.execute(select(User).filter(User.id == stored.user_id))
-    if (user := user_result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize the session identity map.
+    if (user := await db.get(User, stored.user_id)) is None:
         raise ValueError("User not found")
     return user
 

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -169,8 +169,8 @@ async def confirm_password_reset(db: AsyncSession, raw_token: str, new_password:
     if prt.expires_at.replace(tzinfo=UTC) < datetime.now(UTC):
         raise ValueError("Reset token expired")
     prt.used = True
-    user_result = await db.execute(select(User).filter(User.id == prt.user_id))
-    if (user := user_result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize the session identity map.
+    if (user := await db.get(User, prt.user_id)) is None:
         raise ValueError("User not found")
     user.password_hash = hash_password(new_password)
     await db.commit()


### PR DESCRIPTION
- 💡 What: Replaced multiple SQLAlchemy `select().filter(Model.id == pk)` queries with `db.get(Model, pk)` in authentication and passkey services.
- 🎯 Why: `db.get()` first checks the SQLAlchemy session identity map. If the object was already queried in the current transaction, it avoids a database roundtrip entirely. If not, it performs a highly optimized primary key lookup, improving overall efficiency and reducing boilerplate.
- 📊 Impact: Measurable reduction in database queries during authentication and registration flows when the user or flow object is already present in the identity map.
- 🔬 Measurement: Code analysis shows the use of the optimized SQLAlchemy 2.0 API, and tests confirm behavior remains unchanged while leveraging the identity map.

---
*PR created automatically by Jules for task [6364152898588149021](https://jules.google.com/task/6364152898588149021) started by @ToolchainLab*