### PR TITLE
🧭 Atlas: [Config Drift] Generate environment variables README table from code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Config Table drift prevention
+
+**Learning:** Documentation for environment variable configurations is likely to drift from code. Simply keeping configurations in README.md will end up generating bugs.
+**Action:** Extract descriptions from Pydantic `Field` and generate the Config table to prevent any out of date configurations. Add a CI test that calls `uv run --locked scripts/generate_doc_config.py --check` and fails the test if any changes are made.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web app for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode constraints |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that configuration options in README.md match code.
+
+Usage (from repo root):
+    uv run scripts/generate_doc_config.py [--check]
+
+This script imports the h4ckath0n app settings, enumerates all fields, and
+updates the Configuration table in README.md. If --check is passed, it fails if
+the file would change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def generate_config_table() -> str:
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for name, field_info in Settings.model_fields.items():
+        # Handle default value safely avoiding literal "PydanticUndefined"
+        default = field_info.default
+        is_undefined = getattr(type(default), "__name__", "") == "PydanticUndefinedType"
+
+        if is_undefined or default == "":
+            default_str = "empty"
+        elif default == []:
+            default_str = "`[]`"
+        elif isinstance(default, bool):
+            default_str = f"`{str(default).lower()}`"
+        else:
+            default_str = f"`{default}`"
+
+        desc = field_info.description or ""
+        var_name = f"`H4CKATH0N_{name.upper()}`"
+
+        # Exceptions for specific env vars
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+        elif name == "openai_api_key":
+            var_name = "`OPENAI_API_KEY`"
+
+        lines.append(f"| {var_name} | {default_str} | {desc} |")
+
+        # Hardcode H4CKATH0N_OPENAI_API_KEY explicitly since it's an alternate
+        if name == "openai_api_key":
+            lines.append(
+                "| `H4CKATH0N_OPENAI_API_KEY` | empty | "
+                "Alternate OpenAI API key for the LLM wrapper |"
+            )
+
+    return "\n".join(lines)
+
+
+def update_readme(new_table: str, check_only: bool = False) -> int:
+    readme_text = README.read_text()
+
+    start_marker = "<!-- CONFIG_TABLE_START -->"
+    end_marker = "<!-- CONFIG_TABLE_END -->"
+
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print(f"❌ Could not find {start_marker} and {end_marker} in README.md")
+        return 1
+
+    start_idx = readme_text.index(start_marker) + len(start_marker)
+    end_idx = readme_text.index(end_marker)
+
+    new_readme = readme_text[:start_idx] + "\n" + new_table + "\n" + readme_text[end_idx:]
+
+    if readme_text == new_readme:
+        print("✅ README.md configuration table is up-to-date.")
+        return 0
+
+    if check_only:
+        print("❌ README.md configuration table is out-of-date.")
+        print("Run `uv run scripts/generate_doc_config.py` to update it.")
+        return 1
+
+    README.write_text(new_readme)
+    print("✅ Updated README.md configuration table.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if README.md is up-to-date")
+    args = parser.parse_args()
+
+    table = generate_config_table()
+    return update_readme(table, check_only=args.check)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,82 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run background jobs inline in development"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum file upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the web app for email links"
+    )
+    email_backend: str = Field(default="file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender email address"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file email backend"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use SSL for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode constraints")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the manually written environment variable table in `README.md` with an automated section generated directly from the `Settings` class definition in `src/h4ckath0n/config.py`. Added a validation script and CI check.
🎯 Why: Documentation for environment variables frequently drifts from the source code, causing confusion for new contributors. Keeping configuration docs directly attached to Pydantic Fields provides a single source of truth.
🧪 Verification: Run `uv run scripts/generate_doc_config.py` to regenerate the docs, and `uv run scripts/generate_doc_config.py --check` to verify no drift exists. Tests passed using `uv run --locked pytest -v`.
🔒 Drift Prevention: The markdown table is wrapped in `<!-- CONFIG_TABLE_START -->` and `<!-- CONFIG_TABLE_END -->` markers. The GitHub Actions CI pipeline now runs the generator with the `--check` flag to fail any PR that leaves documentation out of sync.
🗺️ Evidence: `src/h4ckath0n/config.py` now serves as the authoritative source.

---
*PR created automatically by Jules for task [15264641491173584098](https://jules.google.com/task/15264641491173584098) started by @ToolchainLab*