### PR TITLE
⚡ Bolt: [performance improvement] Use db.get() for single entity primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize Identity Map cache
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize Identity Map cache
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize Identity Map cache
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup to utilize Identity Map cache
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What: Replaced `await db.execute(select(Model).filter(Model.id == pk))` calls with `await db.get(Model, pk)` in `src/h4ckath0n/auth/passkeys/service.py` for WebAuthnChallenge, User, and WebAuthnCredential lookups.
🎯 Why: Using `db.get()` is more performant as it checks the SQLAlchemy Identity Map cache first, potentially avoiding database roundtrips and parsing/hydration overhead for objects that are already cached in the active session.
📊 Impact: Reduces latency in critical authentication paths (registration, login, and passkey management) by eliminating redundant DB queries and object hydration overhead.
🔬 Measurement: Verify tests run completely and check DB queries profile before/after changes when authenticating to observe caching benefits.

---
*PR created automatically by Jules for task [1457212013961624271](https://jules.google.com/task/1457212013961624271) started by @ToolchainLab*