### PR TITLE
🧭 Atlas: Auto-generate configuration documentation from code to prevent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/generate_doc_config.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Prevent config drift with auto-generated documentation
+**Learning:** Hardcoded environment variables in READMEs inevitably drift from Pydantic `BaseSettings`.
+**Action:** Use `Field(description="...")` to define documentation alongside configuration parameters, and auto-generate the markdown tables in CI via scripts injecting between `<!-- CONFIG_TABLE_START -->` markers. Add `--check` to fail builds to prevent drift.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_TABLE_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development without Redis |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for local file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode constraints (e.g., read-only users) |
+<!-- CONFIG_TABLE_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_doc_config.py
+++ b/scripts/generate_doc_config.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: generate and verify README configuration table."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- CONFIG_TABLE_START -->"
+END_MARKER = "<!-- CONFIG_TABLE_END -->"
+
+
+def generate_table() -> str:
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for field_name, field_info in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{field_name.upper()}"
+
+        # Handle special LLM keys documented as empty
+        if field_name == "openai_api_key":
+            lines.append(f"| `OPENAI_API_KEY` | empty | {field_info.description} |")
+            lines.append(
+                f"| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate {field_info.description} |"
+            )
+            continue
+
+        default_val = field_info.default
+        if getattr(type(default_val), "__name__", "") == "PydanticUndefinedType":
+            default_str = "required"
+        elif default_val == "":
+            default_str = "empty"
+        elif default_val == []:
+            default_str = "`[]`"
+        elif isinstance(default_val, bool):
+            default_str = f"`{'true' if default_val else 'false'}`"
+        else:
+            default_str = f"`{default_val}`"
+
+        # Hardcode specific defaults for docs that are dynamic in code
+        if field_name == "rp_id":
+            default_str = "`localhost` in development"
+        elif field_name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        desc = field_info.description or ""
+        lines.append(f"| `{var_name}` | {default_str} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Fail if the README is out of date")
+    args = parser.parse_args()
+
+    content = README.read_text()
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print("❌ Could not find CONFIG_TABLE_START and CONFIG_TABLE_END in README.md")
+        return 1
+
+    start_idx = content.find(START_MARKER) + len(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    table_md = generate_table()
+    new_section = f"\n{table_md}\n"
+
+    current_section = content[start_idx:end_idx]
+
+    if current_section == new_section:
+        if args.check:
+            print("✅ Configuration table in README.md is up to date.")
+        return 0
+
+    if args.check:
+        print(
+            "❌ Configuration table in README.md is out of date. "
+            "Run 'uv run scripts/generate_doc_config.py' to update it."
+        )
+        return 1
+
+    new_content = content[:start_idx] + new_section + content[end_idx:]
+    README.write_text(new_content)
+    print("✨ Updated configuration table in README.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,82 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run background jobs inline in development without Redis"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum upload size in bytes (default 50 MB)"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application for email links"
+    )
+    email_backend: str = Field("file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(
+        "noreply@localhost", description="Default sender address for outbound emails"
+    )
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for local file email backend"
+    )
+    smtp_host: str = Field("", description="SMTP server hostname")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP authentication username")
+    smtp_password: str = Field("", description="SMTP authentication password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP connections")
+    smtp_ssl: bool = Field(False, description="Use implicit SSL/TLS for SMTP connections")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(
+        False, description="Enable demo mode constraints (e.g., read-only users)"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Added an automated drift-prevention script that parses `pydantic.Field` descriptions from the environment configuration class (`src/h4ckath0n/config.py`) and generates the configuration table in `README.md`.
🎯 Why: Hardcoded environment variables in documentation rapidly drift from the codebase (e.g., several parameters like `H4CKATH0N_MAX_UPLOAD_BYTES` and `H4CKATH0N_DEMO_MODE` were completely undocumented). This ensures documentation matches the source of truth perfectly and warns developers dynamically.
🧪 Verification: Run `uv run scripts/generate_doc_config.py` to update the `README.md`.
🔒 Drift Prevention: Added `uv run --locked scripts/generate_doc_config.py --check` as a required quality gate step in `.github/workflows/ci.yml`.
🗺️ Evidence: `src/h4ckath0n/config.py` is the authoritative class managing `.env` files and prefixes.

---
*PR created automatically by Jules for task [9695263241273936546](https://jules.google.com/task/9695263241273936546) started by @ToolchainLab*