### PR TITLE
⚡ Bolt: Use db.get() for primary key lookups in passkey service

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2024-05-23 - Optimizing PK + Ownership Queries
+**Learning:** When looking up a single record by its primary key alongside additional filters (e.g., ownership checks like `Model.user_id == user.id`), it is generally more performant to fetch the object using `await db.get(Model, pk)` to leverage the SQLAlchemy Identity Map cache and then perform the secondary validations in Python, rather than executing a multi-column SQL query that bypasses the cache lookup.
+**Action:** Always prefer `db.get()` for primary key lookups, even when secondary filtering logic (like checking user ownership) is required.

--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Fetch by PK first, validate ownership in Python
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Fetch by PK first, validate ownership in Python
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What: Replaced multi-column SQL queries in `src/h4ckath0n/auth/passkeys/service.py` with `await db.get(Model, pk)` where looking up records by their primary key. Secondary conditions (like `user_id == user.id`) are now validated in Python after fetching the object.

🎯 Why: Using `db.get()` takes advantage of SQLAlchemy's Identity Map cache, which avoids unnecessary database queries for objects that are already loaded in the active session. This makes the database layer more efficient, particularly for operations like registration, authentication, renaming, and revoking passkeys.

📊 Impact: Reduces database load by leveraging in-memory caching and skipping unnecessary multi-column SQL query execution for primary key lookups.

🔬 Measurement: Measured by analyzing database query logs and ensuring that identical primary key lookups within the same session don't result in duplicate SQL executions. Confirmed no regressions by running the test suite.

---
*PR created automatically by Jules for task [2996653754783354259](https://jules.google.com/task/2996653754783354259) started by @ToolchainLab*