### PR TITLE
🧭 Atlas: Auto-generate environment variable docs from config model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-05-18 - Environment variable table drift
+
+**Learning:** Hand-written tables of environment variables in READMEs drift heavily from Pydantic config models, especially when new features (like Storage or Email) add new settings that the docs miss.
+**Action:** Always generate environment variable markdown tables directly from `pydantic.Field` descriptions and add a CI check (`--check`) to ensure the README remains in sync with the source code.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- GENERATED_ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
-| `H4CKATH0N_ENV` | `development` | `development` or `production` |
+| `H4CKATH0N_ENV` | `development` | development or production |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (local or s3) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (file or smtp) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default From address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- GENERATED_ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script: generate environment variable documentation.
+
+Usage (from repo root):
+    uv run scripts/generate_env_docs.py [--check]
+
+The script imports the h4ckath0n app settings, enumerates all fields, and
+updates the Configuration table in README.md. If --check is passed, it fails
+if the README is out of date.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[tuple[str, str, str]]:
+    """Return all environment variables as (name, default, description)."""
+    from h4ckath0n.config import Settings
+
+    prefix = Settings.model_config.get("env_prefix", "H4CKATH0N_")
+
+    rows = []
+    for field_name, field in Settings.model_fields.items():
+        var_name = f"{prefix}{field_name}".upper()
+
+        # Handle default value formatting
+        default_val = field.default
+        if default_val == "" or default_val is None:
+            default_str = "empty"
+        elif isinstance(default_val, bool):
+            default_str = f"`{'true' if default_val else 'false'}`"
+        elif isinstance(default_val, (list, str)):
+            default_str = f"`{default_val}`"
+        else:
+            default_str = f"`{default_val}`"
+
+        desc = field.description or ""
+
+        if field_name == "openai_api_key":
+            rows.append(("OPENAI_API_KEY", "empty", "OpenAI API key for the LLM wrapper"))
+            desc = "Alternate OpenAI API key for the LLM wrapper"
+
+        rows.append((var_name, default_str, desc))
+
+    return rows
+
+
+def generate_markdown_table(rows: list[tuple[str, str, str]]) -> str:
+    """Generate the markdown table string."""
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, default, desc in rows:
+        lines.append(f"| `{name}` | {default} | {desc} |")
+    return "\n".join(lines)
+
+
+def update_readme(new_table: str, check_only: bool = False) -> int:
+    """Update README.md with the new table or check if it matches."""
+    text = README.read_text()
+
+    pattern = re.compile(
+        r"(<!-- GENERATED_ENV_VARS_START -->\n)(.*?)(\n<!-- GENERATED_ENV_VARS_END -->)", re.DOTALL
+    )
+
+    match = pattern.search(text)
+    if not match:
+        print("❌ Could not find GENERATED_ENV_VARS markers in README.md")
+        return 1
+
+    current_table = match.group(2)
+
+    if current_table == new_table:
+        print("✅ README.md environment variables are up to date.")
+        return 0
+
+    if check_only:
+        print(
+            "❌ README.md environment variables are out of date. "
+            "Run 'uv run scripts/generate_env_docs.py' to update."
+        )
+        return 1
+
+    new_text = pattern.sub(rf"\g<1>{new_table}\g<3>", text)
+    README.write_text(new_text)
+    print("✅ Updated README.md environment variables.")
+    return 0
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    rows = get_env_vars()
+    table = generate_markdown_table(rows)
+    return update_readme(table, check_only)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,72 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="development or production")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL")
+    jobs_inline_in_dev: bool = Field(True, description="Run background jobs inline in development")
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend (local or s3)")
+    storage_dir: str = Field("./.h4ckath0n_storage", description="Local storage directory")
+    max_upload_bytes: int = Field(50 * 1024 * 1024, description="Maximum upload size in bytes")
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL for the frontend application"
+    )
+    email_backend: str = Field("file", description="Email backend (file or smtp)")
+    email_from: str = Field("noreply@localhost", description="Default From address for emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = Field("", description="SMTP host")
+    smtp_port: int = Field(587, description="SMTP port")
+    smtp_username: str = Field("", description="SMTP username")
+    smtp_password: str = Field("", description="SMTP password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Use SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
* 💡 What: Generate the README environment variable table from Pydantic models.
* 🎯 Why: The hand-written table was missing half the actual variables (Redis, Storage, Email).
* 🧪 Verification: `uv run scripts/generate_env_docs.py` locally and `pytest`.
* 🔒 Drift Prevention: Added `scripts/generate_env_docs.py --check` step to `.github/workflows/ci.yml`.
* 🗺️ Evidence: `src/h4ckath0n/config.py` is the single source of truth for config.

---
*PR created automatically by Jules for task [3818289558261696000](https://jules.google.com/task/3818289558261696000) started by @ToolchainLab*