### PR TITLE
🎨 Palette: Improve keyboard focus visibility in Settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-04-24 - Keyboard focus visibility in hover-only and visually hidden inputs
+**Learning:** Elements that rely on `group-hover:opacity-100` for visibility or use `sr-only` inputs inside labels lack visible focus indicators for keyboard users.
+**Action:** Always include `focus-visible:opacity-100` alongside hover opacity, and use the `has-[:focus-visible]:ring-*` Tailwind pattern on the parent label for visually hidden inputs to ensure accessible keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -149,7 +149,7 @@ function PasskeyName({
           variant="ghost"
           data-testid="passkey-edit-btn"
           onClick={startEdit}
-          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />
@@ -290,7 +290,7 @@ export function Settings() {
               <label
                 key={option}
                 className={cn(
-                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all",
+                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-offset-2 has-[:focus-visible]:ring-offset-surface",
                   themePreference === option
                     ? "border-primary bg-primary/5"
                     : "border-border",


### PR DESCRIPTION
💡 What: Added `focus-visible:opacity-100` to the passkey edit button and `has-[:focus-visible]:ring-*` utilities to the theme preference radio labels in `Settings.tsx`.
🎯 Why: Keyboard users tabbing through the settings page had no visible indication of focus when reaching the hover-only edit button or the custom radio buttons (which use visually hidden inputs). This makes the interface inaccessible for keyboard navigation.
📸 Before/After: Before, keyboard focus was invisible on the edit button and theme options. After, the edit button becomes visible on focus, and theme options show a standard focus ring.
♿ Accessibility: Significantly improves keyboard navigation (WCAG 2.1.1 Keyboard and WCAG 2.4.7 Focus Visible) by ensuring all interactive elements have clear focus states.

---
*PR created automatically by Jules for task [8384657973302796707](https://jules.google.com/task/8384657973302796707) started by @ToolchainLab*