### PR TITLE
🧭 Atlas: Prevent config doc drift by generating table from pydantic Fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,5 +1,11 @@
 # Atlas Journal: Critical Learnings
 
+## 2026-03-01 - Prevent config doc drift by generating from source
+
+**Learning:** Configuration documentation in READMEs often drifts from the actual settings loaded by the application (e.g., missing env vars, incorrect defaults). Hand-maintained tables are prone to failure.
+
+**Action:** Centralise configuration in `pydantic-settings` (`config.py`), document fields using `pydantic.Field(description="...")`, and use a script (`scripts/generate_doc_config.py`) to generate the markdown table and inject it between `<!-- CONFIG_TABLE_START -->` and `<!-- CONFIG_TABLE_END -->` markers. Run the script with `--check` in CI to fail builds if the documentation is out-of-sync.
+
 ## 2026-02-28 - API route substring matching is unreliable for drift checks
 
 **Learning:** Checking whether a path string appears *anywhere* in a README causes false negatives

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline when in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend type ('file' or 'smtp') |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script: generates the configuration table in README.md.
+
+Usage (from repo root):
+    uv run scripts/generate_doc_config.py          # Write to README.md
+    uv run scripts/generate_doc_config.py --check  # Fail if README.md is out of sync
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Import Settings safely
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from h4ckath0n.config import Settings  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+MARKER_START = "<!-- CONFIG_TABLE_START -->"
+MARKER_END = "<!-- CONFIG_TABLE_END -->"
+
+
+def generate_table() -> str:
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+    for name, field in Settings.model_fields.items():
+        # Handle special cases if needed, but standard is H4CKATH0N_ + name.upper()
+        env_var = f"H4CKATH0N_{name.upper()}"
+
+        # Determine default representation
+        if field.default == "":
+            default_str = "empty"
+        elif field.default is False:
+            default_str = "`false`"
+        elif field.default is True:
+            default_str = "`true`"
+        elif field.default == []:
+            default_str = "`[]`"
+        else:
+            default_str = f"`{field.default}`"
+
+        desc = field.description or ""
+        lines.append(f"| `{env_var}` | {default_str} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if README.md is up to date")
+    args = parser.parse_args()
+
+    readme_content = README.read_text()
+
+    start_idx = readme_content.find(MARKER_START)
+    end_idx = readme_content.find(MARKER_END)
+
+    if start_idx == -1 or end_idx == -1:
+        print(f"❌ Could not find {MARKER_START} or {MARKER_END} in README.md")
+        return 1
+
+    before = readme_content[: start_idx + len(MARKER_START)]
+    after = readme_content[end_idx:]
+
+    new_table = "\n" + generate_table() + "\n"
+    new_readme_content = before + new_table + after
+
+    if args.check:
+        if readme_content != new_readme_content:
+            print("❌ README.md configuration table is out of sync with Settings.")
+            print("   Run `uv run scripts/generate_doc_config.py` to update it.")
+            return 1
+        else:
+            print("✅ README.md configuration table is up to date.")
+            return 0
+    else:
+        README.write_text(new_readme_content)
+        print("✅ Updated README.md configuration table.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,80 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run background jobs inline when in development"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend type")
+    storage_dir: str = Field(default="./.h4ckath0n_storage", description="Local storage directory")
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes (50 MB)"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the application"
+    )
+    email_backend: str = Field(default="file", description="Email backend type ('file' or 'smtp')")
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender email address"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(default=False, description="Use SSL for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Extracts configuration defaults and documentation out of the hand-maintained README table and into `pydantic.Field` definitions directly inside `src/h4ckath0n/config.py`. A new script, `scripts/generate_doc_config.py`, dynamically generates the markdown table and injects it into `README.md`.
🎯 Why: Hand-maintained environment variable lists are a massive source of documentation drift. This guarantees the docs perfectly mirror the actual configuration loaded by the application at runtime.
🧪 Verification: Run `uv run scripts/generate_doc_config.py` locally to update the README. The format, lint, typecheck, and pytest jobs all pass.
🔒 Drift Prevention: Added `uv run --locked scripts/generate_doc_config.py --check` to the backend CI jobs (`ci.yml`), which fails the build if the README table ever falls out of sync with `config.py`.
🗺️ Evidence: `src/h4ckath0n/config.py`, `README.md`, `.github/workflows/ci.yml`

---
*PR created automatically by Jules for task [2865739027284171123](https://jules.google.com/task/2865739027284171123) started by @ToolchainLab*