### PR TITLE
🧭 Atlas: Generate configuration documentation from source code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-05 - Generate configuration documentation from source code
+**Learning:** Hardcoding configuration env vars and their defaults in markdown causes them to drift over time. Relying on manually maintained tables in the README leads to inconsistencies where new or changed settings are not documented.
+**Action:** Extract configuration fields directly from code (using `pydantic.Field` descriptions and defaults) and inject them into markdown files using markers (`<!-- CONFIG_TABLE_START -->`). Add a CI check to enforce parity.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY`<br>`H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of enqueuing |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name for jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend type (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode with restricted actions |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: generate the configuration table from source code.
+
+This script parses src/h4ckath0n/config.py, extracts the configuration settings,
+and injects them into README.md between the <!-- CONFIG_TABLE_START --> and
+<!-- CONFIG_TABLE_END --> markers. If run with --check, it fails if the file
+would change.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- CONFIG_TABLE_START -->"
+END_MARKER = "<!-- CONFIG_TABLE_END -->"
+
+
+def generate_table() -> str:
+    """Generate the markdown table for settings."""
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+    for name, field in Settings.model_fields.items():
+        if name == "openai_api_key":
+            var_name = "`OPENAI_API_KEY`<br>`H4CKATH0N_OPENAI_API_KEY`"
+        else:
+            var_name = f"`H4CKATH0N_{name.upper()}`"
+
+        default = field.default
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+        elif default == "":
+            default_str = "empty"
+        elif default is False:
+            default_str = "`false`"
+        elif default is True:
+            default_str = "`true`"
+        elif isinstance(default, list):
+            default_str = "`[]`"
+        else:
+            default_str = f"`{default}`"
+
+        desc = field.description or ""
+        lines.append(f"| {var_name} | {default_str} | {desc} |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Fail if README needs updating")
+    args = parser.parse_args()
+
+    table = generate_table()
+    content = README.read_text()
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print("❌ README.md is missing CONFIG_TABLE_START or END_MARKER.", file=sys.stderr)
+        return 1
+
+    start_idx = content.find(START_MARKER) + len(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    new_content = content[:start_idx] + "\n" + table + "\n" + content[end_idx:]
+
+    if content == new_content:
+        print("✅ README.md configuration table is up-to-date.")
+        return 0
+
+    if args.check:
+        print(
+            "❌ README.md configuration table is out-of-date. Run "
+            "scripts/generate_doc_config.py to update it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    README.write_text(new_content)
+    print("✅ README.md configuration table updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,80 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection string (optional)")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run jobs inline in development instead of enqueuing"
+    )
+    jobs_default_queue: str = Field("default", description="Default Redis queue name for jobs")
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend type (`local` or `s3`)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Local directory for uploaded files"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field(
+        "file", description="Email backend type (`file` or `smtp`)"
+    )  # "file" or "smtp"
+    email_from: str = Field(
+        "noreply@localhost", description="Default sender address for outbound emails"
+    )
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Local directory for file-based email outbox"
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP server username")
+    smtp_password: str = Field("", description="SMTP server password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(False, description="Use SSL for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode with restricted actions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: The configuration table in `README.md` is now automatically generated from `src/h4ckath0n/config.py` using a new python script (`scripts/generate_doc_config.py`). The defaults and descriptions have been moved into `pydantic.Field` assignments.

🎯 Why: Hardcoding env vars and their default values in the `README.md` risks documentation drift when the code inevitably changes but the markdown is forgotten. This ensures the configuration remains synchronized.

🧪 Verification:
- Run `uv run scripts/generate_doc_config.py` locally.
- Run `uv run --locked ruff check .`, `uv run --locked mypy src`, and `uv run --locked pytest tests/ -v` to ensure typing and configuration behavior remains unaffected.

🔒 Drift Prevention: A check has been added to `.github/workflows/ci.yml` that runs `scripts/generate_doc_config.py --check`, failing the build if the config definitions and the README fall out of sync.

🗺️ Evidence:
- `src/h4ckath0n/config.py`
- `.github/workflows/ci.yml`

---
*PR created automatically by Jules for task [11633898030386213794](https://jules.google.com/task/11633898030386213794) started by @ToolchainLab*