### PR TITLE
🎨 Palette: Add enter-to-submit and shortcut hint in AI Chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-13 - Enter-to-Submit in Chat Interfaces
+**Learning:** In chat-like interfaces (such as AI prompts), users expect to hit Enter to submit rather than clicking a button. However, during async streaming, if the textarea remains enabled, users might continue typing and mangle the prompt or accidentally trigger overlapping submissions. Absolute-positioned keyboard shortcuts can overlap user text if bottom padding is not increased.
+**Action:** Always apply the `disabled` attribute directly to the textarea during async operations (like streaming). When adding an absolute-positioned `<kbd>` hint, add adequate bottom padding (e.g., `pb-8`) to the textarea to prevent text overlap.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,26 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (!aiStreaming && aiPrompt.trim()) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded-xl border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-2 right-3 pointer-events-none text-xs text-text-muted">
+                <kbd className="font-sans font-medium px-1.5 py-0.5 bg-surface-alt rounded border border-border">Enter</kbd> to send
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added Enter-to-submit support (without Shift) and a keyboard shortcut hint to the AI chat interface.
🎯 Why: To make chat interactions more intuitive and avoid forcing users to click the "Send" button repeatedly.
📸 Before/After: Visual update includes the `<kbd>` hint and `disabled` visual state.
♿ Accessibility: The textarea is now correctly disabled during stream operations to prevent prompt mangling, and visual styles correctly indicate the disabled state.

---
*PR created automatically by Jules for task [1367942407406427120](https://jules.google.com/task/1367942407406427120) started by @ToolchainLab*