### PR TITLE
🎨 Palette: Add keyboard shortcut for AI Chat submission

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -295,15 +295,29 @@ export function Dashboard() {
             <textarea
               value={aiPrompt}
               onChange={(e) => setAiPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  if (!aiStreaming && aiPrompt.trim()) {
+                    void handleAiStream();
+                  }
+                }
+              }}
+              disabled={aiStreaming}
               placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
+              className="w-full h-24 p-3 rounded-xl border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
             />
-            <Button
-              onClick={handleAiStream}
-              disabled={aiStreaming || !aiPrompt.trim()}
-            >
-              {aiStreaming ? "Streaming…" : "Send"}
-            </Button>
+            <div className="flex items-center gap-4">
+              <Button
+                onClick={handleAiStream}
+                disabled={aiStreaming || !aiPrompt.trim()}
+              >
+                {aiStreaming ? "Streaming…" : "Send"}
+              </Button>
+              <div className="text-xs text-text-muted">
+                Press <kbd className="font-sans px-1.5 py-0.5 rounded-lg border border-border bg-surface-alt">Enter</kbd> to send
+              </div>
+            </div>
             {aiResponse && (
               <div className="p-3 rounded bg-surface-alt text-sm whitespace-pre-wrap font-mono">
                 {aiResponse}


### PR DESCRIPTION
- 💡 What: Added an `onKeyDown` handler to the AI Chat textarea to submit the prompt when `Enter` is pressed, added a visual `<kbd>` hint, and disabled the textarea during streaming.
- 🎯 Why: Pressing Enter to submit is a highly expected UX pattern for chat interfaces. The visual hint improves discoverability, and disabling the textarea during streaming prevents conflicting input states and provides consistent feedback.
- 📸 Before/After: Screenshots were taken via playwright to verify the layout and hint placement.
- ♿ Accessibility: The handler mirrors the disabled state logic from the submit button, ensuring users cannot trigger the action when the application is busy or when the input is empty. The `<kbd>` hint is clearly styled using existing border and background tokens.

---
*PR created automatically by Jules for task [15303394815338189304](https://jules.google.com/task/15303394815338189304) started by @ToolchainLab*