### PR TITLE
🧭 Atlas: Automate environment variable documentation from Settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-04-22 - Automated env var docs from Pydantic config
+
+**Learning:** Manual configuration tables in READMEs quickly fall out of sync with actual environment variable loading (in this case, Pydantic's `BaseSettings`). This causes painful onboarding for contributors unaware of undocumented settings (e.g., SMTP or Redis configuration fields added but not documented).
+**Action:** Replace handwritten tables with a generated table driven by Pydantic's `Field(description="...")`. Add a CI step running a script like `scripts/generate_env_docs.py --check` to catch out-of-sync configuration docs on push.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- GENERATED_ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend type (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode to restrict certain operations |
+<!-- GENERATED_ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that environment variables in README.md are generated
+from the config.py Settings class.
+
+Usage (from repo root):
+    uv run scripts/generate_env_docs.py [--check]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+START_MARKER = "<!-- GENERATED_ENV_VARS_START -->"
+END_MARKER = "<!-- GENERATED_ENV_VARS_END -->"
+
+
+def generate_table() -> str:
+    from h4ckath0n.config import Settings
+
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for field_name, field_info in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{field_name.upper()}"
+
+        if field_name == "openai_api_key":
+            lines.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+
+        default_val = field_info.default
+        if default_val == "":
+            default_str = "empty"
+        elif default_val == []:
+            default_str = "`[]`"
+        elif isinstance(default_val, bool):
+            default_str = f"`{'true' if default_val else 'false'}`"
+        elif isinstance(default_val, int) or default_val is not None:
+            default_str = f"`{default_val}`"
+        else:
+            default_str = "empty"
+
+        desc = field_info.description or ""
+
+        # Override descriptions for edge cases as currently in README
+        if field_name == "rp_id":
+            desc = "WebAuthn relying party ID, required in production"
+            default_str = "`localhost` in development"
+        elif field_name == "origin":
+            desc = "WebAuthn origin, required in production"
+            default_str = "`http://localhost:8000` in development"
+
+        lines.append(f"| `{var_name}` | {default_str} | {desc} |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    readme_text = README.read_text()
+
+    if START_MARKER not in readme_text or END_MARKER not in readme_text:
+        print("❌ README.md must contain the START and END markers for generated env vars.")
+        return 1
+
+    pattern = re.compile(rf"{START_MARKER}.*?{END_MARKER}", re.DOTALL)
+    current_section = pattern.search(readme_text).group(0)
+
+    table_content = generate_table()
+    new_section = f"{START_MARKER}\n{table_content}\n{END_MARKER}"
+
+    if args.check:
+        if current_section != new_section:
+            print(
+                "❌ Environment variables documentation in README.md is out of sync "
+                "with Settings in src/h4ckath0n/config.py."
+            )
+            print("Run 'uv run scripts/generate_env_docs.py' to update it.")
+            return 1
+        print("✅ Environment variables documentation is up to date.")
+        return 0
+
+    if current_section != new_section:
+        new_readme_text = readme_text.replace(current_section, new_section)
+        README.write_text(new_readme_text)
+        print("✅ Updated environment variables documentation in README.md.")
+    else:
+        print("✅ Environment variables documentation in README.md is already up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,87 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db",
+        description="SQLAlchemy connection string",
+    )
+    auto_upgrade: bool = Field(
+        False,
+        description="Auto-run packaged DB migrations to head on startup",
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred",
+        description="WebAuthn user verification requirement",
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False,
+        description="Enable password routes when the extra is installed",
+    )
+    password_reset_expire_minutes: int = Field(
+        30,
+        description="Password reset token expiry in minutes",
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [],
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="Alternate OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(True, description="Run background jobs inline in development")
+    jobs_default_queue: str = Field(
+        "default",
+        description="Default queue name for background jobs",
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend type")
+    storage_dir: str = Field("./.h4ckath0n_storage", description="Local storage directory")
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024,
+        description="Maximum upload size in bytes",
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173",
+        description="Base URL of the frontend application",
+    )
+    email_backend: str = Field(
+        "file",
+        description="Email backend type (`file` or `smtp`)",
+    )  # "file" or "smtp"
+    email_from: str = Field("noreply@localhost", description="Default sender email address")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox",
+        description="Directory to save emails when using `file` backend",
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP server username")
+    smtp_password: str = Field("", description="SMTP server password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(False, description="Use SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode to restrict certain operations")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced manually managed env variable docs in `README.md` with an automated section generated by a script that reads from `src/h4ckath0n/config.py` `Settings` using Pydantic fields. Added field descriptions to `Settings`.
🎯 Why: To prevent the list of environment variables from becoming out-of-sync with what's actually coded into the app configuration. This reduces the risk of incorrect or missing configurations for new contributors.
🧪 Verification: Run `uv run scripts/generate_env_docs.py --check` to verify `README.md` has the generated text.
🔒 Drift Prevention: Added `generate_env_docs.py` which generates markdown tables out of `Settings` fields and checks if it's correct. Added a step to the `backend` CI pipeline to fail the build if `README.md` hasn't been updated to match configuration changes.
🗺️ Evidence: `src/h4ckath0n/config.py`, `README.md`, `.github/workflows/ci.yml`.

---
*PR created automatically by Jules for task [2399619964632232477](https://jules.google.com/task/2399619964632232477) started by @ToolchainLab*