### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix user enumeration via timing attack in auth service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-25 - Fix user enumeration via timing attack in auth service
+**Vulnerability:** User enumeration timing attack in `authenticate_user` allows attackers to determine if an email is registered by timing how long the request takes.
+**Learning:** If a user is not found or has no password hash, returning early without hashing the password creates a noticeable timing difference compared to when a valid user is found and verified.
+**Prevention:** Ensure consistent execution time by performing dummy password hashing (`hash_password(password)`) when a user is not found or lacks a password hash (e.g., passkey-only users). Avoid early returns that bypass expensive cryptographic operations.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -73,14 +73,18 @@ async def register_user(
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
-    _hash, verify_password = _require_password_extra()
+    hash_password, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    if user is None or not user.password_hash:
+        # Perform dummy password hashing to prevent user enumeration via timing attacks
+        hash_password(password)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
+
     return user
 
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** User enumeration timing attack in `authenticate_user`. Because cryptographic hashing (Argon2id) takes noticeably longer than a database lookup, an attacker could determine if an email is registered by timing how long the request takes to fail.
🎯 **Impact:** An attacker could rapidly enumerate which email addresses are registered to users of the application.
🔧 **Fix:** Ensured consistent execution time by performing dummy password hashing (`hash_password(password)`) when a user is not found or lacks a password hash. Removed early returns that bypassed the expensive cryptographic operations.
✅ **Verification:** Verified by running the full test suite (`pytest tests/ -v`) which passes. Tested the fix does not introduce regressions and maintains the same authentication rules.

---
*PR created automatically by Jules for task [10967211394600661496](https://jules.google.com/task/10967211394600661496) started by @ToolchainLab*