### PR TITLE
🎨 Palette: Add Enter-to-submit to AI Chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - AI Chat Input Interaction
+**Learning:** AI chat textareas without Enter-to-submit feel broken to users used to standard messaging apps. Failing to disable the input during streaming allows accidental prompt mangling. Absolute-positioned hint overlays need matching bottom padding on the textarea (pb-8) to prevent text overlap.
+**Action:** Always implement Enter-to-submit, disable the textarea during active streaming, and use pb-8 padding for <kbd> overlay hints in chat interfaces.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,24 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey && !aiStreaming && aiPrompt.trim()) {
+                    e.preventDefault();
+                    void handleAiStream();
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-3 right-3 text-xs text-text-muted pointer-events-none select-none">
+                <kbd className="font-sans px-1.5 py-0.5 bg-surface-alt rounded border border-border">Enter</kbd> to send
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added Enter-to-submit functionality to the AI chat textarea, disabled the input during streaming, and added an absolutely-positioned `<kbd>Enter</kbd>` hint for better UX.
🎯 Why: Standard messaging applications universally support Enter-to-submit; requiring a button click is high friction. Disabling the input during active streaming prevents users from accidentally mangling the prompt state while waiting for the LLM. 
📸 Before/After: Before: Plain textarea, submit only via button click. After: Textarea with visual "Enter to send" hint, bottom padding (pb-8) to prevent overlap, and disabled state during processing.
♿ Accessibility: Ensures the disabled state correctly reflects the streaming status and includes appropriate padding to maintain readable text.

---
*PR created automatically by Jules for task [13909189742238592314](https://jules.google.com/task/13909189742238592314) started by @ToolchainLab*