### PR TITLE
🎨 Palette: Add Enter-to-submit and loading states to AI chat textarea

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-19 - [Enter-to-submit Interaction]
+ **Learning:** In chat interfaces, users expect Enter-to-submit functionality. Furthermore, the textarea must be disabled during streaming to avoid mangled prompts, and adequate bottom padding (pb-8) must be added when placing absolute-positioned hint elements to avoid text overlap.
+ **Action:** Implement Enter-to-submit keyboard handling on prompt textareas, ensuring the input is not empty before submitting. Use disabled attributes during async tasks, and allocate layout space (like pb-8) for absolute-positioned elements.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,26 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (aiPrompt.trim() && !aiStreaming) {
+                      void handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-2 right-3 text-xs text-text-muted pointer-events-none">
+                Press <kbd className="font-sans px-1 py-0.5 rounded bg-surface-alt border border-border font-medium">Enter</kbd> to send
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added Enter-to-submit keyboard functionality to the AI chat `<textarea>` in the Dashboard. Added a `<kbd>` visual hint at the bottom right and improved the `disabled` loading state during AI streaming.
🎯 Why: To make the chat interface more intuitive and fast for users who expect to hit Enter to submit messages. Disabling the input prevents users from mangling the prompt while the stream is active.
📸 Before/After: Visual hint added at the bottom of the prompt box; padding adjustments ensure it doesn't overlap text. (Verified via local Playwright visual test)
♿ Accessibility: The textarea correctly receives a `disabled` attribute to communicate async states to screen readers. The prompt visual hint explicitly uses `pointer-events-none` so it does not block cursor interaction or text selection.

---
*PR created automatically by Jules for task [5924095983350802166](https://jules.google.com/task/5924095983350802166) started by @ToolchainLab*