### PR TITLE
🎨 Palette: Improve keyboard accessibility for hidden elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-26 - Keyboard accessibility for hidden interactive elements
+**Learning:** Elements hidden via `opacity-0 group-hover:opacity-100` remain invisible when focused via keyboard, and `sr-only` radio inputs nested inside interactive labels do not show focus states unless the label is explicitly styled.
+**Action:** Use `focus-visible:opacity-100` on hover-revealed elements, and `has-[:focus-visible]:ring-2` on parent labels wrapping visually hidden inputs.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -149,7 +149,7 @@ function PasskeyName({
           variant="ghost"
           data-testid="passkey-edit-btn"
           onClick={startEdit}
-          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />
@@ -294,6 +294,7 @@ export function Settings() {
                   themePreference === option
                     ? "border-primary bg-primary/5"
                     : "border-border",
+                  "has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-offset-2",
                 )}
               >
                 <input


### PR DESCRIPTION
💡 What: Added focus-visible styles to the passkey edit button and theme preference radio labels.
🎯 Why: Interactive elements hidden via opacity or `sr-only` were not visible when navigating with a keyboard, making them inaccessible to keyboard users.
📸 Before/After: Before, tabbing through the settings page skipped visible focus for these elements. After, a focus ring appears on the theme cards and the passkey edit button becomes visible on focus.
♿ Accessibility: Improves keyboard navigation (WCAG 2.1.1 Keyboard) by ensuring focus indicators are visible for interactive elements.

---
*PR created automatically by Jules for task [9193647887044982511](https://jules.google.com/task/9193647887044982511) started by @ToolchainLab*