### PR TITLE
🎨 Palette: Add keyboard shortcuts and hints for AI Chat prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Keyboard Shortcut Discoverability
+ **Learning:** In multi-line textareas meant for chat or messaging, users expect "Enter" to send, but this behavior must be visually communicated. `<kbd>` elements near the submit button provide excellent affordance.
+ **Action:** Add `<kbd>` elements next to interactive form elements to indicate submission shortcuts (e.g. Enter to submit, Shift+Enter for newline) to improve affordance and accessibility.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -295,15 +295,30 @@ export function Dashboard() {
             <textarea
               value={aiPrompt}
               onChange={(e) => setAiPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  if (!aiStreaming && aiPrompt.trim()) {
+                    handleAiStream();
+                  }
+                }
+              }}
               placeholder="Type a prompt…"
               className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
             />
-            <Button
-              onClick={handleAiStream}
-              disabled={aiStreaming || !aiPrompt.trim()}
-            >
-              {aiStreaming ? "Streaming…" : "Send"}
-            </Button>
+            <div className="flex items-center justify-between">
+              <div className="text-xs text-text-muted">
+                <span className="hidden sm:inline">Press </span>
+                <kbd className="px-1.5 py-0.5 bg-surface-alt border border-border rounded font-mono text-[10px] font-semibold">Enter</kbd> to send
+                <span className="hidden sm:inline">, <kbd className="px-1.5 py-0.5 bg-surface-alt border border-border rounded font-mono text-[10px] font-semibold">Shift</kbd> + <kbd className="px-1.5 py-0.5 bg-surface-alt border border-border rounded font-mono text-[10px] font-semibold">Enter</kbd> for new line</span>
+              </div>
+              <Button
+                onClick={handleAiStream}
+                disabled={aiStreaming || !aiPrompt.trim()}
+              >
+                {aiStreaming ? "Streaming…" : "Send"}
+              </Button>
+            </div>
             {aiResponse && (
               <div className="p-3 rounded bg-surface-alt text-sm whitespace-pre-wrap font-mono">
                 {aiResponse}


### PR DESCRIPTION
- 💡 What: Added `onKeyDown` event listener to AI Chat textarea to allow submission via `Enter` (and newline via `Shift+Enter`), along with `<kbd>` visual hints.
- 🎯 Why: Users expect "Enter to send" in chat interfaces. Discoverability is key, so visual hints were added.
- 📸 Before/After: Visual hints added next to the Send button.
- ♿ Accessibility: Improved keyboard navigation and interaction affordance for chat prompts.

---
*PR created automatically by Jules for task [946298358069873459](https://jules.google.com/task/946298358069873459) started by @ToolchainLab*