### PR TITLE
🧭 Atlas: Generate env vars doc from config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2025-04-27 - Generate env vars doc from config loader
+**Learning:** Environment variables documented in README.md naturally drift from `pydantic-settings` classes. A generated approach parsing `pydantic.Field` properties with a CI `--check` mode enforces 100% parity and prevents outdated or missed documentation.
+**Action:** Always parse configuration loaders directly to generate configuration documentation instead of manually copying the definitions to markdown files. Use explicit markers in README files and add CI steps to enforce validation.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- GENERATED_ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -174,7 +175,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of Redis |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (e.g. read-only restrictions) |
+<!-- GENERATED_ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env -S uv run python
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+README = REPO_ROOT / "README.md"
+
+
+def generate_table():
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        if name == "env_prefix":
+            continue
+        if name == "openai_api_key":
+            lines.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+        env_name = f"H4CKATH0N_{name.upper()}"
+        default_val = field.default
+        if default_val == "":
+            default_str = "empty"
+        elif default_val == []:
+            default_str = "`[]`"
+        elif isinstance(default_val, bool):
+            default_str = f"`{'true' if default_val else 'false'}`"
+        else:
+            default_str = f"`{default_val}`"
+
+        desc = field.description or ""
+        lines.append(f"| `{env_name}` | {default_str} | {desc} |")
+    return "\n".join(lines)
+
+
+def main():
+    check_mode = "--check" in sys.argv
+    readme_text = README.read_text()
+    table = generate_table()
+
+    start_marker = "<!-- GENERATED_ENV_VARS_START -->"
+    end_marker = "<!-- GENERATED_ENV_VARS_END -->"
+
+    pattern = re.compile(rf"({start_marker}\n).*?(\n{end_marker})", re.DOTALL)
+
+    if not pattern.search(readme_text):
+        print(f"❌ Could not find {start_marker} and {end_marker} in README.md")
+        return 1
+
+    new_readme = pattern.sub(rf"\g<1>{table}\g<2>", readme_text)
+
+    if check_mode:
+        if new_readme != readme_text:
+            print(
+                "❌ Environment variables documentation is out of date. "
+                "Run `uv run scripts/generate_env_docs.py` to update."
+            )
+            return 1
+        print("✅ Environment variables documentation is up to date.")
+        return 0
+    else:
+        README.write_text(new_readme)
+        print("✅ Updated environment variables documentation in README.md")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+import pydantic
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,88 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = pydantic.Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = pydantic.Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = pydantic.Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = pydantic.Field(
+        "", description="WebAuthn relying party ID, required in production"
+    )
+    origin: str = pydantic.Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = pydantic.Field(
+        300, description="WebAuthn challenge TTL in seconds"
+    )
+    user_verification: str = pydantic.Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = pydantic.Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = pydantic.Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = pydantic.Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = pydantic.Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = pydantic.Field(
+        False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = pydantic.Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = pydantic.Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = pydantic.Field(
+        True, description="Run jobs inline in development instead of Redis"
+    )
+    jobs_default_queue: str = pydantic.Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = pydantic.Field("local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = pydantic.Field(
+        "./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = pydantic.Field(
+        50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = pydantic.Field(
+        "http://localhost:5173", description="Base URL of the frontend application for email links"
+    )
+    email_backend: str = pydantic.Field("file", description="Email backend (`file` or `smtp`)")
+    email_from: str = pydantic.Field(
+        "noreply@localhost", description="Default sender address for outbound emails"
+    )
+    email_outbox_dir: str = pydantic.Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = pydantic.Field("", description="SMTP server hostname")
+    smtp_port: int = pydantic.Field(587, description="SMTP server port")
+    smtp_username: str = pydantic.Field("", description="SMTP authentication username")
+    smtp_password: str = pydantic.Field("", description="SMTP authentication password")
+    smtp_starttls: bool = pydantic.Field(True, description="Use STARTTLS for SMTP connections")
+    smtp_ssl: bool = pydantic.Field(False, description="Use SSL/TLS for SMTP connections")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = pydantic.Field(
+        False, description="Enable demo mode (e.g. read-only restrictions)"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Generate environment variables table in README from `pydantic` fields.
🎯 Why: To prevent drift between `src/h4ckath0n/config.py` and `README.md` and keep configuration docs accurate.
🧪 Verification: Ran `uv run scripts/generate_env_docs.py --check`, pytest, and ruff formatting.
🔒 Drift Prevention: Added `scripts/generate_env_docs.py` and a corresponding step in `.github/workflows/ci.yml` to check for parity during CI.
🗺️ Evidence: `src/h4ckath0n/config.py` is the source of truth for config variables.

---
*PR created automatically by Jules for task [5137541098994091457](https://jules.google.com/task/5137541098994091457) started by @ToolchainLab*