### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Email Enumeration Timing Attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Prevent Email Enumeration via Timing Attack
+**Vulnerability:** The password authentication endpoint had a timing discrepancy allowing email enumeration. When a user was not found or had no password set, the endpoint returned immediately, bypassing the computationally expensive argon2 verification.
+**Learning:** Early exits before password verification functions (which are inherently slow) inadvertently reveal whether a user exists. A dummy hash verification is necessary to balance execution times. The dummy hash MUST be a structurally valid Argon2id hash string, otherwise `argon2-cffi` will throw a fast parsing error, defeating the mitigation.
+**Prevention:** Always verify a dummy hash of the password when short-circuiting an authentication flow due to a missing user or unset password. Ensure the dummy hash is properly formatted for the hashing algorithm.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -74,10 +74,14 @@ async def register_user(
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
+    # 🛡️ Sentinel: Valid dummy hash to mitigate timing attacks on invalid users.
+    dummy_hash = (
+        "$argon2id$v=19$m=65536,t=3,p=4$FkMog8E7An24UxlsIrUJSw$"
+        "UUj5ewvkp4zcmQtLrGX6RDtlv6CdZ5k3msYRiSQX+4U"
+    )
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
-        return None
-    if not user.password_hash:
+    if (user := result.scalars().first()) is None or not user.password_hash:
+        verify_password(password, dummy_hash)
         return None
     if not verify_password(password, user.password_hash):
         return None


### PR DESCRIPTION
- 🚨 Severity: MEDIUM
- 💡 Vulnerability: The authentication endpoint could be subjected to an email enumeration timing attack due to early exit on nonexistent users or users without a password set. The `verify_password` call (which is computationally expensive) was skipped, causing a measurable time difference compared to valid logins.
- 🎯 Impact: An attacker could enumerate registered emails in the system by measuring the response time of the login endpoint.
- 🔧 Fix: Verify a structurally valid dummy Argon2 hash using `verify_password` when the user doesn't exist or hasn't set a password to balance the response times across valid and invalid inputs.
- ✅ Verification: Added the dummy hash validation and visually verified timing differences using local scripts (and deleted the test scripts before committing). Ran the full suite with `uv run --locked pytest -v` to ensure existing auth logic remains unbroken. All 188 tests passed.

---
*PR created automatically by Jules for task [11106829320442500273](https://jules.google.com/task/11106829320442500273) started by @ToolchainLab*