### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration timing attack in authentication

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-23 - Timing Attack on Authentication
+**Vulnerability:** The `authenticate_user` function returns early if the user is not found or has no password hash. This allows attackers to enumerate registered email addresses by observing the response time difference (Argon2id hashing takes ~300ms, while early return is <1ms).
+**Learning:** Even if a standard password hashing algorithm like Argon2 is used, timing side-channels during the user lookup phase can still bypass intended security properties by leaking account existence.
+**Prevention:** Always perform a dummy verification with a structurally valid hash string when the actual verification cannot be performed (e.g., user not found or no password set) to ensure a constant-time response curve across all authentication attempts.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -72,13 +72,24 @@ async def register_user(
     return user
 
 
+# A valid structural dummy Argon2id hash to mitigate timing attacks
+_DUMMY_PASSWORD_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$"
+    "Mh4EaaGNnse7UbAWsmukag$"
+    "30hc4ssw8iJihfICOGtFEpgi31gU9FiLl1hcQcjJWcw"
+)
+
+
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    # Mitigate timing attacks by always performing a password verification
+    if user is None or not user.password_hash:
+        verify_password(password, _DUMMY_PASSWORD_HASH)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `authenticate_user` function returned immediately if the user wasn't found or had no password hash, exposing a timing side-channel because Argon2 hashing is expensive (~300ms).
🎯 Impact: An attacker could enumerate valid email addresses registered in the system by measuring the response time of the login endpoint.
🔧 Fix: Added a dummy password verification using a valid Argon2id hash string whenever the true user or password hash is unavailable, ensuring a constant-time response for login attempts.
✅ Verification: Run `uv run --locked pytest -v` and manual timing measurements.

---
*PR created automatically by Jules for task [17639167287237356436](https://jules.google.com/task/17639167287237356436) started by @ToolchainLab*