### PR TITLE
∷ Vector: Centralize scope parsing and normalization

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,5 @@
+## 2024-04-17 - Centralize scope parsing/normalization
+
+**Learning:** Comma-separated scope string parsing is duplicated and inconsistent across `src/h4ckath0n/auth/dependencies.py`, `src/h4ckath0n/auth/session_router.py`, and `src/h4ckath0n/cli.py`. Sometimes it uses sets, sometimes list comprehensions, and sometimes `filter(None, map(str.strip, ...))`. This lack of centralization causes correctness risks around deduplication and order-preservation, and violates the repo's FP-style preferences.
+
+**Action:** Extract pure helpers `parse_scopes` and `format_scopes` in a common auth utilities file (e.g., `src/h4ckath0n/auth/scopes.py`) and update all call sites to use them to enforce deterministic order and safe handling.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -83,10 +84,10 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[str] = set(filter(None, map(str.strip, scopes)))
+    needed: set[str] = set(parse_scopes(",".join(scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,15 @@
+"""Scope parsing and normalization utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into an ordered, deduplicated list."""
+    return list(dict.fromkeys(filter(None, map(str.strip, raw.split(",")))))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of scopes into a normalized comma-separated string."""
+    return ",".join(scopes)

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,12 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                scope_stripped = scope.strip()
+                if scope_stripped and scope_stripped not in existing:
+                    existing.append(scope_stripped)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +476,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +505,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_auth_scopes.py
+++ b/tests/test_auth_scopes.py
@@ -1,0 +1,20 @@
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
+
+
+def test_parse_scopes() -> None:
+    # Standard case
+    assert parse_scopes("admin,user") == ["admin", "user"]
+    # Whitespace handling
+    assert parse_scopes(" admin ,  user  ") == ["admin", "user"]
+    # Empty string
+    assert parse_scopes("") == []
+    # Extraneous commas and spaces
+    assert parse_scopes("a,,b, c , ") == ["a", "b", "c"]
+    # Order preserving deduplication
+    assert parse_scopes("c,b,a,c,b") == ["c", "b", "a"]
+
+
+def test_format_scopes() -> None:
+    assert format_scopes(["admin", "user"]) == "admin,user"
+    assert format_scopes([]) == ""
+    assert format_scopes(["a"]) == "a"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,12 +9,12 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
 )
-from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from tests.conftest import run_cli as _run_cli
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,8 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from tests.conftest import run_cli as _run_cli
 
 # ---------------------------------------------------------------------------
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert format_scopes(parse_scopes("a,b,c")) == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert format_scopes(parse_scopes("a,b,a")) == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert format_scopes(parse_scopes(" a , b , c ")) == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert format_scopes(parse_scopes("a,,b,,")) == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert format_scopes(parse_scopes("")) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Extracted `parse_scopes` and `format_scopes` into a new `src/h4ckath0n/auth/scopes.py` and updated `cli.py`, `dependencies.py`, and `session_router.py` to use them.
- 🎯 Why: Removes duplicated string parsing logic, prevents subtle parsing bugs, and enforces deterministic scope ordering system-wide. Prior iterations used a mix of `set()`, `list comprehensions`, and `filter(None, map(...))` that had differing rules on empty strings and duplicates.
- 🧠 Design: Centralized module uses `dict.fromkeys` to ensure order-preserving deduplication, matching the repository's FP-style guidelines.
- λ FP Angle: Replaces scattered string mutation and ad hoc list/set comprehensions with explicit, pure transformation pipelines.
- ✅ Verification: Added comprehensive tests in `tests/test_auth_scopes.py`, updated cli tests, ran `pytest`, `ruff check`, `ruff format`, and `mypy`.
- 🧪 Edge cases: Tested empty strings, whitespace gaps, duplicate scopes, and mixed inputs in test coverage explicitly.
- ⚠️ Risk: Very low; behavior preserving refactor with expanded testing covering existing subtleties.

---
*PR created automatically by Jules for task [6273695106960399939](https://jules.google.com/task/6273695106960399939) started by @ToolchainLab*