### PR TITLE
🧭 Atlas: enforce environment variable documentation drift prevention

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-04-10 - Config variable documentation drift
+**Learning:** The repo had ~16 undocumented environment variables (e.g. storage, email, redis settings) because the README table was hand-written and easily forgotten when new fields were added to `Settings`.
+**Action:** Used `pydantic.Field` descriptions on the `Settings` model as the single source of truth, and generated the markdown table in the README inside `<!-- BEGIN ENV VARS -->` markers using a drift-prevention script.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | `empty` | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | `empty` | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -174,7 +175,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | `empty` | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | `empty` | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use (e.g. local or s3) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory path for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the application for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use: "file" or "smtp" |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default From address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to store emails when using file backend |
+| `H4CKATH0N_SMTP_HOST` | `empty` | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | `empty` | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | `empty` | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that environment variables are documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py [--update]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def get_settings_table() -> str:
+    from h4ckath0n.config import Settings
+
+    rows = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for name, field in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+        if name == "openai_api_key":
+            rows.append(f"| `OPENAI_API_KEY` | empty | {field.description or ''} |")
+
+        default_val = (
+            "empty"
+            if field.default == ""
+            else (
+                "[]"
+                if getattr(field, "default_factory", None)
+                else str(field.default).lower()
+                if isinstance(field.default, bool)
+                else str(field.default)
+            )
+        )
+
+        rows.append(f"| `{var_name}` | `{default_val}` | {field.description or ''} |")
+
+    return "\n".join(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    readme_path = repo_root / "README.md"
+
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    start_marker = "<!-- BEGIN ENV VARS -->"
+    end_marker = "<!-- END ENV VARS -->"
+
+    pattern = re.compile(rf"{start_marker}.*?{end_marker}", re.DOTALL)
+
+    if not pattern.search(readme_text):
+        print("❌ Could not find ENV VARS markers in README.md")
+        return 1
+
+    new_table = get_settings_table()
+    replacement = f"{start_marker}\n{new_table}\n{end_marker}"
+
+    if args.update:
+        new_text = pattern.sub(replacement, readme_text)
+        if new_text != readme_text:
+            readme_path.write_text(new_text, encoding="utf-8")
+            print("✅ Updated README.md with latest environment variables")
+        else:
+            print("✅ README.md is already up to date")
+        return 0
+
+    current_match = pattern.search(readme_text)
+    if current_match and current_match.group(0) != replacement:
+        print("❌ Environment variables in README.md are out of sync.")
+        print("Run `uv run scripts/check_doc_env_vars.py --update` to fix.")
+        return 1
+
+    print("✅ Environment variables in README.md are up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,82 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run background jobs inline during development"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend to use (e.g. local or s3)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory path for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum allowed upload size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the application for email links"
+    )
+    email_backend: str = Field("file", description='Email backend to use: "file" or "smtp"')
+    email_from: str = Field(
+        "noreply@localhost", description="Default From address for outbound emails"
+    )
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox",
+        description="Directory to store emails when using file backend",
+    )
+    smtp_host: str = Field("", description="SMTP server hostname")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP authentication username")
+    smtp_password: str = Field("", description="SMTP authentication password")
+    smtp_starttls: bool = Field(True, description="Enable STARTTLS for SMTP connections")
+    smtp_ssl: bool = Field(False, description="Use implicit SSL/TLS for SMTP connections")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 What: Replaced the hand-written environment variables table with a generated section using Pydantic Field descriptions.
- 🎯 Why: Solves a documentation drift issue where over a dozen environment variables (storage, email, redis) were missing from the README.
- 🧪 Verification: Locally run `uv run scripts/check_doc_env_vars.py` and `uv run pytest`.
- 🔒 Drift Prevention: Added `scripts/check_doc_env_vars.py` which will fail in CI if the README table is out of sync with `Settings`.
- 🗺️ Evidence: `src/h4ckath0n/config.py` is the source of truth for configuration.

---
*PR created automatically by Jules for task [5407698024468505088](https://jules.google.com/task/5407698024468505088) started by @ToolchainLab*