### PR TITLE
🎨 Palette: Add Enter-to-submit and prevent prompt mangling in AI Chat

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-25 - Prevent prompt mangling and text overlap in AI Chat textareas
+**Learning:** During async operations (like LLM streaming), the textarea can remain editable which can result in the prompt getting mangled by subsequent keystrokes before the streaming finishes. Also, absolute-positioned hints inside textareas can obscure user text.
+**Action:** When implementing Enter-to-submit keyboard interactions in chat interfaces, apply the `disabled` attribute directly to the textarea during async operations to prevent prompt mangling. Apply adequate bottom padding (e.g., `pb-8`) to the textarea to prevent text overlap with absolutely positioned keyboard `<kbd>` hints.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Dashboard.tsx
@@ -292,12 +292,28 @@ export function Dashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            <textarea
-              value={aiPrompt}
-              onChange={(e) => setAiPrompt(e.target.value)}
-              placeholder="Type a prompt…"
-              className="w-full h-24 p-3 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-            />
+            <div className="relative">
+              <textarea
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    if (aiPrompt.trim() && !aiStreaming) {
+                      handleAiStream();
+                    }
+                  }
+                }}
+                disabled={aiStreaming}
+                placeholder="Type a prompt…"
+                className="w-full h-24 p-3 pb-8 rounded border border-border bg-surface text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <div className="absolute bottom-3 right-3 flex items-center pointer-events-none">
+                <kbd className="hidden sm:inline-flex items-center gap-1 rounded border border-border bg-surface-alt px-1.5 font-sans text-[10px] font-medium text-text-muted">
+                  <span className="text-xs">⏎</span> Enter to send
+                </kbd>
+              </div>
+            </div>
             <Button
               onClick={handleAiStream}
               disabled={aiStreaming || !aiPrompt.trim()}


### PR DESCRIPTION
💡 What: Added Enter-to-submit keyboard interaction to the AI Chat textarea, included a `<kbd>` visual hint, added adequate padding to prevent text overlap, and disabled the textarea during streaming to prevent input mangling.
🎯 Why: To make the interface more intuitive and prevent the user from typing more input while the LLM stream is still actively writing the response.
📸 Before/After: The textarea now features an "Enter to send" keyboard hint and a disabled state during generation.
♿ Accessibility: Provided keyboard support for message submission, making form interaction faster and more accessible for keyboard users.

---
*PR created automatically by Jules for task [3903006201205294498](https://jules.google.com/task/3903006201205294498) started by @ToolchainLab*