### PR TITLE
🎨 Palette: Add Enter-to-submit to AI chat textarea

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-15 - Enter to Submit in AI prompt textareas
+ **Learning:** In chat interfaces, like the AI stream panel in Dashboard.tsx, users expect to be able to submit their prompt by pressing 'Enter' while inside the textarea, but they also might want to type multiple lines (Shift+Enter). We need to handle this keydown interaction, check if the prompt is not empty, and disable the textarea during stream parsing.
+ **Action:** Add a custom onKeyDown handler to AI prompt textareas that triggers submission on Enter (without Shift) and disables the input while streaming to prevent prompt mangling.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,26 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (aiPrompt.trim()) {
+                      void handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+              />
+              <div className="absolute bottom-2 right-3 pointer-events-none text-xs text-text-muted opacity-70">
+                <kbd className="font-sans">Enter</kbd> to send, <kbd className="font-sans">Shift + Enter</kbd> for new line
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
🎨 Palette: Add Enter-to-submit to AI chat textarea

💡 What: Added Enter-to-submit support in the AI chat textarea with a visual keyboard hint.
🎯 Why: Users expect standard chat input behavior where Enter submits and Shift+Enter creates a newline.
📸 Before/After: Visual kbd hint added to the bottom right of the textarea.
♿ Accessibility: Textarea is disabled during streaming to prevent prompt mangling; keyboard navigation is fully preserved.

---
*PR created automatically by Jules for task [2472031738351357158](https://jules.google.com/task/2472031738351357158) started by @ToolchainLab*