### PR TITLE
🎨 Palette: Add Cmd/Ctrl+Enter shortcut to AI Chat textarea

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/App.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Login } from "./pages/Login";
 import { ForgotPassword } from "./pages/ForgotPassword";
 import { ResetPassword } from "./pages/ResetPassword";
 import { Dashboard } from "./pages/Dashboard";
+
 import { Settings } from "./pages/Settings";
 import { Admin } from "./pages/Admin";
 import { DemoRealtime } from "./pages/DemoRealtime";
@@ -17,6 +18,7 @@ export function App() {
       <Route element={<Layout />}>
         <Route path="/" element={<Landing />} />
         <Route path="/register" element={<Register />} />
+
         <Route path="/login" element={<Login />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password" element={<ResetPassword />} />

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -295,15 +295,28 @@ export function Dashboard() {
             <textarea
               value={aiPrompt}
               onChange={(e) => setAiPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  if (!aiStreaming && aiPrompt.trim()) {
+                    void handleAiStream();
+                  }
+                }
+              }}
               placeholder="Type a prompt…"
               className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
             />
-            <Button
-              onClick={handleAiStream}
-              disabled={aiStreaming || !aiPrompt.trim()}
-            >
-              {aiStreaming ? "Streaming…" : "Send"}
-            </Button>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-muted hidden sm:inline-block">
+                Press <kbd className="font-sans px-1 py-0.5 bg-surface-alt border border-border rounded text-[10px]">⌘</kbd> <span className="mx-0.5">/</span> <kbd className="font-sans px-1 py-0.5 bg-surface-alt border border-border rounded text-[10px]">Ctrl</kbd> + <kbd className="font-sans px-1 py-0.5 bg-surface-alt border border-border rounded text-[10px]">Enter</kbd> to send
+              </span>
+              <Button
+                onClick={handleAiStream}
+                disabled={aiStreaming || !aiPrompt.trim()}
+              >
+                {aiStreaming ? "Streaming…" : "Send"}
+              </Button>
+            </div>
             {aiResponse && (
               <div className="p-3 rounded bg-surface-alt text-sm whitespace-pre-wrap font-mono">
                 {aiResponse}


### PR DESCRIPTION
- 💡 What: Added keyboard shortcut (`Cmd/Ctrl + Enter`) support and visual hints to the AI Chat textarea.
- 🎯 Why: Typing a multi-line prompt and then having to use the mouse to click "Send" breaks keyboard flow. This allows power-users to submit quickly while keeping the UI discoverable for everyone.
- 📸 Before/After: Visual hints added using existing design system `<kbd>` styles alongside the Send button.
- ♿ Accessibility: Improves keyboard navigation and usability for power users without interrupting screen reader flow (which relies on focus + Enter on the button natively, but now the textarea is more efficient).

---
*PR created automatically by Jules for task [17807434975272354544](https://jules.google.com/task/17807434975272354544) started by @ToolchainLab*