### PR TITLE
🎨 Palette: Add Enter-to-submit to AI chat prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Chat Interface Keyboard UX
+**Learning:** During AI streaming operations, keeping the prompt textarea active can lead to prompt mangling if the user continues typing or submits again before the stream finishes. Providing keyboard shortcuts (Enter to submit) requires explicitly disabling the input and showing visual `<kbd>` hints to establish a natural interaction model.
+**Action:** Always disable textareas during async stream processing and add `pb-8` padding when floating a `<kbd>` hint to prevent text overlap.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,30 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (aiPrompt.trim() && !aiStreaming) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-3 right-3 text-xs text-text-muted pointer-events-none flex items-center gap-1">
+                <span className="hidden sm:inline">Press</span>
+                <kbd className="px-1.5 py-0.5 rounded-md bg-surface-alt border border-border font-sans font-medium text-[10px] uppercase">
+                  Enter
+                </kbd>
+                <span className="hidden sm:inline">to send</span>
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added an `onKeyDown` handler to the AI stream textarea to allow submission via Enter key, while handling `Shift+Enter` for newlines. Disabled the textarea during streaming and added a floating `<kbd>` visual hint.
🎯 Why: Submitting via a button is slow when typing. "Enter to send" is a universal expectation for chat interfaces. Disabling the input prevents users from accidentally mangling their prompt or queueing multiple submits while the stream is processing.
📸 Before/After: Before: Plain textarea, requiring manual mouse click to submit. After: Textarea with an "Enter to send" hint, bottom padding to prevent overlap, and it properly disables during streaming.
♿ Accessibility: Added clear visual cues (`disabled` state styling, `<kbd>` hint) and improved keyboard navigation support.

---
*PR created automatically by Jules for task [17962537059764828677](https://jules.google.com/task/17962537059764828677) started by @ToolchainLab*