### PR TITLE
🎨 Palette: Add Enter-to-submit UX and disabled state to AI chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-12 - Enter-to-submit and Async Textarea States
+**Learning:** When implementing Enter-to-submit in chat textareas, the textarea must be disabled during async operations (like streaming) to prevent users from mangling the active stream. Also, adding absolute-positioned `<kbd>` hints requires adequate bottom padding (`pb-8`) on the textarea to prevent text from overlapping the hint.
+**Action:** Always apply the `disabled` attribute directly to the textarea and ensure `pb-8` is added when placing bottom-aligned absolute elements inside textarea containers.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,28 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (!aiStreaming && aiPrompt.trim()) {
+                      void handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded-xl border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-3 right-3 flex items-center pointer-events-none">
+                <kbd className="hidden sm:inline-flex items-center gap-1 rounded border border-border bg-surface-alt px-1.5 text-[10px] font-sans font-medium text-text-muted">
+                  <span>↵</span> Enter
+                </kbd>
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added Enter-to-submit keyboard functionality to the AI Chat textarea in the Dashboard, while maintaining `Shift+Enter` for newlines. During async streaming, the textarea is now visually and functionally disabled. Additionally, an absolute-positioned `<kbd>` hint for "Enter" was added to the bottom right.

🎯 Why: To dramatically improve the intuitiveness of the chat interface. Most users expect chat inputs to submit on `Enter`. Disabling the textarea during active streaming prevents users from accidentally mangling the prompt or the stream state while an operation is in-flight. The `<kbd>` hint provides discoverability for desktop users.

📸 Before/After: (See Playwright generated videos and screenshots)

♿ Accessibility: The disabled state on the textarea during streaming prevents keyboard and screen-reader users from interacting with the input while the backend is processing, clearly communicating the busy state. Also added proper keyboard event handling that correctly `e.preventDefault()`s to prevent form submission side-effects.

---
*PR created automatically by Jules for task [13120903758334168828](https://jules.google.com/task/13120903758334168828) started by @ToolchainLab*