### PR TITLE
🧭 Atlas: Prevent documentation drift for configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Prevent documentation drift for configuration
+**Learning:** Environment variables documented in README.md can easily fall out of sync with the actual `pydantic-settings` model.
+**Action:** Generate the configuration table directly from code (e.g., using `pydantic.Field` descriptions) and inject it into markdown files via HTML comment markers. Pair this with a CI check (`--check`) to fail builds if the documentation is out-of-sync.

--- a/README.md
+++ b/README.md
@@ -159,22 +159,41 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
 | `H4CKATH0N_PASSWORD_AUTH_ENABLED` | `false` | Enable password routes when the extra is installed |
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
-| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
+| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | empty | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | App base URL |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Email from address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Email outbox directory |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | SMTP STARTTLS |
+| `H4CKATH0N_SMTP_SSL` | `false` | SMTP SSL |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: generate configuration docs from the source of truth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- CONFIG_TABLE_START -->"
+END_MARKER = "<!-- CONFIG_TABLE_END -->"
+
+
+def generate_table() -> str:
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+    for name, field in Settings.model_fields.items():
+        # Exclude H4CKATH0N_OPENAI_API_KEY to match README content
+        if name == "h4ckath0n_openai_api_key":
+            continue
+        default_val = field.default
+        is_undef = getattr(type(default_val), "__name__", "") == "PydanticUndefinedType"
+        if is_undef or default_val == "":
+            default_str = "empty"
+        elif isinstance(default_val, list):
+            default_str = "`[]`" if not default_val else f"`{json.dumps(default_val)}`"
+        else:
+            default_str = (
+                str(default_val).lower() if isinstance(default_val, bool) else str(default_val)
+            )
+            default_str = f"`{default_str}`"
+
+        env_var = "OPENAI_API_KEY" if name == "openai_api_key" else f"H4CKATH0N_{name.upper()}"
+        desc = field.description or "No description"
+        lines.append(f"| `{env_var}` | {default_str} | {desc} |")
+
+    # Add H4CKATH0N_OPENAI_API_KEY explicitly
+    lines.append(
+        "| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |"
+    )
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if README is up to date.")
+    args = parser.parse_args()
+
+    readme_content = README.read_text(encoding="utf-8")
+
+    if START_MARKER not in readme_content or END_MARKER not in readme_content:
+        print("❌ Markers not found in README.md", file=sys.stderr)
+        return 1
+
+    pattern = re.compile(f"{START_MARKER}.*?{END_MARKER}", re.DOTALL)
+    new_table = f"{START_MARKER}\n{generate_table()}\n{END_MARKER}"
+
+    match = pattern.search(readme_content)
+    if not match:
+        print("❌ Could not match markers in README.md", file=sys.stderr)
+        return 1
+
+    current_section = match.group(0)
+
+    if args.check:
+        if current_section != new_table:
+            print(
+                "❌ The configuration table in README.md is out of sync with config.py.",
+                file=sys.stderr,
+            )
+            print(
+                "Please run `uv run python scripts/generate_doc_config.py` to fix it.",
+                file=sys.stderr,
+            )
+            return 1
+        print("✅ Configuration table in README.md is up to date.")
+        return 0
+
+    if current_section != new_table:
+        new_content = pattern.sub(new_table, readme_content)
+        README.write_text(new_content, encoding="utf-8")
+        print("✅ Updated configuration table in README.md.")
+    else:
+        print("✅ Configuration table in README.md is already up to date.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,73 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(default=True, description="Run jobs inline in development")
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend")
+    storage_dir: str = Field(default="./.h4ckath0n_storage", description="Storage directory")
+    max_upload_bytes: int = Field(default=50 * 1024 * 1024, description="Max upload size in bytes")
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(default="http://localhost:5173", description="App base URL")
+    email_backend: str = Field(default="file", description="`file` or `smtp`")
+    email_from: str = Field(default="noreply@localhost", description="Email from address")
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Email outbox directory"
+    )
+    smtp_host: str = Field(default="", description="SMTP host")
+    smtp_port: int = Field(default=587, description="SMTP port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="SMTP STARTTLS")
+    smtp_ssl: bool = Field(default=False, description="SMTP SSL")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Generated the configuration table in `README.md` directly from the `pydantic.Field` descriptions in `src/h4ckath0n/config.py`.
🎯 Why: Environment variables documented in the README easily fall out of sync with the actual `pydantic-settings` model.
🧪 Verification: Run `uv run scripts/generate_doc_config.py --check` locally to verify the docs are in sync.
🔒 Drift Prevention: Added `scripts/generate_doc_config.py` that generates the configuration section in `README.md` between `<!-- CONFIG_TABLE_START -->` and `<!-- CONFIG_TABLE_END -->` markers. Added a CI check to fail the build if the documentation is out-of-sync.
🗺️ Evidence: `src/h4ckath0n/config.py` is the single source of truth.

---
*PR created automatically by Jules for task [9003425522303395884](https://jules.google.com/task/9003425522303395884) started by @ToolchainLab*