### PR TITLE
∷ Vector: Extract pure helper for display_name validation

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Extract pure helper for field validation
+**Learning:** Pydantic validators can be shared by assigning `field_validator("field_name")(pure_function)` directly, removing the need for duplicated classmethods across different schemas.
+**Action:** Use this pattern to extract and reuse pure validation helpers for shared concepts (like display names) instead of repeating inline `@field_validator` methods.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, clean_display_name
 
 # -- Registration --
 
@@ -18,13 +18,7 @@ class PasskeyRegisterStartRequest(BaseModel):
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
 
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    _clean_display_name = field_validator("display_name")(clean_display_name)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -8,13 +8,11 @@ from pydantic import BaseModel, EmailStr, Field, field_validator
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
-    """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
+def clean_display_name(v: str) -> str:
+    """Trim whitespace and reject empty values."""
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
 
 
@@ -35,13 +33,7 @@ class RegisterRequest(DeviceBindingMixin):
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
 
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    _clean_display_name = field_validator("display_name")(clean_display_name)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted identical `display_name` validation logic from `RegisterRequest` and `PasskeyRegisterStartRequest` into a single pure helper `clean_display_name` in `src/h4ckath0n/auth/schemas.py`. Replaced an unused `_validate_display_name` function.
- 🎯 Why: Removes duplicated validation logic, ensuring a single source of truth for display name normalization and validation.
- 🧠 Design: By defining the validation logic as a pure standalone function, it can be easily shared across different Pydantic models. We use `field_validator("display_name")(clean_display_name)` to bind the pure function to the Pydantic models cleanly without redefining the logic.
- λ FP Angle: Replaces inline, class-bound validation mutation with a pure, composable helper function, moving the codebase towards cleaner declarative transformations.
- ✅ Verification: Ran `pytest -v`, `ruff format --check .`, and `ruff check .` successfully.
- 🧪 Edge cases: The pure helper explicitly handles whitespace stripping and empty-after-strip rejection identically to the previous local implementations.
- ⚠️ Risk: Very low. It's a pure refactoring that preserves existing API behavior identically.

---
*PR created automatically by Jules for task [16953166191677045544](https://jules.google.com/task/16953166191677045544) started by @ToolchainLab*