### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack user enumeration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-28 - Timing Attack in Password Authentication
+**Vulnerability:** The `authenticate_user` function returns early without verifying a hash if the user does not exist or has no password hash set. This leads to observable time differences, permitting user enumeration.
+**Learning:** Returning early or skipping hash verification when a user is not found bypasses timing mitigations provided by the hashing algorithm.
+**Prevention:** Always perform a dummy hash verification against a structurally valid Argon2id dummy hash when authentication fails early.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -17,6 +17,12 @@ from h4ckath0n.auth.models import Device, PasswordResetToken, User
 from h4ckath0n.config import Settings
 from h4ckath0n.rng import token_urlsafe as _rng_urlsafe
 
+# A structurally valid Argon2id dummy hash string for timing attack mitigation.
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$XeHK+QXEty64t/OsrdXo9Q"
+    "$sxzQIkAgRicaSQeyqukmf0EBcAQGSffIPCFJGPx7f/8"
+)
+
 
 def _hash_token(token: str) -> str:
     """SHA-256 hash a token for storage."""
@@ -75,11 +81,13 @@ async def register_user(
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
-        return None
-    if not user.password_hash:
-        return None
-    if not verify_password(password, user.password_hash):
+    user = result.scalars().first()
+
+    # Mitigate timing attacks by always performing a verification.
+    actual_hash = user.password_hash if user and user.password_hash else _DUMMY_HASH
+    is_valid = verify_password(password, actual_hash)
+
+    if not user or not user.password_hash or not is_valid:
         return None
     return user
 


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: `authenticate_user` returns early when a user is not found, making it vulnerable to timing attacks and user enumeration.
- 🎯 Impact: Attackers can enumerate registered users by observing the response time.
- 🔧 Fix: Always verify the provided password against a structurally valid Argon2 dummy hash when a user isn't found.
- ✅ Verification: Ensured the full test suite passes and verified dummy hash structure locally.

---
*PR created automatically by Jules for task [13534277824805905083](https://jules.google.com/task/13534277824805905083) started by @ToolchainLab*