### PR TITLE
⚡ Bolt: Optimize passkey primary key lookups with db.get()

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize identity map cache
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize identity map cache
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
💡 What: Replaced `await db.execute(select(Model).filter(Model.id == pk))` with `await db.get(Model, pk)` for `WebAuthnChallenge` and `User` in passkeys service.
🎯 Why: Using `db.get()` takes advantage of the SQLAlchemy Identity Map cache, avoiding unnecessary trips to the database and bypassing ORM query hydration overhead if the object is already loaded, especially beneficial in authentication hot paths.
📊 Impact: Reduces database latency and memory allocations for primary key lookups during passkey operations.
🔬 Measurement: Review execution plans or query logging; tests verify functionality remains identical.

---
*PR created automatically by Jules for task [2440070215401327778](https://jules.google.com/task/2440070215401327778) started by @ToolchainLab*