### PR TITLE
🗺️ Atlas: Generate config table from pydantic fields to prevent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-05-24 - Configuration Docs Drift Prevention
+**Learning:** Environment-driven configuration managed via `pydantic-settings` in `src/h4ckath0n/config.py` easily drifts from the manually maintained configuration table in `README.md` (e.g., missing 10+ settings like `storage_backend` and `redis_url`).
+**Action:** Prevent documentation drift by generating configuration tables directly from `pydantic.Field` descriptions and injecting them into `README.md` via HTML comment markers (`<!-- CONFIG_TABLE_START -->` and `<!-- CONFIG_TABLE_END -->`). Always pair this with a CI check (`--check`) to fail builds if the documentation is out-of-sync.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline during request in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend app for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | From address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable read-only demo mode |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that the configuration table in README.md matches the config.
+
+Usage (from repo root):
+    uv run scripts/generate_doc_config.py [--check]
+
+The script loads the Settings class from h4ckath0n.config and generates a Markdown table
+documenting the settings and their defaults. It injects this table between markers in README.md.
+If --check is provided, it fails if the file would be modified.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from pydantic.fields import FieldInfo
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from h4ckath0n.config import Settings  # noqa: E402
+
+README_PATH = REPO_ROOT / "README.md"
+START_MARKER = "<!-- CONFIG_TABLE_START -->"
+END_MARKER = "<!-- CONFIG_TABLE_END -->"
+
+
+def format_default(name: str, field: FieldInfo) -> str:
+    if name == "rp_id":
+        return "`localhost` in development"
+    if name == "origin":
+        return "`http://localhost:8000` in development"
+    if name == "openai_api_key":
+        return "empty"
+
+    if field.default == "":
+        return "empty"
+    if field.default == [] or field.default_factory is list:
+        return "`[]`"
+    if isinstance(field.default, bool):
+        return f"`{str(field.default).lower()}`"
+    return f"`{field.default}`"
+
+
+def generate_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+        if name in ("openai_api_key",):
+            var_name = "OPENAI_API_KEY"
+
+        default_val = format_default(name, field)
+        description = field.description or "TODO"
+        lines.append(f"| `{var_name}` | {default_val} | {description} |")
+
+        if name == "openai_api_key":
+            lines.append(
+                f"| `H4CKATH0N_{name.upper()}` | {default_val} | "
+                "Alternate OpenAI API key for the LLM wrapper |"
+            )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    new_table = generate_table()
+
+    content = README_PATH.read_text(encoding="utf-8")
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print(f"Error: Markers {START_MARKER} and {END_MARKER} not found in README.md.")
+        return 1
+
+    start_idx = content.find(START_MARKER)
+    end_idx = content.find(END_MARKER) + len(END_MARKER)
+
+    before = content[:start_idx]
+    after = content[end_idx:]
+
+    new_content = f"{before}{START_MARKER}\n{new_table}\n{END_MARKER}{after}"
+
+    if content == new_content:
+        print("✅ Configuration table in README.md is up to date.")
+        return 0
+
+    if check_only:
+        print("❌ Configuration table in README.md is out of date.")
+        print("Run 'uv run scripts/generate_doc_config.py' to update it.")
+        return 1
+
+    README_PATH.write_text(new_content, encoding="utf-8")
+    print("✅ Configuration table in README.md updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,79 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run jobs inline during request in development"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend app for email links"
+    )
+    email_backend: str = Field("file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field("noreply@localhost", description="From address for outbound emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file email backend"
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP username")
+    smtp_password: str = Field("", description="SMTP password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Use SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable read-only demo mode")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Prevent documentation drift for environment variables by generating the configuration table directly from `pydantic.Field` descriptions.
🎯 Why: The handwritten configuration table in `README.md` was missing over 10 settings (e.g., `redis_url`, `storage_backend`). Generating this table directly from the code ensures parity and eliminates the manual burden of keeping docs updated.
🧪 Verification:
- Run `uv run scripts/generate_doc_config.py` to inject the table into `README.md`.
- Run `uv run scripts/generate_doc_config.py --check` locally (returns 0 when up-to-date).
- CI tests pass locally.
🔒 Drift Prevention: Added `generate_doc_config.py --check` to `.github/workflows/ci.yml`, which fails the build if the markdown table drifts from `config.py`.
🗺️ Evidence: `src/h4ckath0n/config.py` is the single source of truth for configuration definitions.

---
*PR created automatically by Jules for task [12630648133735274563](https://jules.google.com/task/12630648133735274563) started by @ToolchainLab*