### PR TITLE
∷ Vector: Centralize scope parsing logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,4 @@
+## 2025-04-25 - Extracted shared parsing pipelines for strings
+
+**Learning:** Comma-separated strings (like scopes) were being manually parsed and stripped across `cli.py` and `dependencies.py` using `.split(",")`, creating subtle inconsistencies when handling leading/trailing whitespaces around empty fields or building sets directly.
+**Action:** When working with structured strings or list transformations, always abstract the logic into a pure FP-style data processing pipeline (`filter`, `map`) inside a central `scopes.py` module to preserve order determinism, guarantee uniform cleanup, and reduce duplicate logic across the backend.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -83,12 +84,12 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[str] = set(filter(None, map(str.strip, scopes)))
+    needed = set(parse_scopes(",".join(scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
-            missing_scopes = ", ".join(missing)
+            missing_scopes = ", ".join(sorted(missing))
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Missing scope(s): {missing_scopes}",

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,21 @@
+"""Scope parsing and normalization helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a list of cleaned scopes."""
+    return list(filter(None, map(str.strip, raw.split(","))))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of scopes into a normalized, order-preserving comma-separated string."""
+    parts = filter(None, (s.strip() for s in scopes if s is not None))
+    return ",".join(dict.fromkeys(parts))
+
+
+def normalize_scopes(raw: str) -> str:
+    """Normalize a comma-separated scopes string, deduplicating and preserving order."""
+    return format_scopes(parse_scopes(raw))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, normalize_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,9 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
-            for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+            existing = parse_scopes(user.scopes)
+            new_scopes = parse_scopes(",".join(args.scope))
+            user.scopes = format_scopes(existing + new_scopes)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +473,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
-            to_remove = {s.strip() for s in args.scope}
+            existing = parse_scopes(user.scopes)
+            to_remove = set(parse_scopes(",".join(args.scope)))
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +502,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = normalize_scopes(args.scopes)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -125,28 +124,6 @@ class TestAlembicUrlNormalization:
         exit_code = cli_module._cmd_db_migrate_current(args)
         assert exit_code == 0
         assert make_url(captured["sqlalchemy.url"]) == make_url("sqlite:///./test.db")
-
-
-# ---------------------------------------------------------------------------
-# Scopes normalization
-# ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,4 +1,3 @@
-
 from h4ckath0n.auth.scopes import format_scopes, normalize_scopes, parse_scopes
 
 

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,0 +1,28 @@
+
+from h4ckath0n.auth.scopes import format_scopes, normalize_scopes, parse_scopes
+
+
+def test_parse_scopes() -> None:
+    assert parse_scopes("") == []
+    assert parse_scopes("a,b,c") == ["a", "b", "c"]
+    assert parse_scopes("a, b, c") == ["a", "b", "c"]
+    assert parse_scopes(" a , b , c ") == ["a", "b", "c"]
+    assert parse_scopes("a,,b") == ["a", "b"]
+    assert parse_scopes("a, a, b") == ["a", "a", "b"]
+
+
+def test_format_scopes() -> None:
+    assert format_scopes([]) == ""
+    assert format_scopes(["a", "b", "c"]) == "a,b,c"
+    assert format_scopes(["a", "b", "a"]) == "a,b"
+    assert format_scopes([" a ", "b", " c "]) == "a,b,c"
+    assert format_scopes(["a", "", "b", None]) == "a,b"  # type: ignore
+
+
+def test_normalize_scopes() -> None:
+    assert normalize_scopes("") == ""
+    assert normalize_scopes("a,b,c") == "a,b,c"
+    assert normalize_scopes("a, b, c") == "a,b,c"
+    assert normalize_scopes(" a , b , c ") == "a,b,c"
+    assert normalize_scopes("a,a,b,c") == "a,b,c"
+    assert normalize_scopes("a,,b") == "a,b"


### PR DESCRIPTION
- 💡 What: Extract inline `.split(",")` string parsing for scopes into a centralized, pure helper pipeline in `src/h4ckath0n/auth/scopes.py`.
- 🎯 Why: Scope parsing was duplicated across `cli.py`, `auth/dependencies.py`, and `auth/session_router.py`. Some implementations missed subtle edge cases (e.g., whitespace padding around individual scopes wasn't fully removed before sets).
- 🧠 Design: Centralize into `parse_scopes`, `format_scopes`, and `normalize_scopes` functions that enforce order-preserving deduplication using `dict.fromkeys`.
- λ FP Angle: Replaces scattered `for s in .split(",") if s` logic with explicit, composable transformation pipelines (`map`, `filter`) and immutable lists.
- ✅ Verification: Run `uv run pytest tests/` with new coverage in `tests/test_scopes.py`.
- 🧪 Edge cases: Tested empty strings, trailing commas, whitespace padding, duplicate values.
- ⚠️ Risk: Low; behavior preserving. Ensures deterministic output format across the app.

---
*PR created automatically by Jules for task [8737677331887701697](https://jules.google.com/task/8737677331887701697) started by @ToolchainLab*