### PR TITLE
🎨 Palette: Add Enter-to-submit and loading state to AI chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Add Enter-to-submit keyboard interactions in textareas
+**Learning:** When implementing Enter-to-submit keyboard interactions in textareas (like AI prompts), it's important to disable the textarea during async operations to prevent prompt mangling and provide adequate bottom padding (e.g., pb-8) for absolute-positioned <kbd> hints to prevent text overlap.
+**Action:** Apply the `disabled` attribute directly to the textarea and use padding to make room for absolute-positioned visual hints.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,29 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (!aiStreaming && aiPrompt.trim()) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+              />
+              <div className="absolute bottom-2 right-2 pointer-events-none text-xs text-text-muted">
+                <kbd className="hidden sm:inline-block rounded border border-border bg-surface-alt px-1.5 py-0.5 font-sans text-[10px] font-medium text-text-muted">
+                  Enter
+                </kbd>
+                <span className="hidden sm:inline-block ml-1">to send</span>
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What:
Added the ability to submit the AI prompt by pressing `Enter` (without Shift) in the Dashboard's AI Chat textarea. A visual hint (`<kbd>Enter</kbd> to send`) was added to the bottom right of the textarea. The textarea is also now disabled while the AI stream is active to prevent prompt mangling.

🎯 Why:
Users expect modern chat interfaces to submit on `Enter` by default, rather than requiring a mouse click on a "Send" button. Disabling the input while streaming provides immediate visual feedback that the application is busy and prevents unintended inputs.

📸 Before/After:
Before: The text area allowed infinite newlines on `Enter` and required a manual click of the "Send" button.
After: The text area submits on `Enter` (unless `Shift+Enter` is pressed), displays a visual shortcut hint, and disables itself when `aiStreaming` is active.

♿ Accessibility:
The `<kbd>` hint provides a clear visual cue for keyboard users. The `disabled` state handles its own visual styling (opacity) and inherently manages focus state, preventing form submission spam.

---
*PR created automatically by Jules for task [3336175520845211978](https://jules.google.com/task/3336175520845211978) started by @ToolchainLab*