### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration via timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-24 - Fix User Enumeration via Timing Attack
+**Vulnerability:** User enumeration timing attack
+**Learning:** When mitigating timing attacks with argon2-cffi, dummy hash verification must use a structurally valid hash string to avoid early parsing exception
+**Prevention:** Use a structurally valid Argon2id hash string for dummy verifications.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -72,12 +72,20 @@ async def register_user(
     return user
 
 
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$"
+    "IRQLvfIqVc+xUioLXGgyrA$"
+    "Jb4yRrNOPibqqIkq7knSUqOWPtcYco+O+JXa5w/mhv0"
+)
+
+
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
-        return None
-    if not user.password_hash:
+    user = result.scalars().first()
+    if user is None or not user.password_hash:
+        # 🛡️ Sentinel: Mitigate timing attacks by always performing a password hash verification.
+        verify_password(password, _DUMMY_HASH)
         return None
     if not verify_password(password, user.password_hash):
         return None


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: User enumeration was possible because `authenticate_user` returned early when a user was not found, resulting in a measurable difference in response time between valid and invalid usernames.
- 🎯 Impact: An attacker could enumerate valid usernames by measuring authentication response times.
- 🔧 Fix: Always perform an Argon2 verification using a structurally valid dummy hash (`_DUMMY_HASH`) if a user is not found or has no password hash.
- ✅ Verification: Run `uv run pytest tests/` to confirm that standard auth flow remains unbroken.

---
*PR created automatically by Jules for task [12865182596486169965](https://jules.google.com/task/12865182596486169965) started by @ToolchainLab*