### PR TITLE
🎨 Palette: Add accessible names to mobile layout icon buttons

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0];
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,18 +75,19 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0];
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
-      expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
-      ).toBeInTheDocument();
+      const darkButtons = screen.getAllByRole("button", { name: "Theme: dark" });
+      expect(darkButtons.length).toBeGreaterThan(0);
+      expect(darkButtons[0]).toBeInTheDocument();
     });
 
-    fireEvent.click(button);
+    const darkButtonsToClick = screen.getAllByRole("button", { name: "Theme: dark" });
+    fireEvent.click(darkButtonsToClick[0]);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -59,7 +59,7 @@ describe("Layout theme preference", () => {
     renderLayout();
 
     const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0];
-    fireEvent.click(button);
+    fireEvent.click(button!);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
@@ -77,7 +77,7 @@ describe("Layout theme preference", () => {
 
     const button = screen.getAllByRole("button", { name: "Theme: light" })[0];
 
-    fireEvent.click(button);
+    fireEvent.click(button!);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
@@ -87,7 +87,7 @@ describe("Layout theme preference", () => {
     });
 
     const darkButtonsToClick = screen.getAllByRole("button", { name: "Theme: dark" });
-    fireEvent.click(darkButtonsToClick[0]);
+    fireEvent.click(darkButtonsToClick[0]!);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -192,6 +192,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +208,9 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+                aria-expanded={isMobileMenuOpen}
+                aria-controls="mobile-menu"
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -216,7 +224,7 @@ export function Layout() {
 
         {/* Mobile Navigation */}
         {isMobileMenuOpen && (
-          <div className="md:hidden border-t border-border bg-surface">
+          <div id="mobile-menu" className="md:hidden border-t border-border bg-surface">
             <div className="px-4 py-4 space-y-2">
               {isAuthenticated ? (
                 <>


### PR DESCRIPTION
💡 What: Added missing `aria-label` to the mobile theme toggle and mobile menu toggle buttons in the web template Layout. Added `aria-expanded` and `aria-controls` to the mobile menu button, and the corresponding `id="mobile-menu"` to the menu container. Fixed `Layout.test.tsx` to handle the duplicated theme buttons properly.
🎯 Why: Screen reader users on mobile viewports could not identify the purpose of the theme and menu buttons since they were icon-only without accessible names. The mobile menu button was missing standard ARIA state attributes.
📸 Before/After: Visuals remain unchanged, but assistive technology now reads "Theme: system (dark)" or "Open menu" / "Close menu" instead of "button".
♿ Accessibility: Ensures WCAG 2.1 SC 4.1.2 Name, Role, Value is met for mobile navigation buttons, and provides proper state indication (`aria-expanded`) for the mobile menu.

---
*PR created automatically by Jules for task [17394420508712138257](https://jules.google.com/task/17394420508712138257) started by @ToolchainLab*