### PR TITLE
🧭 Atlas: Generate env vars doc from config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2026-03-01 - Generate Environment Variables Table in Docs
+**Learning:** Configuration environment variables drift often between the code (e.g. `h4ckath0n/config.py`) and the README table. Pydantic Fields provide a way to store descriptions alongside the models.
+**Action:** Implemented a `check_doc_env_vars.py` script running in CI to parse pydantic `Field` attributes and verify/update the `README.md` generated table automatically.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -174,7 +175,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper. Also accepts `OPENAI_API_KEY` |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type (`local`, `s3`, etc.) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that environment variables are documented in README.md.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py [--update]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Fix: Ensure correct imports and Pydantic field parsing logic
+try:
+    from pydantic_core import PydanticUndefined
+except ImportError:
+    # Handle older pydantic versions if needed
+    class _PydanticUndefined:
+        pass
+
+    PydanticUndefined = _PydanticUndefined()
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+BEGIN_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+
+def get_env_vars_table() -> str:
+    from h4ckath0n.config import Settings
+
+    # We parse the Pydantic model fields correctly.
+    # The instruction says: use `field.is_required()` to identify required fields without defaults,
+    # and check `field.default_factory` for dynamic defaults, rather than checking
+    # `field_info.default` for the `PydanticUndefined` sentinel type.
+
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for name, field in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+
+        # Handle OPENAI_API_KEY special case
+        if name == "openai_api_key":
+            lines.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+
+        if field.is_required():
+            default_str = "required"
+        elif field.default_factory is not None:
+            if field.default_factory is list:
+                default_str = "`[]`"
+            elif field.default_factory is dict:
+                default_str = "`{}`"
+            else:
+                default_str = "dynamic"
+        else:
+            if field.default == "":
+                default_str = "empty"
+            elif field.default is None:
+                default_str = "`null`"
+            elif isinstance(field.default, bool):
+                default_str = f"`{'true' if field.default else 'false'}`"
+            elif isinstance(field.default, str):
+                default_str = f"`{field.default}`"
+            else:
+                default_str = f"`{field.default}`"
+
+        desc = field.description or "No description provided."
+
+        # Add a special note for RP_ID and ORIGIN since they have special defaults in dev
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        lines.append(f"| `{var_name}` | {default_str} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    try:
+        import h4ckath0n.config  # noqa: F401
+    except ImportError:
+        print(
+            "❌ Cannot import h4ckath0n.config. Run from project root using uv run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    table_content = get_env_vars_table()
+
+    readme_text = README.read_text()
+
+    if BEGIN_MARKER not in readme_text or END_MARKER not in readme_text:
+        print("❌ README.md must contain the following markers for env vars:")
+        print(f"  {BEGIN_MARKER}")
+        print(f"  {END_MARKER}")
+        print("\nPlease add them to the Configuration section of README.md.")
+        return 1
+
+    start_idx = readme_text.find(BEGIN_MARKER) + len(BEGIN_MARKER)
+    end_idx = readme_text.find(END_MARKER)
+
+    current_content = readme_text[start_idx:end_idx].strip()
+
+    if current_content == table_content:
+        print("✅ Environment variables documentation is up-to-date.")
+        return 0
+
+    if "--update" in sys.argv:
+        new_readme = readme_text[:start_idx] + "\n" + table_content + "\n" + readme_text[end_idx:]
+        README.write_text(new_readme)
+        print("✨ Updated README.md with latest environment variables.")
+        return 0
+    else:
+        print("❌ Environment variables documentation is out-of-date!")
+        print("Run `uv run scripts/check_doc_env_vars.py --update` to fix it.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,81 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(
+        "", description="OpenAI API key for the LLM wrapper. Also accepts `OPENAI_API_KEY`"
+    )
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run background jobs inline during development"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend type (`local`, `s3`, etc.)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Local directory for file storage"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum allowed upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field("file", description="Email backend to use (`file` or `smtp`)")
+    email_from: str = Field("noreply@localhost", description="Default sender address for emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Local directory for file-based email outbox"
+    )
+    smtp_host: str = Field("", description="SMTP server hostname")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP server username")
+    smtp_password: str = Field("", description="SMTP server password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(False, description="Use SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode (restricts certain actions)")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 What: Generate the Environment Variables table in README.md from the `pydantic-settings` model.
- 🎯 Why: Prevents documentation drift between code default configs/variable names and user-facing docs.
- 🧪 Verification: Validated with `uv run --locked scripts/check_doc_env_vars.py`.
- 🔒 Drift Prevention: Added `check_doc_env_vars.py` to the backend CI job.
- 🗺️ Evidence: Used `src/h4ckath0n/config.py` as the source of truth.

---
*PR created automatically by Jules for task [8400386641868509624](https://jules.google.com/task/8400386641868509624) started by @ToolchainLab*