### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
💡 What: Optimized primary key lookups using `db.get()` for `WebAuthnChallenge` in `_get_valid_flow` and `User` in `finish_registration`.
🎯 Why: To avoid ORM hydration overhead and utilize SQLAlchemy identity map caching on frequently accessed paths (authentication and registration).
📊 Impact: Reduces DB roundtrips and object instantiation overhead for single-record lookups by primary key, especially if the object is already in the cache.
🔬 Measurement: Run the full test suite (`uv run --locked pytest -v`) to ensure no regressions in passkey flows, or benchmark DB query frequency under load.

---
*PR created automatically by Jules for task [654071840917948365](https://jules.google.com/task/654071840917948365) started by @ToolchainLab*