### PR TITLE
🧭 Atlas: Generate env var docs from Pydantic config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env var docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-04-19 - Generate Config Docs from Pydantic
+**Learning:** Hardcoded environment variable lists in READMEs drift easily from the actual configuration fields.
+**Action:** Use `Settings.model_fields` to programmatically extract descriptions and defaults, outputting them between markdown markers in the README, and add a CI step to enforce parity.

--- a/README.md
+++ b/README.md
@@ -159,22 +159,41 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- GENERATED_ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
-| `H4CKATH0N_ENV` | `development` | `development` or `production` |
+| `H4CKATH0N_ENV` | `development` | development or production |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
-| `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
+| `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | 300 | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
 | `H4CKATH0N_PASSWORD_AUTH_ENABLED` | `false` | Enable password routes when the extra is installed |
-| `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
+| `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | 30 | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend ('local' or 's3') |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory path for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | 52428800 | Maximum upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend ('file' or 'smtp') |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory path for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | 587 | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- GENERATED_ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: generate env var docs from Pydantic config."""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- GENERATED_ENV_VARS_START -->"
+END_MARKER = "<!-- GENERATED_ENV_VARS_END -->"
+
+
+def generate_table() -> str:
+    from h4ckath0n.config import Settings
+
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        if name == "openai_api_key":
+            var_name = "`OPENAI_API_KEY`"
+        else:
+            var_name = f"`H4CKATH0N_{name.upper()}`"
+
+        default = field.default
+        if default == "":
+            default = "empty"
+        elif default == []:
+            default = "`[]`"
+        elif default is False:
+            default = "`false`"
+        elif default is True:
+            default = "`true`"
+        elif isinstance(default, str) and default != "empty":
+            default = f"`{default}`"
+
+        desc = field.description or ""
+        lines.append(f"| {var_name} | {default} | {desc} |")
+
+        # Add the alternate openai key to match existing docs
+        if name == "openai_api_key":
+            lines.append(
+                "| `H4CKATH0N_OPENAI_API_KEY` | empty | "
+                "Alternate OpenAI API key for the LLM wrapper |"
+            )
+
+    return "\n".join(lines)
+
+
+def update_readme(check_only: bool = False) -> int:
+    readme_text = README.read_text()
+    table = generate_table()
+
+    pattern = re.compile(rf"{START_MARKER}.*?{END_MARKER}", re.DOTALL)
+    if not pattern.search(readme_text):
+        print("❌ Markers not found in README.md")
+        return 1
+
+    new_text = pattern.sub(f"{START_MARKER}\n{table}\n{END_MARKER}", readme_text)
+
+    if check_only:
+        if new_text != readme_text:
+            print("❌ Env var docs are out of date. Run scripts/generate_env_docs.py")
+            return 1
+        print("✅ Env var docs are up to date.")
+        return 0
+
+    README.write_text(new_text)
+    print("✅ Env var docs updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    check = "--check" in sys.argv
+    sys.exit(update_readme(check))

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,76 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="development or production")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(True, description="Run background jobs inline in development")
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend ('local' or 's3')")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory path for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum upload size in bytes (default 50MB)"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field("file", description="Email backend ('file' or 'smtp')")
+    email_from: str = Field("noreply@localhost", description="Sender address for outbound emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory path for file-based email outbox"
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP server username")
+    smtp_password: str = Field("", description="SMTP server password")
+    smtp_starttls: bool = Field(True, description="Enable STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Enable SSL for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 What: Replaced the static, hardcoded environment variable table in `README.md` with a generated section driven directly by Pydantic's `Field(description=...)` metadata. Added a generation script and wired it into CI.
- 🎯 Why: Hardcoded lists drift easily, particularly as the app grows and new settings (like Redis, Storage, and Email) are added. Driving the documentation from the `Settings` class ensures the README always matches the exact configuration schema.
- 🧪 Verification: Validated locally via `uv run scripts/generate_env_docs.py --check` and standard project checks.
- 🔒 Drift Prevention: Added `generate_env_docs.py --check` to `.github/workflows/ci.yml` so that CI will fail if `config.py` is updated without updating the `README.md` docs.
- 🗺️ Evidence: Used `src/h4ckath0n/config.py` as the true source of configuration, executing `scripts/generate_env_docs.py` as the bridge to standard markdown.

---
*PR created automatically by Jules for task [9617002889006578208](https://jules.google.com/task/9617002889006578208) started by @ToolchainLab*