### PR TITLE
⚡ Bolt: Optimize primary key lookups in passkey auth

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-18 - Optimize Passkey Authentication Flow Lookups
+
+**Learning:** In the passkey registration and authentication flow, the user and flow lookup logic repeatedly uses `db.execute(select(...).filter(...)).scalars().first()` to find single records. For primary key lookups like `User.id == flow.user_id` and `WebAuthnChallenge.id == flow_id`, converting these to `await db.get(...)` bypasses ORM hydration overhead and utilizes the session identity cache, leading to significant latency reduction during authentication hotspots.
+
+**Action:** Consistently replace `db.execute(select(...).filter(Model.id == pk)).scalars().first()` with `await db.get(Model, pk)` across all high-traffic authentication modules.

--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
💡 What: Replace `.execute(select(...).filter(...)).scalars().first()` with `await db.get(...)` for User and WebAuthnChallenge lookups by ID in the passkeys service.

🎯 Why: To bypass ORM query parsing overhead and leverage the SQLAlchemy session identity map cache, improving latency in hot-path authentication flows.

📊 Impact: Reduces database roundtrips and object hydration allocation during authentication hotspots when the record is already loaded or only the ID is needed.

🔬 Measurement: Verified that the backend tests still pass. Expected to show fewer raw DB queries per auth request in traces.

---
*PR created automatically by Jules for task [972848207791922518](https://jules.google.com/task/972848207791922518) started by @ToolchainLab*