### PR TITLE
⚡ Bolt: [performance improvement] Offload Argon2 password hashing to thread

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-24 - Offload Cryptographic CPU-Bound Tasks to Threads
+
+**Learning:** Operations like Argon2 password hashing and verification are intensely CPU-bound by design. Running them synchronously in asyncio request handlers directly blocks the main event loop, significantly increasing latency and dropping concurrency for all other parallel HTTP/WebSocket requests during the operation.
+
+**Action:** Use `await asyncio.to_thread()` to offload expensive CPU-bound computations (such as cryptographic hashing) to worker threads so the main event loop remains free to serve other requests.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -6,6 +6,7 @@ They will raise ``RuntimeError`` if called without the extra installed.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
@@ -60,9 +61,14 @@ async def register_user(
     if result.scalars().first():
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
+
+    # ⚡ Bolt: Offload CPU-bound Argon2 password hashing to a worker thread
+    # to prevent blocking the main asyncio event loop.
+    password_hash = await asyncio.to_thread(hash_password, password)
+
     user = User(
         email=email,
-        password_hash=hash_password(password),
+        password_hash=password_hash,
         role=role,
         display_name=display_name,
     )
@@ -79,7 +85,11 @@ async def authenticate_user(db: AsyncSession, email: str, password: str) -> User
         return None
     if not user.password_hash:
         return None
-    if not verify_password(password, user.password_hash):
+
+    # ⚡ Bolt: Offload CPU-bound Argon2 password verification to a worker thread
+    # to prevent blocking the main asyncio event loop.
+    is_valid = await asyncio.to_thread(verify_password, password, user.password_hash)
+    if not is_valid:
         return None
     return user
 
@@ -172,6 +182,9 @@ async def confirm_password_reset(db: AsyncSession, raw_token: str, new_password:
     # ⚡ Bolt: Use db.get() for primary key lookup
     if (user := await db.get(User, prt.user_id)) is None:
         raise ValueError("User not found")
-    user.password_hash = hash_password(new_password)
+
+    # ⚡ Bolt: Offload CPU-bound Argon2 password hashing to a worker thread
+    # to prevent blocking the main asyncio event loop.
+    user.password_hash = await asyncio.to_thread(hash_password, new_password)
     await db.commit()
     return user


### PR DESCRIPTION
💡 What: Used `asyncio.to_thread` for `hash_password` and `verify_password` in `src/h4ckath0n/auth/service.py`.
🎯 Why: Argon2id is intensely CPU-bound by design. Running it synchronously directly blocks the main asyncio event loop, causing severe latency and dropping concurrency for all other parallel HTTP/WebSocket requests during the hashing process.
📊 Impact: Significantly improves server concurrency and responsiveness for all incoming requests during authentication spikes. The event loop remains free to serve other requests while the thread pool handles the heavy lifting.
🔬 Measurement: Observe overall server latency when multiple users authenticate simultaneously. P99 wait times for other fast endpoints will drop drastically during hashing operations.

---
*PR created automatically by Jules for task [3543172372018977001](https://jules.google.com/task/3543172372018977001) started by @ToolchainLab*