### PR TITLE
🎨 Palette: Add Enter-to-submit for AI Chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-17 - [Add Enter-to-submit to AI Chat]
+**Learning:** Textarea inputs for AI chat components without Enter-to-submit interactions are unintuitive. Users naturally press Enter to send chat messages. Adding this along with a visual hint (`<kbd>Enter</kbd>`) improves both intuitiveness and accessibility.
+**Action:** Always consider Enter-to-submit patterns for single-message oriented textarea inputs, ensuring to disable the input during async processing and preserving `Shift+Enter` for multiline text.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,26 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (aiPrompt.trim() && !aiStreaming) {
+                      void handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+              />
+              <div className="absolute bottom-2 right-3 pointer-events-none text-xs text-text-muted">
+                <kbd className="font-sans px-1 py-0.5 rounded bg-surface-alt border border-border">Enter</kbd> to send
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added an `onKeyDown` handler to the AI chat textarea to submit the prompt when "Enter" is pressed (while preserving "Shift+Enter" for newlines). Also added an absolute-positioned `<kbd>Enter</kbd> to send` hint. The textarea is disabled while `aiStreaming` is true to prevent prompt mangling.

🎯 Why: Users naturally expect to hit "Enter" to submit a message in chat-like interfaces. Requiring a manual click on the "Send" button adds unnecessary friction to the user experience. 

📸 Before/After: The textarea now features a clean "Enter to send" hint in the bottom right corner. 

♿ Accessibility: Ensures the Enter key natively triggers the primary action (submission) in the text context. The input is safely disabled during asynchronous streaming to prevent unintended state changes, communicating to screen readers that the input is temporarily locked.

---
*PR created automatically by Jules for task [18421892365069637465](https://jules.google.com/task/18421892365069637465) started by @ToolchainLab*