### PR TITLE
∯ Vector: [centralize display name normalization]

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -6,7 +6,11 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import (
+    DISPLAY_NAME_MAX_LENGTH,
+    DeviceBindingMixin,
+    clean_display_name,
+)
 
 # -- Registration --
 
@@ -18,13 +22,7 @@ class PasskeyRegisterStartRequest(BaseModel):
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
 
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    _clean_display_name = field_validator("display_name")(clean_display_name)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -8,6 +8,14 @@ from pydantic import BaseModel, EmailStr, Field, field_validator
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
+def clean_display_name(v: str) -> str:
+    """Trim whitespace and reject empty-after-trim values for required display names."""
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
 def _validate_display_name(v: str | None) -> str | None:
     """Trim whitespace; reject empty-after-trim values."""
     if v is None:
@@ -35,13 +43,7 @@ class RegisterRequest(DeviceBindingMixin):
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
 
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    _clean_display_name = field_validator("display_name")(clean_display_name)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted and centralized the `display_name` validation logic (trimming and empty checks) into a single pure helper `clean_display_name` in `src/h4ckath0n/auth/schemas.py`.
- 🎯 Why: The exact same Pydantic `@field_validator` logic was duplicated across `src/h4ckath0n/auth/schemas.py` and `src/h4ckath0n/auth/passkeys/schemas.py`.
- 🧠 Design: By defining `clean_display_name` once and reusing it across both `RegisterRequest` and `PasskeyRegisterStartRequest`, we enforce a single source of truth for display name normalization without needing a new base class mixin just for one field.
- λ FP Angle: Transitioned from duplicated `@classmethod` validators with inline mutation to a single, composable pure function that applies declarative normalization.
- ✅ Verification: Ran backend tests (`pytest`, `mypy`, `ruff`) and frontend quality gates (`Playwright`, `tsc`, `lint`), ensuring both backend validation and frontend passkey flows continue to work flawlessly.
- 🧪 Edge cases: Continued to handle whitespace-only, empty strings, and long strings consistently by relying on the same validation rules.
- ⚠️ Risk: Extremely low risk since the exact same semantics are applied to the same fields.

---
*PR created automatically by Jules for task [12565806019123882689](https://jules.google.com/task/12565806019123882689) started by @ToolchainLab*