### PR TITLE
🎨 Palette: Enter-to-submit for AI Chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-14 - Chat Textarea Enhancements
+**Learning:** Users naturally expect chat textareas to submit via the Enter key. Adding an absolute-positioned hint requires extra padding on the textarea to avoid text overlap, and the textarea should be disabled during streaming to prevent prompt mangling.
+**Action:** When implementing chat interfaces, always add `onKeyDown` for Enter-to-submit, disable the input during async operations, and ensure adequate padding (e.g., `pb-8`) for hint elements.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,28 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (aiPrompt.trim()) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-2 right-2 flex items-center gap-2">
+                <kbd className="hidden sm:inline-block px-1.5 py-0.5 text-[10px] font-medium text-text-muted bg-surface-alt border border-border rounded opacity-70">
+                  Enter to send
+                 </kbd>
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
- 💡 What: Added Enter-to-submit functionality, disabled states during streaming, and a keyboard hint to the AI chat textarea.
- 🎯 Why: Users expect standard chat interfaces to submit via Enter, and disabling the input during streaming prevents prompt mangling.
- 📸 Before/After: Added `<kbd>` visual hint.
- ♿ Accessibility: Added visual hint for keyboard interactions and proper disabled attributes for screen readers.

---
*PR created automatically by Jules for task [3607942082167988572](https://jules.google.com/task/3607942082167988572) started by @ToolchainLab*