### PR TITLE
⚡ Bolt: Use db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,11 +148,11 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        return session.execute(stmt).scalars().first()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Refactored primary key entity lookups in `passkeys/service.py` and `cli.py` to use SQLAlchemy's `db.get()` / `session.get()` instead of `select(Model).where(Model.id == ...)`.

🎯 Why: Querying full ORM objects manually by ID forces SQLAlchemy to execute a DB query and hydrate the model every time. `db.get()` checks the Session's Identity Map cache first. In high-frequency operations, skipping unneeded network roundtrips and hydration overhead improves throughput.

📊 Impact: Direct primary key queries are slightly faster and reduce DB load since identity-map-cached objects skip the query altogether.

🔬 Measurement: Verified the code behaves identically via unit tests (`uv run pytest`) and by reviewing the generated log outputs; both paths resolve identical users correctly.

---
*PR created automatically by Jules for task [12625451181424976834](https://jules.google.com/task/12625451181424976834) started by @ToolchainLab*