### PR TITLE
⚡ Bolt: Use db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get for primary key lookup to hit the Identity Map cache first
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get for primary key lookup to hit the Identity Map cache first
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
- 💡 What: Replaced `db.execute(select(...).filter(id == ...))` with `db.get(...)` in `src/h4ckath0n/auth/passkeys/service.py` for fetching objects by primary key.
- 🎯 Why: `db.get()` takes advantage of the SQLAlchemy Identity Map cache, avoiding a database roundtrip and hydration overhead if the object is already loaded in the active session.
- 📊 Impact: Prevents unnecessary database queries and improves lookup performance when objects are already in session memory.
- 🔬 Measurement: The speed of cache hits without the network roundtrip is measurably faster than always executing a query.

---
*PR created automatically by Jules for task [6176704682805007069](https://jules.google.com/task/6176704682805007069) started by @ToolchainLab*