### PR TITLE
⚡ Bolt: Offload blocking file I/O and hashing to thread

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+## 2024-05-24 - Async IO blocking via CPU/Disk operations
+**Learning:** In asynchronous applications like FastAPI, performing CPU-bound operations (e.g., `hashlib.sha256`) and blocking disk I/O (`os.makedirs`, `open().write()`) inside an `async def` function directly blocks the event loop, causing latency spikes for all concurrent requests.
+**Action:** Always offload CPU-bound and blocking disk I/O operations inside `async def` routes/functions to a worker thread using `asyncio.to_thread()`.

--- a/src/h4ckath0n/uploads/storage.py
+++ b/src/h4ckath0n/uploads/storage.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import os
 
 from h4ckath0n.rng import token_hex as _rng_hex
 
 
-async def store_file(storage_dir: str, data: bytes) -> tuple[str, str]:
-    """Store file data and return (storage_key, sha256_hex).
-
-    The storage key is fully opaque – it never contains any user-supplied
-    values such as original filenames.
-    """
+def _store_file_sync(storage_dir: str, data: bytes) -> tuple[str, str]:
+    """Synchronous helper to store file data and return (storage_key, sha256_hex)."""
+    # Optimize: Offload CPU-bound hashing and blocking I/O to a worker thread
     sha256 = hashlib.sha256(data).hexdigest()
     prefix = sha256[:2]
     random_part = _rng_hex(16)  # 128-bit opaque path component.
@@ -27,6 +25,15 @@ async def store_file(storage_dir: str, data: bytes) -> tuple[str, str]:
         f.write(data)
 
     return storage_key, sha256
+
+
+async def store_file(storage_dir: str, data: bytes) -> tuple[str, str]:
+    """Store file data and return (storage_key, sha256_hex).
+
+    The storage key is fully opaque – it never contains any user-supplied
+    values such as original filenames.
+    """
+    return await asyncio.to_thread(_store_file_sync, storage_dir, data)
 
 
 def get_file_path(storage_dir: str, storage_key: str) -> str:


### PR DESCRIPTION
- 💡 What: Refactored `store_file` to offload CPU-bound hashing (`hashlib.sha256`) and blocking disk I/O (`os.makedirs`, `open().write()`) to a synchronous helper function `_store_file_sync` executed in a worker thread using `asyncio.to_thread`.
- 🎯 Why: Executing CPU-bound tasks and blocking disk I/O directly inside an `async def` function blocks the main event loop, causing latency spikes and halting the processing of all other concurrent requests.
- 📊 Impact: Prevents the event loop from being blocked during file uploads, significantly improving the responsiveness and concurrency of the application under load.
- 🔬 Measurement: Observe reduced latency spikes and improved throughput for concurrent requests during file upload operations in a load testing environment.

---
*PR created automatically by Jules for task [3706036801041001200](https://jules.google.com/task/3706036801041001200) started by @ToolchainLab*