### PR TITLE
∷ Vector: Centralize database scope parsing logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-04-13 - Centralize Scope Parsing
+**Learning:** Parsing comma-separated lists to and from database text columns was being repeatedly re-implemented across different modules, leading to subtle style variations and potential drift.
+**Action:** Extracted pure, functional helpers into `h4ckath0n.auth.scopes` for parsing and formatting. These helpers are tested directly, ensuring consistent deduplication, whitespace stripping, and order preservation across the codebase.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -86,7 +87,7 @@ def require_scopes(*scopes: str) -> Any:
     needed: set[str] = set(filter(None, map(str.strip, scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,17 @@
+"""Utilities for parsing and formatting comma-separated scope strings."""
+
+from collections.abc import Iterable
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into an ordered, deduplicated list."""
+    if not raw:
+        return []
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of scopes into a normalized comma-separated string."""
+    parts = filter(None, map(str.strip, scopes))
+    return ",".join(dict.fromkeys(parts))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,11 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                if scope.strip() not in existing:
+                    existing.append(scope.strip())
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +475,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +504,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_auth_scopes.py
+++ b/tests/test_auth_scopes.py
@@ -1,0 +1,26 @@
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+
+def test_parse_scopes_empty():
+    assert parse_scopes("") == []
+    assert parse_scopes("   ") == []
+
+
+def test_parse_scopes_deduplicates():
+    assert parse_scopes("foo, bar, foo") == ["foo", "bar"]
+
+
+def test_parse_scopes_trims():
+    assert parse_scopes("  foo  ,  bar  ") == ["foo", "bar"]
+
+
+def test_parse_scopes_empty_items():
+    assert parse_scopes("foo,,bar, ,baz") == ["foo", "bar", "baz"]
+
+
+def test_format_scopes_empty():
+    assert format_scopes([]) == ""
+
+
+def test_format_scopes_trims_and_dedupes():
+    assert format_scopes([" foo ", "bar", "foo", ""]) == "foo,bar"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,11 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert format_scopes(parse_scopes("a,b,c")) == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert format_scopes(parse_scopes("a,b,a")) == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert format_scopes(parse_scopes(" a , b , c ")) == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert format_scopes(parse_scopes("a,,b,,")) == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert format_scopes(parse_scopes("")) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Extracted comma-separated scope parsing logic into centralized, pure helpers `parse_scopes` and `format_scopes`.
- 🎯 Why: Scope parsing and normalization was scattered across `dependencies.py`, `session_router.py`, and `cli.py`, leading to duplication.
- 🧠 Design: By centralizing into `h4ckath0n.auth.scopes`, we establish a single source of truth that is fully tested.
- λ FP Angle: Transitioned away from localized loops and sets to deterministic, functional `dict.fromkeys` and `filter/map` pipelines.
- ✅ Verification: Added unit tests `tests/test_auth_scopes.py` and ran standard linting and test suites.
- 🧪 Edge cases: Explicit tests added for whitespace stripping, empty values within lists, and deduplication while preserving order.
- ⚠️ Risk: Very low. Existing functionality was maintained by retaining deterministic ordering and duplicate elimination.

---
*PR created automatically by Jules for task [915161669942999356](https://jules.google.com/task/915161669942999356) started by @ToolchainLab*