### PR TITLE
⚡ Bolt: Offload hashing and I/O to worker thread during file upload

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-22 - Offload CPU-Bound and Blocking I/O from the Event Loop
+
+**Learning:** Synchronous, CPU-bound tasks like large-buffer hashing via `hashlib` and blocking I/O operations such as `os.makedirs` or file writes, when placed directly in asynchronous functions, will block the main thread and introduce severe event loop latency. This reduces concurrency, especially for high-latency operations like large file uploads.
+
+**Action:** Always offload CPU-bound computations and blocking filesystem I/O in async routes to a worker thread using `asyncio.to_thread` to maintain a non-blocking event loop.

--- a/src/h4ckath0n/uploads/storage.py
+++ b/src/h4ckath0n/uploads/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import os
 
@@ -14,19 +15,26 @@ async def store_file(storage_dir: str, data: bytes) -> tuple[str, str]:
     The storage key is fully opaque – it never contains any user-supplied
     values such as original filenames.
     """
-    sha256 = hashlib.sha256(data).hexdigest()
-    prefix = sha256[:2]
+    # Generate random part on the main thread for predictable RNG state if needed
     random_part = _rng_hex(16)  # 128-bit opaque path component.
-    storage_key = f"{prefix}/{random_part}"
 
-    full_path = os.path.join(storage_dir, prefix)
-    os.makedirs(full_path, exist_ok=True)
+    def _store_sync() -> tuple[str, str]:
+        # Optimize: Offload CPU-bound hashing and blocking I/O to a worker thread
+        # to prevent event loop latency during large file uploads.
+        sha256 = hashlib.sha256(data).hexdigest()
+        prefix = sha256[:2]
+        storage_key = f"{prefix}/{random_part}"
 
-    file_path = os.path.join(storage_dir, storage_key)
-    with open(file_path, "wb") as f:
-        f.write(data)
+        full_path = os.path.join(storage_dir, prefix)
+        os.makedirs(full_path, exist_ok=True)
 
-    return storage_key, sha256
+        file_path = os.path.join(storage_dir, storage_key)
+        with open(file_path, "wb") as f:
+            f.write(data)
+
+        return storage_key, sha256
+
+    return await asyncio.to_thread(_store_sync)
 
 
 def get_file_path(storage_dir: str, storage_key: str) -> str:


### PR DESCRIPTION
- 💡 What: Refactored `store_file` in `src/h4ckath0n/uploads/storage.py` to offload CPU-bound tasks (hashing via `hashlib.sha256()`) and blocking I/O (`os.makedirs` and file writes) to a worker thread using `asyncio.to_thread`.
- 🎯 Why: Synchronous operations directly within `async def` functions block the main event loop thread. For potentially large file uploads, synchronous hashing and writing to disk blocks the server from processing concurrent requests, severely increasing latency.
- 📊 Impact: Significantly improves concurrency and application responsiveness by preventing the event loop from stalling while processing large file payloads.
- 🔬 Measurement: Benchmark concurrent file upload requests against standard API reads; the non-blocking event loop will allow reads to complete unimpeded while large uploads process in worker threads.

---
*PR created automatically by Jules for task [16425758004248227851](https://jules.google.com/task/16425758004248227851) started by @ToolchainLab*