### PR TITLE
🧭 Atlas: Replace hand-written env var lists with a generated list from config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-05-24 - Env var documentation drift
+**Learning:** The `README.md` file previously used a hand-written table to document environment variables defined in `src/h4ckath0n/config.py`. This manual process inevitably leads to drift when new settings are added or defaults changed.
+**Action:** Add a generation script `scripts/generate_env_docs.py` to parse pydantic `Settings` and update `README.md`. Ensure `README.md` includes `<!-- GENERATED_ENV_VARS_START -->` and `<!-- GENERATED_ENV_VARS_END -->` markers. Add a CI step `uv run scripts/generate_env_docs.py --check` to enforce parity.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- GENERATED_ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use (e.g. local, s3) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory path for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the application for generating links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (file or smtp) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- GENERATED_ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script: generates markdown table of env vars from Settings."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+START_MARKER = "<!-- GENERATED_ENV_VARS_START -->\n"
+END_MARKER = "<!-- GENERATED_ENV_VARS_END -->\n"
+
+
+def generate_markdown_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for field_name, field_info in Settings.model_fields.items():
+        env_name = f"H4CKATH0N_{field_name.upper()}"
+        if field_name == "env":
+            # Special override for 'env' to match existing docs
+            lines.append(f"| `{env_name}` | `development` | {field_info.description or ''} |")
+            continue
+        if field_name == "openai_api_key":
+            # Special case for OpenAI API key alias
+            lines.append(f"| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+
+        default_val = field_info.default
+        if (
+            default_val is None
+            or str(default_val) == ""
+            or (isinstance(default_val, list) and not default_val)
+        ):
+            if isinstance(default_val, list):
+                default_str = "`[]`"
+            else:
+                default_str = "empty"
+        elif str(default_val) == "PydanticUndefined":
+            if field_info.default_factory is list:
+                default_str = "`[]`"
+            elif field_info.default_factory is dict:
+                default_str = "`{}`"
+            else:
+                default_str = "empty"
+        elif isinstance(default_val, bool):
+            default_str = f"`{str(default_val).lower()}`"
+        else:
+            default_str = f"`{default_val}`"
+
+        # Specific overrides to match current README exactly
+        if field_name == "rp_id":
+            default_str = "`localhost` in development"
+        elif field_name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        desc = field_info.description or ""
+        lines.append(f"| `{env_name}` | {default_str} | {desc} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def update_readme(table_content: str, check_only: bool) -> int:
+    text = README.read_text(encoding="utf-8")
+
+    start_idx = text.find(START_MARKER)
+    end_idx = text.find(END_MARKER)
+
+    if start_idx == -1 or end_idx == -1:
+        print("Error: Markers not found in README.md")
+        return 1
+
+    before = text[: start_idx + len(START_MARKER)]
+    after = text[end_idx:]
+
+    new_text = before + table_content + after
+
+    if check_only:
+        if text != new_text:
+            print("❌ Environment variable documentation is out of sync!")
+            print("Run 'uv run scripts/generate_env_docs.py' to update README.md.")
+            return 1
+        print("✅ Environment variable documentation is up to date.")
+        return 0
+
+    README.write_text(new_text, encoding="utf-8")
+    print("✅ README.md updated.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check for drift without writing")
+    args = parser.parse_args()
+
+    table = generate_markdown_table()
+    return update_readme(table, args.check)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -25,7 +25,7 @@ def generate_markdown_table() -> str:
             continue
         if field_name == "openai_api_key":
             # Special case for OpenAI API key alias
-            lines.append(f"| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+            lines.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
 
         default_val = field_info.default
         if (
@@ -33,10 +33,7 @@ def generate_markdown_table() -> str:
             or str(default_val) == ""
             or (isinstance(default_val, list) and not default_val)
         ):
-            if isinstance(default_val, list):
-                default_str = "`[]`"
-            else:
-                default_str = "empty"
+            default_str = "`[]`" if isinstance(default_val, list) else "empty"
         elif str(default_val) == "PydanticUndefined":
             if field_info.default_factory is list:
                 default_str = "`[]`"

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+import pydantic
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,91 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = pydantic.Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = pydantic.Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = pydantic.Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = pydantic.Field(
+        "", description="WebAuthn relying party ID, required in production"
+    )
+    origin: str = pydantic.Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = pydantic.Field(
+        300, description="WebAuthn challenge TTL in seconds"
+    )
+    user_verification: str = pydantic.Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = pydantic.Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = pydantic.Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = pydantic.Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = pydantic.Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = pydantic.Field(
+        False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = pydantic.Field(
+        "", description="Alternate OpenAI API key for the LLM wrapper"
+    )
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = pydantic.Field("", description="Redis connection URL")
+    jobs_inline_in_dev: bool = pydantic.Field(
+        True, description="Run jobs inline in development mode"
+    )
+    jobs_default_queue: str = pydantic.Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = pydantic.Field(
+        "local", description="Storage backend to use (e.g. local, s3)"
+    )
+    storage_dir: str = pydantic.Field(
+        "./.h4ckath0n_storage", description="Directory path for local storage backend"
+    )
+    max_upload_bytes: int = pydantic.Field(
+        50 * 1024 * 1024, description="Maximum allowed upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = pydantic.Field(
+        "http://localhost:5173", description="Base URL of the application for generating links"
+    )
+    email_backend: str = pydantic.Field("file", description="Email backend to use (file or smtp)")
+    email_from: str = pydantic.Field(
+        "noreply@localhost", description="Default from address for outgoing emails"
+    )
+    email_outbox_dir: str = pydantic.Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email backend"
+    )
+    smtp_host: str = pydantic.Field("", description="SMTP server host")
+    smtp_port: int = pydantic.Field(587, description="SMTP server port")
+    smtp_username: str = pydantic.Field("", description="SMTP username")
+    smtp_password: str = pydantic.Field("", description="SMTP password")
+    smtp_starttls: bool = pydantic.Field(True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = pydantic.Field(False, description="Use SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = pydantic.Field(False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the manual environment variable table in `README.md` with a dynamically generated table powered by pydantic `Field` descriptions in `src/h4ckath0n/config.py`.
🎯 Why: To eliminate the risk of documentation drift as new configuration options are added or defaults changed.
🧪 Verification: Ran `uv run scripts/generate_env_docs.py` locally and verified checks with pytest and ruff.
🔒 Drift Prevention: Added `scripts/generate_env_docs.py --check` to `.github/workflows/ci.yml` to fail CI if the documentation is out of sync with the codebase.
🗺️ Evidence: `src/h4ckath0n/config.py`, `.github/workflows/ci.yml`.

---
*PR created automatically by Jules for task [1827567867775883538](https://jules.google.com/task/1827567867775883538) started by @ToolchainLab*