### PR TITLE
⚡ Bolt: Optimize primary key lookups with db.get()

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
- 💡 What: Replaced `await db.execute(select(Model).filter(Model.id == pk))` with `await db.get(Model, pk)` in `src/h4ckath0n/auth/passkeys/service.py` for `WebAuthnChallenge` and `User` lookups.
- 🎯 Why: Using `db.get()` is more performant as it checks the active Session's Identity Map cache first before querying the database, avoiding unnecessary network roundtrips and object hydration overhead.
- 📊 Impact: Improves authentication and registration flow performance by leveraging the SQLAlchemy cache.
- 🔬 Measurement: Observe reduced database queries during passkey authentication via APM/tracing tools and verify correct behavior by running the pytest suite.

---
*PR created automatically by Jules for task [10369970418465495488](https://jules.google.com/task/10369970418465495488) started by @ToolchainLab*