### PR TITLE
🧭 Atlas: Replace hand-written env var list with generated config loader docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var docs drift
+**Learning:** Manually updating environment variable docs in README.md inevitably leads to drift when new settings are added to Pydantic BaseSettings.
+**Action:** Use Pydantic's `Field(description="...")` directly on the model, and use a script to automatically parse `model_fields` and generate the markdown table in the README between HTML comment delimiters. Run this script with a `--check` flag in CI.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- GENERATED_ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
-| `H4CKATH0N_ENV` | `development` | `development` or `production` |
+| `H4CKATH0N_ENV` | `development` | development or production |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | `empty` | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | `empty` | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY` or `H4CKATH0N_OPENAI_API_KEY` | `empty` | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | `empty` | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of via Redis |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use (local or s3) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory path for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (file or smtp) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | `empty` | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | `empty` | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | `empty` | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- GENERATED_ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script to generate README.md environment variables table."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    from h4ckath0n.config import Settings
+
+    rows = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+        if name == "openai_api_key":
+            var_name = "`OPENAI_API_KEY` or `H4CKATH0N_OPENAI_API_KEY`"
+        else:
+            var_name = f"`{var_name}`"
+
+        default = field.default if field.default is not None else ""
+        if isinstance(default, str) and not default:
+            default = "empty"
+        elif isinstance(default, bool):
+            default = str(default).lower()
+        elif isinstance(default, list) and not default:
+            default = "[]"
+
+        desc = field.description or ""
+        rows.append(f"| {var_name} | `{default}` | {desc} |")
+
+    table_str = "\n".join(rows) + "\n"
+
+    readme_path = Path("README.md")
+    readme_content = readme_path.read_text()
+
+    start_marker = "<!-- GENERATED_ENV_VARS_START -->\n"
+    end_marker = "<!-- GENERATED_ENV_VARS_END -->"
+
+    pattern = re.compile(rf"{re.escape(start_marker)}.*?{re.escape(end_marker)}", re.DOTALL)
+
+    if not pattern.search(readme_content):
+        print("Markers not found in README.md")
+        sys.exit(1)
+
+    new_content = pattern.sub(f"{start_marker}{table_str}{end_marker}", readme_content)
+
+    if args.check:
+        if new_content != readme_content:
+            print("❌ README.md environment variables table is out of date.")
+            print("Run `uv run scripts/generate_env_docs.py` to update it.")
+            sys.exit(1)
+        print("✅ README.md environment variables table is up to date.")
+    else:
+        readme_path.write_text(new_content)
+        print("✅ README.md updated successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,78 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="development or production")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run jobs inline in development instead of via Redis"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend to use (local or s3)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory path for local storage"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum file upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field("file", description="Email backend to use (file or smtp)")
+    email_from: str = Field("noreply@localhost", description="Default from address for emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP server username")
+    smtp_password: str = Field("", description="SMTP server password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Use SSL for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 What: Replaced manually maintained configuration table in README with a generated table parsed directly from pydantic BaseSettings fields.
- 🎯 Why: Solves a significant doc gap where new environment variables were repeatedly added to `config.py` but missed in `README.md`.
- 🧪 Verification: Run `uv run scripts/generate_env_docs.py` to auto-generate, or run with `--check` to fail if there's drift.
- 🔒 Drift Prevention: Added `generate_env_docs.py --check` step to the CI backend job. 
- 🗺️ Evidence: `src/h4ckath0n/config.py` is the single source of truth.

---
*PR created automatically by Jules for task [754200031496539356](https://jules.google.com/task/754200031496539356) started by @ToolchainLab*