### PR TITLE
🧭 Atlas: Auto-generate environment variable docs from config

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2025-04-11 - Generate environment variable docs from config
+**Learning:** Configuration docs (like env vars) manually written in READMEs frequently drift from the actual source code. The `Settings` model in pydantic can store descriptions, which we can parse dynamically to auto-generate the README env var table.
+**Action:** Add `Field(..., description="...")` to the `Settings` model, create a verification script (`check_doc_env_vars.py`), and use markdown markers in `README.md` to embed the auto-generated documentation. Add this verification step to the project's quality checks.

--- a/README.md
+++ b/README.md
@@ -159,22 +159,40 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
 | `H4CKATH0N_PASSWORD_AUTH_ENABLED` | `false` | Enable password routes when the extra is installed |
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
-| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
+| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | empty | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY` or `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory path |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local outbox directory for file backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (read-only actions, etc.) |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import sys
+
+from h4ckath0n.config import Settings
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true")
+    args = parser.parse_args()
+
+    table_lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for name, field in Settings.model_fields.items():
+        if name == "model_config":
+            continue
+
+        env_var = f"H4CKATH0N_{name.upper()}"
+        if name == "openai_api_key":
+            env_var = "`OPENAI_API_KEY` or `H4CKATH0N_OPENAI_API_KEY`"
+        else:
+            env_var = f"`{env_var}`"
+
+        default = field.default_factory() if field.default_factory is not None else field.default
+
+        if default == "" or default == []:
+            default_str = "empty"
+        elif isinstance(default, bool):
+            default_str = f"`{'true' if default else 'false'}`"
+        elif name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+        else:
+            default_str = f"`{default}`"
+
+        desc = field.description or ""
+        table_lines.append(f"| {env_var} | {default_str} | {desc} |")
+
+    table_str = "\n".join(table_lines)
+    full_str = f"<!-- BEGIN ENV VARS -->\n{table_str}\n<!-- END ENV VARS -->"
+
+    with open("README.md") as f:
+        readme = f.read()
+
+    pattern = re.compile(r"<!-- BEGIN ENV VARS -->.*?<!-- END ENV VARS -->", re.DOTALL)
+
+    if "<!-- BEGIN ENV VARS -->" not in readme:
+        print("Error: Markers not found in README.md")
+        sys.exit(1)
+
+    current_match = pattern.search(readme)
+    if current_match.group(0) == full_str:
+        print("✅ Environment variables documentation is up to date.")
+        sys.exit(0)
+
+    if args.update:
+        new_readme = pattern.sub(full_str, readme)
+        with open("README.md", "w") as f:
+            f.write(new_readme)
+        print("✅ README.md updated with environment variables.")
+        sys.exit(0)
+    else:
+        print("❌ Environment variables documentation is out of date. Run with --update.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,73 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL")
+    jobs_inline_in_dev: bool = Field(True, description="Run jobs inline during development")
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field("./.h4ckath0n_storage", description="Local storage directory path")
+    max_upload_bytes: int = Field(50 * 1024 * 1024, description="Maximum upload size in bytes")
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field("file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field("noreply@localhost", description="Default sender address")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Local outbox directory for file backend"
+    )
+    smtp_host: str = Field("", description="SMTP host")
+    smtp_port: int = Field(587, description="SMTP port")
+    smtp_username: str = Field("", description="SMTP username")
+    smtp_password: str = Field("", description="SMTP password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Use SSL for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode (read-only actions, etc.)")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
* 💡 What: Generate the `README.md` environment variable table dynamically from the `src/h4ckath0n/config.py` Pydantic `Settings` model.
* 🎯 Why: Hand-written environment variables often drift out of sync with the actual runtime configuration.
* 🧪 Verification: Run `uv run --locked scripts/check_doc_env_vars.py`
* 🔒 Drift Prevention: `scripts/check_doc_env_vars.py` added as a script to verify sync.
* 🗺️ Evidence: `src/h4ckath0n/config.py` and `scripts/check_doc_env_vars.py`

---
*PR created automatically by Jules for task [11121319583278699916](https://jules.google.com/task/11121319583278699916) started by @ToolchainLab*