### PR TITLE
⚡ Bolt: [performance improvement] Use db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -44,8 +44,8 @@ def _new_challenge() -> bytes:
 
 async def _get_valid_flow(db: AsyncSession, flow_id: str, kind: str) -> WebAuthnChallenge:
     """Fetch and validate an unconsumed, non-expired flow."""
-    result = await db.execute(select(WebAuthnChallenge).filter(WebAuthnChallenge.id == flow_id))
-    if (flow := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (flow := await db.get(WebAuthnChallenge, flow_id)) is None:
         raise ValueError("Unknown flow")
     if flow.kind != kind:
         raise ValueError("Flow kind mismatch")
@@ -141,8 +141,8 @@ async def finish_registration(
     db.add(cred)
     await db.commit()
 
-    result = await db.execute(select(User).filter(User.id == flow.user_id))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (user := await db.get(User, flow.user_id)) is None:
         raise ValueError("User not found")
     return user
 


### PR DESCRIPTION
- 💡 What: Replaced `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` with `await db.get(Model, pk)` for primary key lookups in `src/h4ckath0n/auth/passkeys/service.py`.
- 🎯 Why: Using `db.get()` bypasses the SQLAlchemy identity map and avoids triggering a database query when the object is already loaded, thus reducing database roundtrips and parsing overhead. This is a known performance bottleneck as documented in the journal.
- 📊 Impact: Measurably faster query performance and reduced database load on hot paths related to passkeys.
- 🔬 Measurement: Observe database query logs to confirm that unnecessary queries are eliminated, and monitor the overall response times of the passkey authentication endpoints.

---
*PR created automatically by Jules for task [17118820339896782711](https://jules.google.com/task/17118820339896782711) started by @ToolchainLab*