### PR TITLE
∷ Vector: [code quality improvement] Centralize and fix scope parsing logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Centralize String Normalization
+**Learning:** `user.scopes` was parsed inconsistently using ad-hoc `filter(None, map(str.strip, string.split(",")))` or list comprehensions or sets. Sets destroyed determinism during CLI mutations.
+**Action:** Centralize order-preserving deduplication for comma-separated fields into pure formatters/parsers in their domain schema.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -85,8 +85,10 @@ def require_scopes(*scopes: str) -> Any:
 
     needed: set[str] = set(filter(None, map(str.strip, scopes)))
 
+    from h4ckath0n.auth.schemas import parse_scopes
+
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,10 +2,26 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
+
+
+def parse_scopes(raw: str | None) -> list[str]:
+    """Parse comma-separated string into deduplicated, trimmed scopes preserving order."""
+    if not raw:
+        return []
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of strings into a deduplicated, comma-separated scopes string."""
+    parts = filter(None, map(str.strip, scopes))
+    return ",".join(dict.fromkeys(parts))
 
 
 def _validate_display_name(v: str | None) -> str | None:

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends
 
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
-from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.schemas import SessionResponse, parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +22,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.schemas import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,11 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                if (cleaned := scope.strip()) not in existing:
+                    existing.append(cleaned)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +475,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +504,9 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(
+                [args.scopes] if "," not in args.scopes else args.scopes.split(",")
+            )
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_auth_schemas.py
+++ b/tests/test_auth_schemas.py
@@ -1,0 +1,18 @@
+from h4ckath0n.auth.schemas import format_scopes, parse_scopes
+
+
+def test_parse_scopes():
+    assert parse_scopes(None) == []
+    assert parse_scopes("") == []
+    assert parse_scopes("a,b,c") == ["a", "b", "c"]
+    assert parse_scopes(" a , b , c ") == ["a", "b", "c"]
+    assert parse_scopes("a,b,a,c") == ["a", "b", "c"]
+    assert parse_scopes("a,,b") == ["a", "b"]
+
+
+def test_format_scopes():
+    assert format_scopes([]) == ""
+    assert format_scopes(["a", "b", "c"]) == "a,b,c"
+    assert format_scopes([" a ", " b ", " c "]) == "a,b,c"
+    assert format_scopes(["a", "b", "a", "c"]) == "a,b,c"
+    assert format_scopes(["a", "", "b"]) == "a,b"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -130,23 +129,6 @@ class TestAlembicUrlNormalization:
 # ---------------------------------------------------------------------------
 # Scopes normalization
 # ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Centralized scope parsing and formatting logic into pure functional helpers (`parse_scopes` and `format_scopes`) in `schemas.py`. Replaced ad-hoc string splitting across `dependencies.py`, `session_router.py`, and `cli.py`. Fixed order-destruction in the CLI's add-scope command.
- 🎯 Why: Scope parsing logic (`user.scopes.split(",")`) was duplicated in 4 different files, with inconsistent behavior (some places used `set()` which destroyed ordering, some used lists, some `filter()`). Centralizing this prevents drift and edge-case bugs.
- 🧠 Design: Created two small, pure helpers that handle whitespace trimming, empty string filtering, and order-preserving deduplication consistently.
- λ FP Angle: Replaced ad-hoc in-place mutation and inconsistent parsing with a pure, deterministic transformation pipeline.
- ✅ Verification: Ran `pytest` suite and added dedicated unit tests for the new helpers.
- 🧪 Edge cases: Tested empty strings, `None`, excessive whitespace, and duplicate values explicitly in the new `test_auth_schemas.py`.
- ⚠️ Risk: Low. Behavior is functionally identical but more robust, maintaining determinism.

---
*PR created automatically by Jules for task [4846236345165798626](https://jules.google.com/task/4846236345165798626) started by @ToolchainLab*