### PR TITLE
⚡ Bolt: [performance improvement] Optimize primary key lookups to use db.get()

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to hit the session identity map.
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to hit the session identity map.
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
💡 **What:** 
Replaced `select().filter(id=X)` with `db.get(Model, X)` for primary key lookups in `src/h4ckath0n/auth/passkeys/service.py` (`_get_valid_flow` and `finish_registration`).

🎯 **Why:** 
Using `db.get()` for primary key lookups checks the SQLAlchemy identity map first. If the entity is already loaded in the current session, it returns it instantly without performing a database query, or performs an optimized single primary key fetch otherwise. In hot authentication paths like WebAuthn registration and verification, this reduces query overhead and parsing times.

📊 **Impact:** 
Bypasses unnecessary database roundtrips and object hydration for repeated PK lookups, marginally improving response latency for the core passkey authentication APIs.

🔬 **Measurement:** 
Run `pytest` to ensure authentication flows remain 100% correct. Lookups for valid flows and users during registration and assertions will now use the identity map effectively.

---
*PR created automatically by Jules for task [3776018991207765503](https://jules.google.com/task/3776018991207765503) started by @ToolchainLab*