### PR TITLE
🎨 Palette: Add Enter-to-submit keyboard shortcut and disabled state to AI chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-09 - Enter-to-submit and Disabled State in AI Chat Textareas
+**Learning:** When implementing "Enter-to-submit" shortcuts in textareas used for AI chat, users often submit prompts while an async stream is still active, causing prompt mangling or overlapping streams. Additionally, when placing an absolute-positioned `<kbd>` hint, typing long prompts can overlap the hint text.
+**Action:** Explicitly add the `disabled` attribute to the `textarea` during the async stream. Always add adequate bottom padding (e.g., `pb-8`) to the textarea to ensure typed text does not obscure the inline keyboard hint.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,26 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (aiPrompt.trim() && !aiStreaming) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-2 right-3 pointer-events-none text-xs text-text-muted">
+                Press <kbd className="font-mono bg-surface-alt px-1 py-0.5 rounded border border-border">Enter</kbd> to send
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added an "Enter to send" shortcut (Shift+Enter for new line) to the AI Chat textarea, included a visual `<kbd>` hint, and disabled the input while the AI response is streaming.
🎯 Why: Improves keyboard accessibility and efficiency for power users interacting with the AI chat, while preventing prompt mangling from multiple submissions during active streams.
📸 Before/After: Visual <kbd> hint is now shown at the bottom right of the textarea.
♿ Accessibility: Enhances keyboard-only workflows and explicitly communicates the disabled (streaming) state to assistive technologies.

---
*PR created automatically by Jules for task [10008405961714023778](https://jules.google.com/task/10008405961714023778) started by @ToolchainLab*