### PR TITLE
⚡ Bolt: [performance improvement] Utilize `db.get()` for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,9 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # Optimize: Use db.get for primary key lookups to leverage the identity map
+    flow = await db.get(WebAuthnChallenge, flow_id)
+    if flow is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +142,9 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # Optimize: Use db.get for primary key lookups to leverage the identity map
+    user = await db.get(User, flow.user_id)
+    if user is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
💡 What: Replaced `db.execute(select(Model).filter(Model.id == id))` with `db.get(Model, id)` for WebAuthnChallenge and User lookups in `src/h4ckath0n/auth/passkeys/service.py`.
🎯 Why: Retrieving objects by primary key via an explicit `select` query bypasses the SQLAlchemy identity map, always triggering a DB query and bringing overhead from parsing and hydrating objects. `db.get()` first checks the active Session's identity map cache, avoiding DB hits and extra parsing.
📊 Impact: Expected to reduce DB query execution time for hot paths (especially device authentication checks) by avoiding roundtrips for locally cached records.
🔬 Measurement: Verify reduction in database roundtrips on authentication endpoints, testing passes successfully with `uv run --locked pytest -v`.

---
*PR created automatically by Jules for task [2288164453538889344](https://jules.google.com/task/2288164453538889344) started by @ToolchainLab*