### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration via timing attack in auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-28 - [Timing Attack] User enumeration vulnerability in auth
+**Vulnerability:** The authentication endpoint allowed user enumeration because it returned early without performing expensive hashing operations if a user did not exist or had no password (e.g., passkey-only users).
+**Learning:** Always perform dummy cryptographic operations when a user isn't found to ensure consistent response times and avoid leaking user existence through timing differences.
+**Prevention:** Use `hash_password(password)` as a dummy operation before returning `None` when the user lookup fails or they lack a password hash.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -73,12 +73,15 @@ async def register_user(
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
-    _hash, verify_password = _require_password_extra()
+    hash_password, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    if user is None or not user.password_hash:
+        # Sentinel: Perform dummy password hashing to prevent user enumeration via timing attacks
+        hash_password(password)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: User enumeration via timing attack in `authenticate_user` endpoint. The endpoint returned early if a user wasn't found or lacked a password, leaking whether an email address exists in the system based on response time differences.
- 🎯 Impact: Attackers could enumerate valid email addresses by observing how quickly the login endpoint responds (since failing early bypasses the expensive Argon2id hash).
- 🔧 Fix: Added dummy password hashing `hash_password(password)` before returning `None` to equalize execution time for invalid users.
- ✅ Verification: Run `pytest` locally to ensure auth flows still work correctly. Checked execution paths in `authenticate_user` for consistency.

---
*PR created automatically by Jules for task [655357742569833661](https://jules.google.com/task/655357742569833661) started by @ToolchainLab*