### PR TITLE
⚡ Bolt: Use `db.get()` for primary key lookups to optimize database queries

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use primary key lookup to hit the session identity map.
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use primary key lookup to hit the session identity map.
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,11 +148,11 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use primary key lookup to hit the session identity map.
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        return session.execute(stmt).scalars().first()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 **What**: Replaced instances of `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` with `db.get(Model, pk)` and `session.execute(select(Model).where(Model.id == pk)).scalars().first()` with `session.get(Model, pk)`.
- 🎯 **Why**: Using `db.get()` is a known SQLAlchemy performance optimization. It checks the local session's identity map first, potentially bypassing a database query completely. Even when a query is made, it avoids some of the overhead associated with constructing and parsing a more complex `select` statement.
- 📊 **Impact**: Reduces unnecessary database queries and lowers overhead for single record primary key lookups, improving overall execution speed for passkey flow validations and CLI user lookups.
- 🔬 **Measurement**: Verify by inspecting the updated code in `src/h4ckath0n/auth/passkeys/service.py` and `src/h4ckath0n/cli.py`. Python tests (`pytest`) and Playwright E2E tests pass, ensuring functionality remains unchanged.

---
*PR created automatically by Jules for task [8224361994620318907](https://jules.google.com/task/8224361994620318907) started by @ToolchainLab*