### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-18 - Optimize Primary Key + Filter Lookups
+
+**Learning:** When querying a single record by its primary key with an additional filter (such as an ownership check like `user_id == user.id`), using `db.execute(select(Model).filter(...))` forces a database roundtrip and bypasses the Identity Map cache.
+**Action:** For primary key lookups with secondary filters, prefer fetching the object with `await db.get(Model, pk)` to leverage the Identity Map cache, and then perform the secondary validation (like ownership checks) in Python.

--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # Optimize: Use db.get() for primary key lookup to leverage identity map cache
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # Optimize: Use db.get() for primary key lookup to leverage identity map cache
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # Optimize: Use db.get() for primary key lookup and check secondary condition in Python
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # Optimize: Use db.get() for primary key lookup and check secondary condition in Python
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What: Replaced direct `db.execute(select(Model).filter(Model.id == pk))` calls with `await db.get(Model, pk)` in `src/h4ckath0n/auth/passkeys/service.py`. Also optimized composite lookups to fetch by primary key using `db.get` and handle ownership validation in Python.
🎯 Why: Using `db.get()` is faster because it checks the active Session's Identity Map cache first. This potentially avoids unnecessary database roundtrips and object hydration overhead.
📊 Impact: Reduces database roundtrips and object hydration overhead on highly accessed authorization routes.
🔬 Measurement: Monitor memory usage and database query count on high-frequency routes relying on authentication and passkey management endpoints.

---
*PR created automatically by Jules for task [18222585737196435247](https://jules.google.com/task/18222585737196435247) started by @ToolchainLab*