### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix timing attack in authenticate_user

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-01 - Fix timing attack in authenticate_user
+**Vulnerability:** Timing attack allowing email enumeration during login because password verification was skipped if user didn't exist.
+**Learning:** Returning early without doing the same amount of work lets attackers map existing emails based on response times. When using `argon2-cffi`, the dummy hash must be a structurally valid Argon2id hash.
+**Prevention:** Always verify a dummy hash of equivalent cost when early-exiting from an authentication flow to normalize the response times.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -17,6 +17,11 @@ from h4ckath0n.auth.models import Device, PasswordResetToken, User
 from h4ckath0n.config import Settings
 from h4ckath0n.rng import token_urlsafe as _rng_urlsafe
 
+DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$"
+    "UG0xAL6Ra+7oidbPLbrtPw$Z4Zy26jLCH/jPrX198HPOZX2x4efquFtuMGlONKFOk4"
+)
+
 
 def _hash_token(token: str) -> str:
     """SHA-256 hash a token for storage."""
@@ -75,10 +80,12 @@ async def register_user(
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    if user is None or not user.password_hash:
+        verify_password(password, DUMMY_HASH)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Timing attack allows email enumeration in authenticate_user
🎯 Impact: Attackers can enumerate registered email addresses by observing timing differences because the original implementation returned early if the user did not exist.
🔧 Fix: Added a dummy Argon2id hash verification when user is not found to normalize the response time.
✅ Verification: Timing difference is mitigated. Ran full test suite.

---
*PR created automatically by Jules for task [13752560554415269719](https://jules.google.com/task/13752560554415269719) started by @ToolchainLab*