### PR TITLE
∴ Vector: Centralize scope parsing logic into functional helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Centralize scope parsing
+**Learning:** The codebase previously duplicated list-to-comma-string parsing and normalization for user scopes in dependencies, CLI, and routers.
+**Action:** Extracted pure functional helpers `parse_scopes` and `format_scopes` into `src/h4ckath0n/auth/scopes.py` to serve as the single source of truth for scope list conversion and normalization.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -86,7 +87,7 @@ def require_scopes(*scopes: str) -> Any:
     needed: set[str] = set(filter(None, map(str.strip, scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,23 @@
+"""Functional utilities for processing comma-separated scope strings."""
+
+from collections.abc import Iterable
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """
+    Parse a comma-separated string of scopes into a stable, deduplicated list.
+    Empty strings and whitespace are stripped.
+    """
+    parts = filter(None, map(str.strip, raw.split(",")))
+    # de-duplicate preserving order
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """
+    Format an iterable of scopes into a comma-separated string.
+    Empty strings and whitespace are stripped. Order is preserved.
+    """
+    parts = filter(None, map(str.strip, scopes))
+    # de-duplicate preserving order
+    return ",".join(dict.fromkeys(parts))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -124,13 +124,6 @@ def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
 
 
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
-
-
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
     """Resolve a user by --user-id or --email. Returns user or None."""
     from sqlalchemy import select
@@ -451,10 +444,12 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                existing.append(scope)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +475,12 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +506,9 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,11 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert format_scopes(parse_scopes("a,b,c")) == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert format_scopes(parse_scopes("a,b,a")) == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert format_scopes(parse_scopes(" a , b , c ")) == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert format_scopes(parse_scopes("a,,b,,")) == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert format_scopes(parse_scopes("")) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Extracted repeated scope parsing and normalization logic from `cli.py`, `dependencies.py`, and `session_router.py` into a new `src/h4ckath0n/auth/scopes.py` module containing pure functional helpers.
- 🎯 Why: The codebase previously duplicated variations of `filter(None, map(str.strip, user.scopes.split(",")))` across four locations. This centralizes the semantics into a single source of truth, removing ad-hoc pipelines.
- 🧠 Design: The new `parse_scopes` and `format_scopes` functions handle whitespace trimming, empty string filtering, and order-preserving deduplication (via `dict.fromkeys`), matching the existing CLI normalization behavior safely.
- λ FP Angle: Reduces scattered mutation and complex inline transformations into reusable, composable pure functions with explicit contracts.
- ✅ Verification: Ran `ruff check`, `ruff format`, `mypy`, and the `pytest` suite. Existing CLI tests targeting `_normalize_scopes` were updated to test the new utilities and passed successfully.
- 🧪 Edge cases: Ensures consistent trimming and filtering of empty/duplicate scopes globally, rather than just in the CLI.
- ⚠️ Risk: Low. The deterministic `dict.fromkeys` preserves ordering from the original list, preventing unexpected DB churn or logic breaks.

---
*PR created automatically by Jules for task [8242861790295068514](https://jules.google.com/task/8242861790295068514) started by @ToolchainLab*