### PR TITLE
⚡ Bolt: Optimize DB primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,9 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # Optimize: Use db.get() for PK lookups to check identity map cache
+    # and avoid ORM hydration overhead
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +142,9 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # Optimize: Use db.get() for PK lookups to check identity map cache
+    # and avoid ORM hydration overhead
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
💡 What: Refactored queries inside `src/h4ckath0n/auth/passkeys/service.py` to fetch database records by their primary keys (`WebAuthnChallenge`, `User`) using `await db.get(...)` instead of `await db.execute(select(...))`.

🎯 Why: To reduce database load and improve request throughput. `db.get()` checks the SQLAlchemy Identity Map cache first. If the object was already loaded in the current async session, this completely avoids a database roundtrip and the cost of SQLAlchemy compiling the query and re-hydrating the ORM model instances. This is particularly valuable on high-traffic auth paths.

📊 Impact: Reduces SQL query compilation overhead, improves request latency when records hit the identity map, and lowers application memory usage by avoiding unnecessary object instantiation.

🔬 Measurement: Verify tests run perfectly clean. Any custom profiling for auth route latency would show a small but measurable reduction in db time overhead during successive identity checks.

---
*PR created automatically by Jules for task [11356505926451937138](https://jules.google.com/task/11356505926451937138) started by @ToolchainLab*