### PR TITLE
🎨 Palette: Add keyboard shortcut and visual hint for AI Chat submission

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,29 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (!aiStreaming && aiPrompt.trim()) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <div className="absolute bottom-2 right-2 flex items-center gap-1 text-xs text-text-muted pointer-events-none">
+                <span className="opacity-70">Press</span>
+                <kbd className="px-1.5 py-0.5 rounded border border-border bg-surface-alt font-sans text-[10px] font-medium opacity-70">
+                  Enter
+                </kbd>
+                <span className="opacity-70">to send</span>
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added an `onKeyDown` handler to the AI Chat textarea that triggers submission when `Enter` (without `Shift`) is pressed. Also added a visual `<kbd>Enter</kbd>` shortcut hint to the bottom-right of the textarea.
🎯 Why: Submitting a form or chat input via the keyboard is an expected and intuitive interaction pattern that reduces friction compared to requiring a mouse click. The visual hint ensures users discover this functionality.
📸 Before/After: Visual change introduces a small "Press [Enter] to send" hint inside the textarea.
♿ Accessibility: Ensures the keyboard handler respects the exact same disabled state conditions (`!aiStreaming && aiPrompt.trim()`) as the submit button, preventing invalid submissions.

---
*PR created automatically by Jules for task [14837228259762356318](https://jules.google.com/task/14837228259762356318) started by @ToolchainLab*