### PR TITLE
🧭 Atlas: Auto-generate and verify environment variables in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2025-04-12 - Prevented README.md environment variables drift
+
+**Learning:** The configuration table in README.md is hand-written, which frequently drifts when new `Settings` variables are added or changed in `src/h4ckath0n/config.py`.
+**Action:** Wrote `scripts/check_doc_env_vars.py` to parse Pydantic `Settings` and generate a markdown table of environment variables, with automated validation to enforce parity between the README and configuration fields. Added to `.github/workflows/ci.yml` as a backend CI gate.

--- a/README.md
+++ b/README.md
@@ -159,22 +159,40 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
 | `H4CKATH0N_PASSWORD_AUTH_ENABLED` | `false` | Enable password routes when the extra is installed |
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
-| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
+| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | *Dynamic* | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend, file or smtp |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | From email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Email outbox directory |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/README.patch
+++ b/README.patch
@@ -1,0 +1,27 @@
+--- README.md
++++ README.md
+@@ -141,13 +141,16 @@
+
+ All settings use the `H4CKATH0N_` prefix unless noted.
+
+-| Variable | Default | Description |
+-|---|---|---|
+-| `H4CKATH0N_ENV` | `development` | `development` or `production` |
+-| `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
+-| `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
+-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
+-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+-| `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
+-| `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
+-| `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
+-| `H4CKATH0N_PASSWORD_AUTH_ENABLED` | `false` | Enable password routes when the extra is installed |
+-| `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
+-| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
+-| `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
+-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
++<!-- BEGIN ENV VARS -->
++<!-- END ENV VARS -->
+
+ In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
+ warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that environment variables are documented."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+
+def generate_env_table() -> str:
+    """Generate markdown table of environment variables from Settings."""
+    from h4ckath0n.config import Settings
+
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for name, field in Settings.model_fields.items():
+        # Handle prefix
+        prefix = Settings.model_config.get("env_prefix", "")
+        env_var = f"{prefix}{name}".upper()
+
+        # Handle default
+        if field.is_required():
+            default_str = "*Required*"
+        elif field.default_factory is not None:
+            default_str = "*Dynamic*"
+        else:
+            default_val = field.default
+            if default_val == "":
+                default_str = "empty"
+            elif default_val == []:
+                default_str = "`[]`"
+            elif isinstance(default_val, bool):
+                default_str = f"`{'true' if default_val else 'false'}`"
+            else:
+                default_str = f"`{default_val}`"
+
+        # Handle description
+        description = field.description or ""
+
+        lines.append(f"| `{env_var}` | {default_str} | {description} |")
+
+    return "\n".join(lines)
+
+
+def update_readme(new_table: str) -> bool:
+    """Update README.md with the new table. Returns True if changed."""
+    text = README.read_text()
+
+    start_idx = text.find(START_MARKER)
+    end_idx = text.find(END_MARKER)
+
+    if start_idx == -1 or end_idx == -1:
+        print(f"❌ Markers {START_MARKER} or {END_MARKER} not found in README.md")
+        sys.exit(1)
+
+    before = text[: start_idx + len(START_MARKER)]
+    after = text[end_idx:]
+
+    new_text = f"{before}\n{new_table}\n{after}"
+
+    if new_text != text:
+        README.write_text(new_text)
+        return True
+    return False
+
+
+def check_readme(new_table: str) -> bool:
+    """Check if README.md has the current table."""
+    text = README.read_text()
+
+    start_idx = text.find(START_MARKER)
+    end_idx = text.find(END_MARKER)
+
+    if start_idx == -1 or end_idx == -1:
+        print(f"❌ Markers {START_MARKER} or {END_MARKER} not found in README.md")
+        return False
+
+    current_table = text[start_idx + len(START_MARKER) : end_idx].strip()
+
+    if current_table != new_table.strip():
+        print("❌ README.md environment variables table is out of date.")
+        print("Run with --update to fix.")
+        return False
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true", help="Update README.md inline")
+    args = parser.parse_args()
+
+    new_table = generate_env_table()
+
+    if args.update:
+        if update_readme(new_table):
+            print("✅ Updated README.md with current environment variables.")
+        else:
+            print("✅ README.md is already up to date.")
+        return 0
+    else:
+        if check_readme(new_table):
+            print("✅ README.md environment variables table is up to date.")
+            return 0
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,69 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(True, description="Run jobs inline in development")
+    jobs_default_queue: str = Field("default", description="Default queue name")
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend")
+    storage_dir: str = Field("./.h4ckath0n_storage", description="Storage directory")
+    max_upload_bytes: int = Field(50 * 1024 * 1024, description="Max upload size in bytes")
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field("http://localhost:5173", description="Base URL of the application")
+    email_backend: str = Field("file", description="Email backend, file or smtp")
+    email_from: str = Field("noreply@localhost", description="From email address")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Email outbox directory"
+    )
+    smtp_host: str = Field("", description="SMTP host")
+    smtp_port: int = Field(587, description="SMTP port")
+    smtp_username: str = Field("", description="SMTP username")
+    smtp_password: str = Field("", description="SMTP password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS")
+    smtp_ssl: bool = Field(False, description="Use SSL")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 **What**: Added script to sync the README's Configuration environment variable table directly from the Pydantic `Settings` in `src/h4ckath0n/config.py`.
- 🎯 **Why**: To prevent documentation drift and ensure that configurations, their defaults, and parameters aren't forgotten in the README.
- 🧪 **Verification**: Ran `uv run --locked ruff format --check .`, `uv run --locked ruff check .`, `uv run --locked pytest -v`, and `uv run scripts/check_doc_env_vars.py` locally.
- 🔒 **Drift Prevention**: The `scripts/check_doc_env_vars.py` script automatically verifies and generates the table inside `<!-- BEGIN ENV VARS -->` and `<!-- END ENV VARS -->` tags. Additionally, `ci.yml` executes it during backend build gates.
- 🗺️ **Evidence**: `src/h4ckath0n/config.py`, `scripts/check_doc_env_vars.py`, `README.md`, `.github/workflows/ci.yml`

---
*PR created automatically by Jules for task [5521373580424711815](https://jules.google.com/task/5521373580424711815) started by @ToolchainLab*