### PR TITLE
🧭 Atlas: Generate environment variables docs from Settings config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var drift check
+
+**Learning:** Environment variables documented in README.md quickly fall out of sync with Settings in src/h4ckath0n/config.py. Parsing README markdown tables for fields is fragile.
+**Action:** Instead of manually keeping README.md env vars up-to-date, add descriptions to `pydantic.Field` properties inside `Settings` and write a generation script (`scripts/generate_env_docs.py`) to keep the source of truth entirely in python code, which generates markdown inside `<!-- GENERATED_ENV_VARS_START -->` blocks. Use `--check` flags in CI to prevent drift.

--- a/README.md
+++ b/README.md
@@ -159,22 +159,41 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- GENERATED_ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
-| `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
+| `H4CKATH0N_AUTO_UPGRADE` | false | Auto-run packaged DB migrations to head on startup |
 | `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
 | `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
-| `H4CKATH0N_PASSWORD_AUTH_ENABLED` | `false` | Enable password routes when the extra is installed |
+| `H4CKATH0N_PASSWORD_AUTH_ENABLED` | false | Enable password routes when the extra is installed |
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
-| `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_FIRST_USER_IS_ADMIN` | false | First password signup becomes admin |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper (alias) |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | true | Run background jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type (local, s3, etc) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (file or smtp) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to store emails when using file backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | true | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | false | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | false | Enable demo mode with read-only restrictions |
+<!-- GENERATED_ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check and generator: ensure that all configuration settings in Settings
+are documented in README.md.
+
+Usage (from repo root):
+    uv run scripts/generate_env_docs.py          # Regenerates the table in README.md
+    uv run scripts/generate_env_docs.py --check  # Fails if README.md is out of date
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+MARKER_START = "<!-- GENERATED_ENV_VARS_START -->\n"
+MARKER_END = "<!-- GENERATED_ENV_VARS_END -->\n"
+
+
+def format_default(val: Any) -> str:
+    """Format default value for markdown table."""
+    if val == "":
+        return "empty"
+    if val is None:
+        return "empty"
+    if isinstance(val, bool):
+        return str(val).lower()
+    if isinstance(val, list) and not val:
+        return "`[]`"
+    return f"`{val}`"
+
+
+def generate_table() -> str:
+    """Generate the markdown table of environment variables."""
+    env_prefix = Settings.model_config.get("env_prefix", "")
+
+    lines = ["| Variable | Default | Description |\n", "|---|---|---|\n"]
+
+    for name, field in Settings.model_fields.items():
+        var_name = f"`{env_prefix}{name}`".upper()
+        default_val = format_default(field.default)
+
+        # Look for custom formatting for known fields based on the previous README
+        if name == "rp_id":
+            default_val = "`localhost` in development"
+        elif name == "origin":
+            default_val = "`http://localhost:8000` in development"
+
+        desc = field.description or ""
+
+        lines.append(f"| {var_name} | {default_val} | {desc} |\n")
+
+        # Also add OPENAI_API_KEY without prefix if we see openai_api_key
+        if name == "openai_api_key":
+            lines.append(f"| `OPENAI_API_KEY` | {default_val} | {desc} (alias) |\n")
+
+    return "".join(lines)
+
+
+def update_readme(content: str, dry_run: bool = False) -> bool:
+    """Update README.md with the new table. Returns True if changed."""
+    readme_text = README.read_text()
+
+    if MARKER_START not in readme_text or MARKER_END not in readme_text:
+        print(
+            f"❌ Could not find markers {MARKER_START.strip()} and "
+            f"{MARKER_END.strip()} in README.md"
+        )
+        sys.exit(1)
+
+    start_idx = readme_text.find(MARKER_START) + len(MARKER_START)
+    end_idx = readme_text.find(MARKER_END)
+
+    new_text = readme_text[:start_idx] + content + readme_text[end_idx:]
+
+    if new_text == readme_text:
+        return False
+
+    if not dry_run:
+        README.write_text(new_text)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if out of date")
+    args = parser.parse_args()
+
+    table_content = generate_table()
+
+    changed = update_readme(table_content, dry_run=args.check)
+
+    if args.check:
+        if changed:
+            print(
+                "❌ README.md is out of date. "
+                "Run `uv run scripts/generate_env_docs.py` to update it."
+            )
+            return 1
+        print("✅ README.md environment variables are up to date.")
+        return 0
+
+    if changed:
+        print("✅ Updated README.md with latest environment variables.")
+    else:
+        print("✅ README.md environment variables are already up to date.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+import pydantic
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,101 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = pydantic.Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = pydantic.Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = pydantic.Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = pydantic.Field(
+        default="", description="WebAuthn relying party ID, required in production"
+    )
+    origin: str = pydantic.Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = pydantic.Field(
+        default=300, description="WebAuthn challenge TTL in seconds"
+    )
+    user_verification: str = pydantic.Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = pydantic.Field(
+        default="none", description="WebAuthn attestation preference"
+    )
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = pydantic.Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = pydantic.Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = pydantic.Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = pydantic.Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = pydantic.Field(
+        default="", description="OpenAI API key for the LLM wrapper"
+    )
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = pydantic.Field(
+        default="", description="Redis connection URL for background jobs"
+    )
+    jobs_inline_in_dev: bool = pydantic.Field(
+        default=True, description="Run background jobs inline during development"
+    )
+    jobs_default_queue: str = pydantic.Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = pydantic.Field(
+        default="local", description="Storage backend type (local, s3, etc)"
+    )
+    storage_dir: str = pydantic.Field(
+        default="./.h4ckath0n_storage", description="Local directory for file storage"
+    )
+    max_upload_bytes: int = pydantic.Field(
+        default=50 * 1024 * 1024, description="Maximum allowed upload size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = pydantic.Field(
+        default="http://localhost:5173", description="Base URL for the frontend application"
+    )
+    email_backend: str = pydantic.Field(
+        default="file", description="Email backend to use (file or smtp)"
+    )
+    email_from: str = pydantic.Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = pydantic.Field(
+        default="./.h4ckath0n_email_outbox",
+        description="Directory to store emails when using file backend",
+    )
+    smtp_host: str = pydantic.Field(default="", description="SMTP server hostname")
+    smtp_port: int = pydantic.Field(default=587, description="SMTP server port")
+    smtp_username: str = pydantic.Field(default="", description="SMTP authentication username")
+    smtp_password: str = pydantic.Field(default="", description="SMTP authentication password")
+    smtp_starttls: bool = pydantic.Field(
+        default=True, description="Use STARTTLS for SMTP connection"
+    )
+    smtp_ssl: bool = pydantic.Field(default=False, description="Use SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = pydantic.Field(
+        default=False, description="Enable demo mode with read-only restrictions"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 What: Replaced hand-written env var lists with a generated list from the config loader via a new script `scripts/generate_env_docs.py`.
- 🎯 Why: Several environment variables were undocumented. This prevents configuration drift between Settings and README.md.
- 🧪 Verification: Locally run `uv run scripts/generate_env_docs.py` to update docs or `uv run scripts/generate_env_docs.py --check` to verify no drift.
- 🔒 Drift Prevention: Added `scripts/generate_env_docs.py --check` step in `.github/workflows/ci.yml`.
- 🗺️ Evidence: `src/h4ckath0n/config.py` Settings class serves as the source of truth.

---
*PR created automatically by Jules for task [6149138992576973043](https://jules.google.com/task/6149138992576973043) started by @ToolchainLab*