### PR TITLE
⚡ Bolt: Offload CPU-bound password hashing to threads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-18 - Offload Password Hashing and Verification to Threads
+**Learning:** Synchronous password hashing and verification using Argon2 are intentionally CPU-bound and block the main event loop when executed directly within asynchronous routes, degrading API throughput and performance.
+**Action:** Always wrap heavy CPU-bound cryptographic functions (like `hash_password` and `verify_password`) with `await asyncio.to_thread(...)` to ensure they execute without blocking other concurrent async requests.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -6,6 +6,7 @@ They will raise ``RuntimeError`` if called without the extra installed.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
@@ -60,9 +61,10 @@ async def register_user(
     if result.scalars().first():
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
+    hashed_pw = await asyncio.to_thread(hash_password, password)
     user = User(
         email=email,
-        password_hash=hash_password(password),
+        password_hash=hashed_pw,
         role=role,
         display_name=display_name,
     )
@@ -79,7 +81,7 @@ async def authenticate_user(db: AsyncSession, email: str, password: str) -> User
         return None
     if not user.password_hash:
         return None
-    if not verify_password(password, user.password_hash):
+    if not await asyncio.to_thread(verify_password, password, user.password_hash):
         return None
     return user
 
@@ -172,6 +174,6 @@ async def confirm_password_reset(db: AsyncSession, raw_token: str, new_password:
     # ⚡ Bolt: Use db.get() for primary key lookup
     if (user := await db.get(User, prt.user_id)) is None:
         raise ValueError("User not found")
-    user.password_hash = hash_password(new_password)
+    user.password_hash = await asyncio.to_thread(hash_password, new_password)
     await db.commit()
     return user


### PR DESCRIPTION
- 💡 **What**: Wrap Argon2 `hash_password` and `verify_password` calls in `await asyncio.to_thread(...)` within the `auth/service.py` file.
- 🎯 **Why**: Password hashing is intentionally CPU-bound. When called directly inside an `async def` route handler, it completely blocks the Python event loop for the duration of the hash (~100-300ms depending on Argon2 parameters), destroying concurrent request throughput and increasing latency for unrelated requests.
- 📊 **Impact**: Prevents event loop stalling during password operations. Concurrent throughput under load (especially during login/registration spikes) will improve significantly because other async requests will no longer wait for cryptographic operations to finish.
- 🔬 **Measurement**: Profiling or load-testing the `/auth/login` endpoint concurrently with lightweight endpoints (like `/health` or simple DB queries). The lightweight endpoints should no longer spike in latency during login bursts.

---
*PR created automatically by Jules for task [2288709400288500240](https://jules.google.com/task/2288709400288500240) started by @ToolchainLab*