### PR TITLE
⚡ Bolt: Optimize primary key lookups with db.get()

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize identity map cache
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize identity map cache
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 
@@ -338,13 +338,9 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup and perform ownership check in Python
+    cred = await db.get(WebAuthnCredential, key_id)
+    if cred is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +371,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup and perform ownership check in Python
+        cred = await db.get(WebAuthnCredential, key_id)
+        if cred is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What: Swapped `db.execute(select(...).filter(...))` for `await db.get(...)` across four locations in `auth/passkeys/service.py` where objects are looked up by their primary keys (`id`), executing secondary filter validations (like ownership checks) in Python.
🎯 Why: When retrieving a single object by its primary key, using a multi-column SQL query stringency circumvents the SQLAlchemy Identity Map cache and consistently forces a network roundtrip and parsing overhead. Fetching by `db.get()` first consults the cache.
📊 Impact: Reduced database roundtrips and object hydration times for already-loaded items on frequently accessed auth lifecycle paths.
🔬 Measurement: Verified caching efficacy via unit tests execution duration and reduction of debug-level SQL query emission metrics when handling cached objects.

---
*PR created automatically by Jules for task [8227657072493888138](https://jules.google.com/task/8227657072493888138) started by @ToolchainLab*