### PR TITLE
🧭 Atlas: Replace hand-written env var lists with generated list from config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-04-14 - Replace hand-written env var lists with generated list from config loader
+**Learning:** Pydantic model configurations containing descriptions are an excellent source of truth for generating accurate documentation tables and avoiding manual drift in `README.md`.
+**Action:** Instead of hard-coding environment variables manually, write a script to generate the markdown from `model_fields` and run it during CI.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,26 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default background job queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max upload bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | App base URL |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Email from address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Email outbox directory |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | SMTP STARTTLS |
+| `H4CKATH0N_SMTP_SSL` | `false` | SMTP SSL |
+| `H4CKATH0N_DEMO_MODE` | `false` | Demo mode |
+| `OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+<!-- ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that environment variables in README.md match config.py.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py [--update]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+MARKER_START = "<!-- ENV_VARS_START -->\n"
+MARKER_END = "<!-- ENV_VARS_END -->\n"
+
+
+def generate_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+        default = field.default
+        if default == "":
+            default_str = "empty"
+        elif default == []:
+            default_str = "`[]`"
+        elif isinstance(default, bool):
+            default_str = f"`{str(default).lower()}`"
+        elif isinstance(default, str) and "sqlite" in default:
+            default_str = f"`{default}`"
+        elif default == "localhost":
+            default_str = "`localhost` in development"
+        elif default == "http://localhost:8000":
+            default_str = "`http://localhost:8000` in development"
+        elif isinstance(default, str):
+            default_str = f"`{default}`"
+        else:
+            default_str = f"`{default}`"
+        desc = field.description or ""
+        lines.append(f"| `{var_name}` | {default_str} | {desc} |")
+    # also add the alternate openai one manually as it's not a field
+    lines.append("| `OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true")
+    args = parser.parse_args()
+
+    readme_text = README.read_text()
+    if MARKER_START not in readme_text or MARKER_END not in readme_text:
+        print("❌ Markers not found in README.md.")
+        return 1
+
+    start_idx = readme_text.index(MARKER_START) + len(MARKER_START)
+    end_idx = readme_text.index(MARKER_END)
+
+    current_table = readme_text[start_idx:end_idx]
+    expected_table = generate_table()
+
+    if current_table == expected_table:
+        print("✅ Environment variables in README.md are up to date.")
+        return 0
+
+    if args.update:
+        new_text = readme_text[:start_idx] + expected_table + readme_text[end_idx:]
+        README.write_text(new_text)
+        print("✅ Updated environment variables in README.md.")
+        return 0
+    else:
+        print("❌ Environment variables in README.md are out of date.")
+        print("Run 'uv run scripts/check_doc_env_vars.py --update' to fix.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,68 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL")
+    jobs_inline_in_dev: bool = Field(True, description="Run background jobs inline in development")
+    jobs_default_queue: str = Field("default", description="Default background job queue name")
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend")
+    storage_dir: str = Field("./.h4ckath0n_storage", description="Storage directory")
+    max_upload_bytes: int = Field(50 * 1024 * 1024, description="Max upload bytes")
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field("http://localhost:5173", description="App base URL")
+    email_backend: str = Field("file", description="Email backend")
+    email_from: str = Field("noreply@localhost", description="Email from address")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Email outbox directory"
+    )
+    smtp_host: str = Field("", description="SMTP host")
+    smtp_port: int = Field(587, description="SMTP port")
+    smtp_username: str = Field("", description="SMTP username")
+    smtp_password: str = Field("", description="SMTP password")
+    smtp_starttls: bool = Field(True, description="SMTP STARTTLS")
+    smtp_ssl: bool = Field(False, description="SMTP SSL")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Demo mode")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 What: Replaced manually curated environment variables table with a dynamically generated list from `config.py`.
- 🎯 Why: To prevent drift between available environment variables and documentation.
- 🧪 Verification: Validated locally with `pytest`, `ruff`, and `uv run scripts/check_doc_env_vars.py`.
- 🔒 Drift Prevention: Added `scripts/check_doc_env_vars.py` and a corresponding step to the CI pipeline to catch undocumented configurations.
- 🗺️ Evidence: Used `src/h4ckath0n/config.py` as the source of truth for settings.

---
*PR created automatically by Jules for task [2059930571517498767](https://jules.google.com/task/2059930571517498767) started by @ToolchainLab*