### PR TITLE
🎨 Palette: [UX improvement] Add keyboard shortcut and hint to AI Chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-23 - Keyboard Shortcut Discoverability in Textareas
+**Learning:** Adding keyboard shortcuts (like Enter to submit) to textareas is great for power users, but it's invisible to most. Adding visual `<kbd>` hints significantly improves discoverability of these shortcuts. Additionally, custom `onKeyDown` handlers must carefully replicate the exact `disabled` state conditions of their corresponding submit buttons (e.g., preventing submission when streaming or if input is empty) to prevent invalid state transitions.
+**Action:** Whenever adding `onKeyDown` submission handlers to inputs or textareas, always pair them with a visual `<kbd>` hint and ensure the handler's execution conditions perfectly mirror the associated button's `disabled` prop.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,25 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (!aiStreaming && aiPrompt.trim()) {
+                      void handleAiStream();
+                    }
+                  }
+                }}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <div className="absolute bottom-3 right-3 text-xs text-text-muted pointer-events-none flex items-center gap-1">
+                Press <kbd className="font-sans px-1.5 py-0.5 rounded bg-surface-alt border border-border">Enter</kbd> to send
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
- 💡 **What:** Added a keyboard shortcut (`Enter`) to submit prompts in the Dashboard's AI Chat textarea, and added a visual `<kbd>` hint indicating the shortcut.
- 🎯 **Why:** To make the interface more efficient for power users who prefer keyboard navigation, while ensuring discoverability for all users through the visual hint.
- 📸 **Before/After:** The textarea now has "Press Enter to send" rendered cleanly in the bottom right corner.
- ♿ **Accessibility:** The `onKeyDown` event handler matches the disabled state logic of the associated Submit button, ensuring the form cannot be submitted when loading or when the input is empty. The `<kbd>` hint provides clear affordances.

---
*PR created automatically by Jules for task [9195771466994334834](https://jules.google.com/task/9195771466994334834) started by @ToolchainLab*