### PR TITLE
🎨 Palette: Add Enter shortcut and visual hint to AI chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-29 - Discoverability of Keyboard Shortcuts
+**Learning:** Adding custom keyboard shortcuts (like 'Enter' to submit) is excellent for power users, but invisible to others. Without visual cues, the feature is undiscoverable.
+**Action:** When adding custom keyboard shortcuts to UI elements (e.g., using 'Enter' to submit a textarea), improve discoverability by displaying visual `<kbd>` shortcut hints directly below or alongside the interactive element.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -295,15 +295,28 @@ export function Dashboard() {
             <textarea
               value={aiPrompt}
               onChange={(e) => setAiPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  if (!aiStreaming && aiPrompt.trim()) {
+                    handleAiStream();
+                  }
+                }
+              }}
               placeholder="Type a prompt…"
               className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
             />
-            <Button
-              onClick={handleAiStream}
-              disabled={aiStreaming || !aiPrompt.trim()}
-            >
-              {aiStreaming ? "Streaming…" : "Send"}
-            </Button>
+            <div className="flex items-center gap-3">
+              <Button
+                onClick={handleAiStream}
+                disabled={aiStreaming || !aiPrompt.trim()}
+              >
+                {aiStreaming ? "Streaming…" : "Send"}
+              </Button>
+              <span className="text-xs text-text-muted hidden sm:inline-block">
+                Press <kbd className="px-1.5 py-0.5 bg-surface-alt border border-border rounded-md font-sans text-[10px] uppercase font-semibold text-text">Enter</kbd> to send
+              </span>
+            </div>
             {aiResponse && (
               <div className="p-3 rounded bg-surface-alt text-sm whitespace-pre-wrap font-mono">
                 {aiResponse}


### PR DESCRIPTION
- 💡 What: Added 'Enter' to submit the AI Chat textarea and a visual `<kbd>` hint.
- 🎯 Why: 'Enter to submit' is a common chat UX pattern. Adding the visual hint makes this power-user feature discoverable to all.
- 📸 Before/After: See PR.
- ♿ Accessibility: Improved discoverability and provided alternative to pointing device.

---
*PR created automatically by Jules for task [17170242036803368743](https://jules.google.com/task/17170242036803368743) started by @ToolchainLab*