### PR TITLE
🎨 Palette: Add native tooltips to icon-only buttons

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -87,6 +87,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           <button
             type="button"
             aria-label={visible ? "Hide password" : "Show password"}
+            title={visible ? "Hide password" : "Show password"}
             aria-pressed={visible}
             onClick={handleToggle}
             onPointerDown={handlePointerDown}

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -112,6 +112,7 @@ function PasskeyName({
             disabled={saving}
             className="h-8 w-8 text-success hover:text-success hover:bg-success/10"
             aria-label="Save name"
+            title="Save name"
           >
             <Check className="w-4 h-4" />
           </Button>
@@ -122,6 +123,7 @@ function PasskeyName({
             onClick={cancel}
             className="h-8 w-8 text-text-muted hover:text-text"
             aria-label="Cancel rename"
+            title="Cancel rename"
           >
             <X className="w-4 h-4" />
           </Button>
@@ -151,6 +153,7 @@ function PasskeyName({
           onClick={startEdit}
           className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
+          title="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />
         </Button>


### PR DESCRIPTION
💡 **What:** Added `title` attributes to icon-only buttons in `PasswordField.tsx` and `Settings.tsx`.
🎯 **Why:** To provide native browser tooltips for sighted users navigating the interface, improving discoverability of button functions (e.g., "Show password", "Edit passkey name").
♿ **Accessibility:** Complements existing `aria-label` attributes by providing visual feedback on hover without requiring external tooltip libraries.

---
*PR created automatically by Jules for task [552176693500629355](https://jules.google.com/task/552176693500629355) started by @ToolchainLab*