### PR TITLE
🎨 Palette: Add Enter-to-submit keyboard interaction and disabled state to AI chat input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-21 - [Chat Input Keyboard Interaction]
+**Learning:** Users expect Enter-to-submit keyboard interactions in chat interfaces (like AI prompt textareas), but this can cause prompt mangling if the input isn't disabled during async operations (like streaming). Additionally, absolute-positioned keyboard hints can overlap with text if bottom padding isn't applied to the textarea.
+**Action:** When implementing Enter-to-submit, check that the input isn't empty, apply the disabled attribute directly to the textarea during async operations, and apply adequate bottom padding (e.g., pb-8) to prevent text overlap with hints.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,29 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (aiPrompt.trim() && !aiStreaming) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-2 right-2 flex items-center gap-1 text-xs text-text-muted pointer-events-none">
+                <kbd className="hidden sm:inline-block rounded bg-surface-alt px-1.5 py-0.5 font-sans font-medium border border-border">
+                  Enter
+                </kbd>
+                <span className="hidden sm:inline-block">to send</span>
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added an `onKeyDown` handler to the AI chat textarea to allow Enter-to-submit, disabled the textarea during streaming, added a visual `<kbd>` hint for the shortcut, and applied bottom padding to prevent text overlap.
🎯 Why: Users naturally expect to submit chat messages by pressing Enter. Disabling the input while streaming prevents prompt mangling. The `<kbd>` hint helps users discover the shortcut.
📸 Before/After: Before, users had to manually click "Send" and could accidentally modify the prompt while the AI was generating. After, they can type and press Enter seamlessly with visual guidance.
♿ Accessibility: Improved keyboard accessibility by allowing form submission via the Enter key and visually explaining the shortcut. The disabled state correctly communicates to screen readers that the input is temporarily unavailable.

---
*PR created automatically by Jules for task [11962661300057999680](https://jules.google.com/task/11962661300057999680) started by @ToolchainLab*