### PR TITLE
⚡ Bolt: Use session.get() for primary key lookup in CLI

### DIFF
--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,10 +148,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        # ⚡ Bolt: Use session.get() for primary key lookup
+        return session.get(User, user_id)
 
+    stmt = select(User).where(User.email == email)
     return session.execute(stmt).scalars().first()
 
 


### PR DESCRIPTION
💡 What: Replace `select(User).where(User.id == user_id)` with `session.get(User, user_id)` in the CLI's `_resolve_user` function.
🎯 Why: `session.get()` utilizes the SQLAlchemy identity map, avoiding unnecessary database queries and hydration overhead if the user object is already loaded in the session.
📊 Impact: Improves CLI command performance by bypassing parsing and round-trips to the database for cached primary key lookups.
🔬 Measurement: Verified by standard test suite ensuring functionally equivalent behavior while leveraging SQLAlchemy's internal cache.

---
*PR created automatically by Jules for task [1439813156937384545](https://jules.google.com/task/1439813156937384545) started by @ToolchainLab*