### PR TITLE
∴ Vector: [Extract and centralize scopes parsing and normalization logic]

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Centralize String Normalization
+**Learning:** In projects that store comma-separated lists in database columns (like roles or scopes), scattered `split(",")` and `strip()` logic often leads to subtle inconsistencies in filtering out empty strings and preserving list order. Python's `dict.fromkeys()` is a fast, idiomatic way to preserve order when deduplicating these parsed sequences compared to standard `set()`.
+**Action:** When extracting data normalization rules (like cleaning up string sequences), move them into a shared, pure-functional utility file rather than repeating the parsing/formatting ad-hoc at the DB interface or API layer.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -83,10 +84,10 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[str] = set(filter(None, map(str.strip, scopes)))
+    needed: set[str] = set(parse_scopes(",".join(scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a deduplicated list, preserving order."""
+    if not raw:
+        return []
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of scopes into a normalized comma-separated string."""
+    parts = filter(None, map(str.strip, scopes))
+    return ",".join(dict.fromkeys(parts))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,10 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                existing.append(scope)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +474,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +503,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_auth_scopes.py
+++ b/tests/test_auth_scopes.py
@@ -1,0 +1,15 @@
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+
+def test_parse_scopes():
+    assert parse_scopes("") == []
+    assert parse_scopes("admin") == ["admin"]
+    assert parse_scopes("admin, demo") == ["admin", "demo"]
+    assert parse_scopes("admin, , test, admin") == ["admin", "test"]
+
+
+def test_format_scopes():
+    assert format_scopes([]) == ""
+    assert format_scopes(["admin"]) == "admin"
+    assert format_scopes(["admin", "demo", ""]) == "admin,demo"
+    assert format_scopes(["admin", " test ", "admin"]) == "admin,test"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -125,28 +124,6 @@ class TestAlembicUrlNormalization:
         exit_code = cli_module._cmd_db_migrate_current(args)
         assert exit_code == 0
         assert make_url(captured["sqlalchemy.url"]) == make_url("sqlite:///./test.db")
-
-
-# ---------------------------------------------------------------------------
-# Scopes normalization
-# ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Extract shared scope logic into `src/h4ckath0n/auth/scopes.py`.
- 🎯 Why: To deduplicate scope parsing and formatting scattered across the CLI, auth dependencies, and session endpoints.
- 🧠 Design: Introduce small pure functional helpers (`parse_scopes`, `format_scopes`) for converting between DB representations and lists.
- λ FP Angle: Reduces side-effects, improves composability, centralizes normalisation into pure helpers, maintaining immutability context.
- ✅ Verification: Run `uv run pytest`, `uv run ruff check .`, `uv run ruff format .`.
- 🧪 Edge cases: Tested empty lists/strings, extra spacing, duplicates.
- ⚠️ Risk: Low, modifies logic flow safely and preserves behavior.

---
*PR created automatically by Jules for task [1329008055936308853](https://jules.google.com/task/1329008055936308853) started by @ToolchainLab*