### PR TITLE
🧭 Atlas: Prevent configuration doc drift by generating from Settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check config docs
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-28 - Drift prevention for configuration documentation
+**Learning:** Hardcoded documentation for configuration options drifts away from the actual `BaseSettings` over time, leading to missing or incorrectly described options.
+**Action:** Use Pydantic's `Field(..., description="...")` in the code, and extract `model_fields` to automatically generate the documentation table using markers (e.g. `<!-- CONFIG_TABLE_START -->`). Safely check for `PydanticUndefinedType` as Pydantic uses it for missing defaults.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use (`local`, `s3`, etc.) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use explicit SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode with seeded data |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script: generates markdown configuration table from Settings class.
+
+Usage (from repo root):
+    uv run scripts/generate_doc_config.py
+    uv run scripts/generate_doc_config.py --check
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_config_table() -> str:
+    """Generate a Markdown table of configuration options."""
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for name, field in Settings.model_fields.items():
+        if name == "model_config":
+            continue
+
+        env_name = f"`H4CKATH0N_{name.upper()}`"
+
+        # Override specific cases based on README.md
+        if name == "openai_api_key":
+            env_name = "`OPENAI_API_KEY`"
+
+        default_val = field.default
+        default_str = ""
+
+        # Safe check for undefined default
+        if (
+            getattr(type(default_val), "__name__", "") == "PydanticUndefinedType"
+            or default_val == ""
+            or default_val is None
+        ):
+            default_str = "empty"
+        elif isinstance(default_val, bool):
+            default_str = f"`{str(default_val).lower()}`"
+        elif isinstance(default_val, (int, str)):
+            default_str = f"`{default_val}`"
+        elif isinstance(default_val, list) and not default_val:
+            default_str = "`[]`"
+        else:
+            default_str = f"`{default_val}`"
+
+        # Hardcode the specific dev defaults as mentioned in the original README
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        desc = field.description or ""
+        lines.append(f"| {env_name} | {default_str} | {desc} |")
+
+        if name == "openai_api_key":
+            lines.append(
+                "| `H4CKATH0N_OPENAI_API_KEY` | empty | "
+                "Alternate OpenAI API key for the LLM wrapper |"
+            )
+
+    return "\n".join(lines)
+
+
+def update_readme(check_only: bool = False) -> int:
+    """Update or check the README.md configuration table."""
+    readme_text = README.read_text()
+    table = get_config_table()
+
+    # The marker is exactly `<!-- CONFIG_TABLE_START -->` then newline,
+    # then table, then newline `<!-- CONFIG_TABLE_END -->`
+    pattern = re.compile(r"<!-- CONFIG_TABLE_START -->.*?<!-- CONFIG_TABLE_END -->", re.DOTALL)
+    replacement = f"<!-- CONFIG_TABLE_START -->\n{table}\n<!-- CONFIG_TABLE_END -->"
+
+    if not pattern.search(readme_text):
+        print(
+            "❌ Marker tags <!-- CONFIG_TABLE_START --> and <!-- CONFIG_TABLE_END --> "
+            "not found in README.md"
+        )
+        return 1
+
+    new_text = pattern.sub(replacement, readme_text)
+
+    if new_text == readme_text:
+        print("✅ Configuration table is up to date.")
+        return 0
+
+    if check_only:
+        print(
+            "❌ Configuration table is out of date. "
+            "Run `uv run scripts/generate_doc_config.py` to update."
+        )
+        return 1
+
+    README.write_text(new_text)
+    print("✅ Configuration table updated.")
+    return 0
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    return update_readme(check_only)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,80 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run background jobs inline in development mode"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(
+        "local", description="Storage backend to use (`local`, `s3`, etc.)"
+    )
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum allowed upload size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field("file", description="Email backend to use (`file` or `smtp`)")
+    email_from: str = Field("noreply@localhost", description="Sender address for outbound emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email backend"
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP server username")
+    smtp_password: str = Field("", description="SMTP server password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP connections")
+    smtp_ssl: bool = Field(False, description="Use explicit SSL/TLS for SMTP connections")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode with seeded data")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the hardcoded configuration table in `README.md` with an auto-generated one based on `src/h4ckath0n/config.py`. Added `Field` descriptions to `Settings` and a script `scripts/generate_doc_config.py` to keep docs in sync.
🎯 Why: Hardcoded environment variables drift. New options get added or defaults change, but the documentation misses them. This generates the single source of truth (the Pydantic `BaseSettings`) directly into the markdown via markers.
🧪 Verification: Run `uv run scripts/generate_doc_config.py` locally to see it rewrite the `README.md`.
🔒 Drift Prevention: Added `uv run --locked scripts/generate_doc_config.py --check` to `.github/workflows/ci.yml` so that any PR adding a new config variable without updating the generated docs will fail CI.
🗺️ Evidence: `src/h4ckath0n/config.py` is the source of truth.

---
*PR created automatically by Jules for task [4975808564284322128](https://jules.google.com/task/4975808564284322128) started by @ToolchainLab*