### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration via timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-19 - Timing Attack Mitigation in Argon2id
+**Vulnerability:** User enumeration via timing attack in `authenticate_user` because it returns early when a user is not found.
+**Learning:** When mitigating timing attacks with `argon2-cffi`, the dummy hash must be a structurally valid Argon2id string. An invalid hash triggers an early `InvalidHashError` exception, bypassing the mitigation.
+**Prevention:** Always use a real, pre-computed valid Argon2id hash (e.g. implicitly concatenated literal) for the dummy verification step to ensure identical execution paths.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -72,15 +72,26 @@ async def register_user(
     return user
 
 
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$"
+    "7BxQ8okN8oZHoVGWq3OtLw$"
+    "ZcBw/F18UeXNDuotAljDBLshCZS2wNgMuSFmYXsFxC0"
+)
+
+
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    if user is None or not user.password_hash:
+        # Mitigate timing attacks by always verifying a dummy hash
+        verify_password(password, _DUMMY_HASH)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
+
     return user
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User enumeration via timing attack in `authenticate_user`.
🎯 Impact: Attackers can enumerate registered users by measuring response times because the function returns early when a user is not found.
🔧 Fix: Verify a structurally valid dummy Argon2id hash when the user is not found or has no password to equalize execution paths.
✅ Verification: Ran `uv run --locked ruff check --fix . && uv run --locked ruff format . && uv run --locked pytest -v` locally.

---
*PR created automatically by Jules for task [16499001376362692809](https://jules.google.com/task/16499001376362692809) started by @ToolchainLab*