### PR TITLE
🧭 Atlas: Replace hand-written env var lists with a generated list from config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var table drifts from config loader
+**Learning:** Hardcoding environment variable tables in README.md inevitably leads to drift as new configuration options are added (like Redis, Storage, and Email).
+**Action:** Use `pydantic.Field(description="...")` to document settings directly in `src/h4ckath0n/config.py` and enforce parity by using a documentation generator script running in CI (`scripts/generate_env_docs.py --check`).

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- GENERATED_ENV_VARS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of queueing |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the web app (used in emails) |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host for email sending |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `False` | Use explicit SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- GENERATED_ENV_VARS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: enforce parity between config.py and README.md env vars."""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add src to sys.path so we can import from h4ckath0n
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- GENERATED_ENV_VARS_START -->\n"
+END_MARKER = "<!-- GENERATED_ENV_VARS_END -->\n"
+
+
+def generate_table() -> str:
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+    for name, field in Settings.model_fields.items():
+        env_name = f"H4CKATH0N_{name.upper()}"
+        if name == "openai_api_key":
+            # Special case for OpenAI API Key (multiple vars)
+            lines.append(f"| `OPENAI_API_KEY` | empty | {field.description} |")
+            lines.append(f"| `{env_name}` | empty | Alternate {field.description} |")
+            continue
+
+        default_val = field.default if field.default_factory is None else "[]"
+        default_str = (
+            f"`{default_val}`" if not isinstance(default_val, str) or default_val else "empty"
+        )
+        if isinstance(default_val, str) and default_val:
+            default_str = f"`{default_val}`"
+
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+        elif name == "auto_upgrade":
+            default_str = "`false`"
+        elif (
+            name == "password_auth_enabled" or name == "first_user_is_admin" or name == "demo_mode"
+        ):
+            default_str = "`false`"
+        elif name == "jobs_inline_in_dev" or name == "smtp_starttls":
+            default_str = "`true`"
+
+        desc = field.description or ""
+        lines.append(f"| `{env_name}` | {default_str} | {desc} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if README is up to date")
+    args = parser.parse_args()
+
+    table = generate_table()
+    readme_content = README.read_text()
+
+    if START_MARKER not in readme_content or END_MARKER not in readme_content:
+        print("❌ Markers not found in README.md")
+        return 1
+
+    start_idx = readme_content.index(START_MARKER) + len(START_MARKER)
+    end_idx = readme_content.index(END_MARKER)
+
+    current_table = readme_content[start_idx:end_idx]
+
+    if args.check:
+        if current_table != table:
+            print("❌ README.md environment variables table is out of date.")
+            print("Run `uv run scripts/generate_env_docs.py` to update it.")
+            return 1
+        print("✅ README.md environment variables table is up to date.")
+        return 0
+
+    new_content = readme_content[:start_idx] + table + readme_content[end_idx:]
+    README.write_text(new_content)
+    print("✅ README.md environment variables table updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -39,9 +39,7 @@ def generate_table() -> str:
             default_str = "`localhost` in development"
         elif name == "origin":
             default_str = "`http://localhost:8000` in development"
-        elif name == "auto_upgrade":
-            default_str = "`false`"
-        elif (
+        elif name == "auto_upgrade" or (
             name == "password_auth_enabled" or name == "first_user_is_admin" or name == "demo_mode"
         ):
             default_str = "`false`"

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,83 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline in development instead of queueing"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL for the web app (used in emails)"
+    )
+    email_backend: str = Field(default="file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = Field(default="", description="SMTP host for email sending")
+    smtp_port: int = Field(default=587, description="SMTP port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use explicit SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the manual environment variable table in `README.md` with an automatically generated one using `scripts/generate_env_docs.py` and `pydantic.Field`.
🎯 Why: The configuration table had drifted from `src/h4ckath0n/config.py` (missing Redis, Storage, and Email settings), which misleads new contributors.
🧪 Verification: Run `uv run scripts/generate_env_docs.py --check` locally.
🔒 Drift Prevention: Added `generate_env_docs.py --check` to the CI pipeline in `.github/workflows/ci.yml`.
🗺️ Evidence: `src/h4ckath0n/config.py`

---
*PR created automatically by Jules for task [9953125104621176713](https://jules.google.com/task/9953125104621176713) started by @ToolchainLab*