### PR TITLE
🧭 Atlas: Add generated documentation configuration table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config table
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Config table manual maintenance leads to drift
+
+**Learning:** Manually maintaining configuration variables in markdown tables leads to drift between the source of truth (`src/h4ckath0n/config.py` settings model) and the documentation.
+**Action:** Use code-generated configuration tables directly from `pydantic.Field` descriptions and inject them using HTML comment markers. Always pair this with a `--check` CI flag to prevent future drift.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend ('local' or 's3') |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory path |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the application for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend ('file' or 'smtp') |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default 'from' address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using 'file' backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script to generate the configuration table in README.md.
+
+Usage (from repo root):
+    uv run scripts/generate_doc_config.py [--check]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- CONFIG_TABLE_START -->"
+END_MARKER = "<!-- CONFIG_TABLE_END -->"
+
+
+def generate_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field_info in Settings.model_fields.items():
+        # The Settings model already prefixes with H4CKATH0N_ via env_prefix.
+        # But we handle OPENAI_API_KEY differently to match the original doc
+        # where it is listed without the prefix, with an alternate version.
+
+        var_name = f"H4CKATH0N_{name.upper()}"
+
+        from pydantic_core import PydanticUndefined
+
+        if field_info.default is not PydanticUndefined:
+            default = field_info.default
+        elif field_info.default_factory is not None:
+            default = field_info.default_factory()
+        else:
+            default = None
+
+        if default == "":
+            default_str = "empty"
+        elif default == []:
+            default_str = "`[]`"
+        elif isinstance(default, bool):
+            default_str = f"`{'true' if str(default).lower() == 'true' else 'false'}`"
+        else:
+            default_str = f"`{default}`"
+
+        description = field_info.description or ""
+        # In development mode, RP_ID and ORIGIN fall back to localhost defaults.
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        if name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        if name == "openai_api_key":
+            lines.append(f"| `OPENAI_API_KEY` | {default_str} | {description} |")
+            lines.append(
+                f"| `H4CKATH0N_OPENAI_API_KEY` | {default_str} | Alternate {description} |"
+            )
+        else:
+            lines.append(f"| `{var_name}` | {default_str} | {description} |")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if README.md is up to date")
+    args = parser.parse_args()
+
+    table = generate_table()
+    content = README.read_text()
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print("❌ Markers not found in README.md")
+        return 1
+
+    start_idx = content.find(START_MARKER) + len(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    new_content = content[:start_idx] + "\n" + table + "\n" + content[end_idx:]
+
+    if args.check:
+        if content != new_content:
+            print(
+                "❌ Configuration table in README.md is out of date.\n"
+                "Run 'uv run scripts/generate_doc_config.py' to update it."
+            )
+            return 1
+        print("✅ Configuration table in README.md is up to date.")
+        return 0
+    else:
+        README.write_text(new_content)
+        print("✅ Updated configuration table in README.md.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,74 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL")
+    jobs_inline_in_dev: bool = Field(True, description="Run jobs inline during development")
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend ('local' or 's3')")
+    storage_dir: str = Field("./.h4ckath0n_storage", description="Local storage directory path")
+    max_upload_bytes: int = Field(50 * 1024 * 1024, description="Maximum upload size in bytes")
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the application for email links"
+    )
+    email_backend: str = Field("file", description="Email backend ('file' or 'smtp')")
+    email_from: str = Field("noreply@localhost", description="Default 'from' address for emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox",
+        description="Directory to save emails when using 'file' backend",
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP username")
+    smtp_password: str = Field("", description="SMTP password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(False, description="Use SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
* 💡 **What**: Replaces the hand-written configuration table in `README.md` with a dynamically generated table.
* 🎯 **Why**: Manually maintaining configuration variables in markdown tables leads to drift between the source of truth (`src/h4ckath0n/config.py` settings model) and the documentation. Generating it directly ensures they always match.
* 🧪 **Verification**: Run `uv run scripts/generate_doc_config.py --check` locally to validate that the configuration table is up to date.
* 🔒 **Drift Prevention**: Added `scripts/generate_doc_config.py` and a CI step in `.github/workflows/ci.yml` to check for documentation drift on every pull request.
* 🗺️ **Evidence**: `src/h4ckath0n/config.py` (authoritative settings model).

---
*PR created automatically by Jules for task [916263611336440413](https://jules.google.com/task/916263611336440413) started by @ToolchainLab*