### PR TITLE
🎨 Palette: Improve keyboard discoverability and file input affordances

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -201,7 +201,8 @@ export function Dashboard() {
                 <input
                   ref={fileInputRef}
                   type="file"
-                  className="flex-1 text-sm file:mr-2 file:py-1 file:px-3 file:rounded file:border-0 file:text-sm file:bg-primary file:text-white"
+                disabled={uploading}
+                className="flex-1 text-sm file:mr-2 file:py-1 file:px-3 file:rounded file:border-0 file:text-sm file:bg-primary file:text-white file:cursor-pointer file:hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-50"
                 />
                 <Button onClick={handleUpload} disabled={uploading}>
                   {uploading ? "Uploading…" : "Upload"}
@@ -292,12 +293,26 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div>
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (!aiStreaming && aiPrompt.trim()) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 rounded-xl border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <div className="flex items-center gap-4 mt-1 mb-2 text-xs text-text-muted">
+                <span><kbd className="px-1.5 py-0.5 rounded-lg bg-surface-alt border border-border font-sans text-text">Enter</kbd> to send</span>
+                <span><kbd className="px-1.5 py-0.5 rounded-lg bg-surface-alt border border-border font-sans text-text">Shift</kbd> + <kbd className="px-1.5 py-0.5 rounded-lg bg-surface-alt border border-border font-sans text-text">Enter</kbd> for new line</span>
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added keyboard shortcut hints (`<kbd>`) and Enter-to-submit functionality to the AI Chat prompt. Also added disabled and hover/cursor states to the `<input type="file" />`.

🎯 Why: Users expect `Enter` to submit chat forms rather than having to click the button. Additionally, the file upload input lacked interaction feedback (hover effects, pointer cursor) and could theoretically still be interacted with during an upload state. 

📸 Before/After: Visual hints added below the AI text area. File upload button now turns darker primary on hover.

♿ Accessibility: Ensures the AI chat can be fully operated via keyboard without needing to tab to the Send button. The `onKeyDown` handler replicates the exact validation of the disabled button state. Displays `<kbd>` hints to make this functionality discoverable.

---
*PR created automatically by Jules for task [1942982384730312178](https://jules.google.com/task/1942982384730312178) started by @ToolchainLab*