### PR TITLE
🧭 Atlas: Replace hand-written env var lists with generated table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/check_doc_config.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty |  |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` |  |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` |  |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` |  |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` |  |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` |  |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` |  |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` |  |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` |  |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` |  |
+| `H4CKATH0N_SMTP_HOST` | empty |  |
+| `H4CKATH0N_SMTP_PORT` | `587` |  |
+| `H4CKATH0N_SMTP_USERNAME` | empty |  |
+| `H4CKATH0N_SMTP_PASSWORD` | empty |  |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` |  |
+| `H4CKATH0N_SMTP_SSL` | `false` |  |
+| `H4CKATH0N_DEMO_MODE` | `false` |  |
+<!-- ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_config.py
+++ b/scripts/check_doc_config.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that the configuration table in README.md is up to date.
+
+Usage (from repo root):
+    uv run scripts/check_doc_config.py [--fix]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+MARKER_START = "<!-- ENV_VARS_START -->\n"
+MARKER_END = "<!-- ENV_VARS_END -->\n"
+
+
+def generate_config_table() -> str:
+    """Generate a Markdown table of environment variables from Settings."""
+    from h4ckath0n.config import Settings
+
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for name, field in Settings.model_fields.items():
+        if name == "openai_api_key":
+            lines.append(
+                f"| `OPENAI_API_KEY` | empty | "
+                f"{field.description or 'OpenAI API key for the LLM wrapper'} |"
+            )
+            lines.append(
+                f"| `H4CKATH0N_OPENAI_API_KEY` | empty | "
+                f"Alternate {field.description or 'OpenAI API key for the LLM wrapper'} |"
+            )
+            continue
+
+        env_var = f"H4CKATH0N_{name.upper()}"
+
+        default = field.default
+        if str(default) == "PydanticUndefined":
+            default_str = "`[]`" if name == "bootstrap_admin_emails" else "empty"
+        elif default == "":
+            default_str = "empty"
+        elif default == []:
+            default_str = "`[]`"
+        elif isinstance(default, bool):
+            default_str = f"`{str(default).lower()}`"
+        elif default is None:
+            default_str = "empty"
+        else:
+            default_str = f"`{default}`"
+
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        desc = field.description or ""
+
+        lines.append(f"| `{env_var}` | {default_str} | {desc} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    fix = "--fix" in sys.argv
+    readme_text = README.read_text()
+
+    if MARKER_START not in readme_text or MARKER_END not in readme_text:
+        print(
+            "❌ Markers not found in README.md. "
+            "Please add <!-- ENV_VARS_START --> and <!-- ENV_VARS_END -->."
+        )
+        return 1
+
+    start_idx = readme_text.index(MARKER_START) + len(MARKER_START)
+    end_idx = readme_text.index(MARKER_END)
+
+    current_table = readme_text[start_idx:end_idx]
+    expected_table = generate_config_table()
+
+    if current_table == expected_table:
+        print("✅ Environment variables documentation is up to date.")
+        return 0
+
+    if fix:
+        new_text = readme_text[:start_idx] + expected_table + readme_text[end_idx:]
+        README.write_text(new_text)
+        print("✅ Updated README.md with latest environment variables.")
+        return 0
+    else:
+        print("❌ Environment variables documentation is out of date.")
+        print("Run `uv run scripts/check_doc_config.py --fix` to update it.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,29 +19,42 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
     redis_url: str = ""


### PR DESCRIPTION
* 💡 **What**: Replaced the hand-written environment variables table in `README.md` with dynamically generated sections built directly from the `Settings` class (`src/h4ckath0n/config.py`) using `pydantic.Field` descriptions.
* 🎯 **Why**: Hardcoded environment variables in READMEs frequently drift from the actual application configuration. This change ensures documentation parity and eliminates the risk of missing or incorrect environment variable docs.
* 🧪 **Verification**: Run `uv run scripts/check_doc_config.py` locally to verify parity. Passing tests and CI.
* 🔒 **Drift Prevention**: Added `scripts/check_doc_config.py` which runs in the standard CI workflow (`.github/workflows/ci.yml`) alongside the existing route checker. The CI job will fail if the README and `config.py` drift.
* 🗺️ **Evidence**: `src/h4ckath0n/config.py` treated as the canonical source of truth for all config values.

---
*PR created automatically by Jules for task [16388291137400066939](https://jules.google.com/task/16388291137400066939) started by @ToolchainLab*