### PR TITLE
∷ Vector: Centralize scope string parsing

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,4 @@
+
+## 2024-04-27 - Centralized scope parsing pipeline
+**Learning:** Parsing comma-separated string logic like scopes was scattered with inline `.split(",")` calls causing brittle and repeated edge-case handling across CLI and routers.
+**Action:** Centralized extraction and normalization logic into pure helper pipelines (`h4ckath0n.scopes`) to maintain FP style composability and provide one robust source of truth.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
+from h4ckath0n.scopes import parse_scopes
 
 _bearer = HTTPBearer(
     scheme_name="DeviceJWT",
@@ -86,7 +87,7 @@ def require_scopes(*scopes: str) -> Any:
     needed: set[str] = set(filter(None, map(str.strip, scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -8,6 +8,7 @@ from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
 from h4ckath0n.realtime.auth import AuthContext
+from h4ckath0n.scopes import parse_scopes
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -23,6 +23,7 @@ from h4ckath0n.db.migrations.runtime import (
     packaged_migrations_dir,
     run_upgrade_to_head,
 )
+from h4ckath0n.scopes import format_scopes, parse_scopes
 
 # ---------------------------------------------------------------------------
 # Exit codes
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,8 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
-            for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+            existing = parse_scopes(user.scopes)
+            user.scopes = format_scopes(existing + args.scope)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +472,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
-            to_remove = {s.strip() for s in args.scope}
+            existing = parse_scopes(user.scopes)
+            to_remove = set(parse_scopes(",".join(args.scope)))
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +501,8 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            raw_scopes = [args.scopes] if "," not in args.scopes else args.scopes.split(",")
+            user.scopes = format_scopes(raw_scopes)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/src/h4ckath0n/scopes.py
+++ b/src/h4ckath0n/scopes.py
@@ -1,0 +1,13 @@
+"""Scope normalization helpers."""
+
+from __future__ import annotations
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a deduplicated list."""
+    return list(dict.fromkeys(filter(None, map(str.strip, raw.split(",")))))
+
+
+def format_scopes(scopes: list[str]) -> str:
+    """Format a list of scopes into a deduplicated comma-separated string."""
+    return ",".join(dict.fromkeys(filter(None, map(str.strip, scopes))))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,8 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
+from h4ckath0n.scopes import format_scopes
 from tests.conftest import run_cli as _run_cli
 
 # ---------------------------------------------------------------------------
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert format_scopes(["a", "b", "c"]) == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert format_scopes(["a", "b", "a"]) == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert format_scopes([" a ", " b ", " c "]) == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert format_scopes(["a", "", "b", "", ""]) == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert format_scopes([""]) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Extracted `parse_scopes` and `format_scopes` into a shared `h4ckath0n.scopes` module and replaced inline `.split(",")` and `_normalize_scopes` logic across the codebase.
- 🎯 Why: Scope parsing and normalization was scattered in `auth.dependencies`, `auth.session_router`, and `cli`, causing duplication and slight inconsistencies in trimming, empty string handling, and deduplication.
- 🧠 Design: A small, pure, FP-style pipeline (using `dict.fromkeys(filter(None, map(str.strip, ...)))`) serves as the single source of truth for both reading and writing scope lists, replacing ad hoc list comprehensions and sets.
- λ FP Angle: Reduces inline mutation and scattered logic, providing a testable declarative transformation pipeline that safely extracts deduplicated arrays from string fields and vice-versa.
- ✅ Verification: Ran complete pytest test suite and ruff checks.
- 🧪 Edge cases: Re-verified empty strings, spaces, and repeated scopes behave identically to previous tests but now use the centralized format.
- ⚠️ Risk: Low; behavior is identical, just sharing logic.

---
*PR created automatically by Jules for task [621214772616596843](https://jules.google.com/task/621214772616596843) started by @ToolchainLab*