### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix user enumeration timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Mitigate User Enumeration Timing Attack
+**Vulnerability:** The password authentication routine (`authenticate_user` in `src/h4ckath0n/auth/service.py`) returns early if a user is not found or has no password hash. This bypassed the expensive Argon2 password hashing step, creating a timing discrepancy that allowed attackers to enumerate existing email addresses or determine if a user uses passkeys.
+**Learning:** Even early returns or validations must be careful not to create significant timing discrepancies when dealing with expensive cryptographic operations on a hot path like authentication.
+**Prevention:** Perform a dummy password hash (`hash_password(password)`) to consume an equivalent amount of time before returning when a user is missing or has no password hash.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -73,11 +73,13 @@ async def register_user(
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
-    _hash, verify_password = _require_password_extra()
+    hash_password, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
-        return None
-    if not user.password_hash:
+    user = result.scalars().first()
+    if user is None or not user.password_hash:
+        # 🛡️ Sentinel: Mitigate user enumeration timing attacks by performing
+        # a dummy hash when user is not found or has no password.
+        hash_password(password)
         return None
     if not verify_password(password, user.password_hash):
         return None


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `authenticate_user` function returned early if a user was not found or had no password hash. This bypassed the expensive Argon2 password hashing step, creating a timing discrepancy. Attackers could measure the response time to enumerate existing email addresses or determine if an account uses passkeys.
🎯 **Impact:** Exposes registered user email addresses, leading to privacy violations and providing targeted lists for phishing, credential stuffing, or brute-force attacks.
🔧 **Fix:** Added a dummy `hash_password(password)` call when the user lookup fails or the user has no password. This ensures the authentication execution time remains consistent regardless of user existence.
✅ **Verification:** Verified all tests pass (`pytest tests/`) and ensuring standard linting rules (`ruff`) are respected. Added an entry to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [17966025343756128145](https://jules.google.com/task/17966025343756128145) started by @ToolchainLab*