### PR TITLE
⚡ Bolt: Optimize primary key lookups in passkey service

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
💡 What: Replaced `await db.execute(select(Model).filter(Model.id == pk))` with `await db.get(Model, pk)` in the passkey service (`_get_valid_flow` and `finish_registration`).
🎯 Why: `db.get()` is faster for single primary key lookups because it checks the active session's identity map before hitting the database, potentially avoiding a database query and the overhead of query construction entirely.
📊 Impact: Reduces database load and latency for hot paths (flow validation and user lookups during registration).
🔬 Measurement: Run the test suite (`pytest`) to ensure no functionality is broken.


---
*PR created automatically by Jules for task [10003120645719550105](https://jules.google.com/task/10003120645719550105) started by @ToolchainLab*