### PR TITLE
🎨 Palette: [UX improvement] Add focus visibility to passkey edit button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-30 - Interactive elements hidden via group-hover require focus-visible styles
+**Learning:** Interactive elements hidden via `opacity-0 group-hover:opacity-100` are inaccessible to keyboard users because they remain transparent when receiving focus.
+**Action:** When hiding interactive elements visually using hover opacity, always append `focus-visible:opacity-100` so they become visible upon receiving keyboard focus.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -149,7 +149,7 @@ function PasskeyName({
           variant="ghost"
           data-testid="passkey-edit-btn"
           onClick={startEdit}
-          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />


### PR DESCRIPTION
💡 What: Added `focus-visible:opacity-100` to the passkey edit button.
🎯 Why: The button was hidden until hovered, but it wasn't visible when navigated to via keyboard. This makes it accessible to keyboard users.
📸 Before/After: Button is now visible when focused via keyboard.
♿ Accessibility: Added `focus-visible:opacity-100` to an element hidden via `opacity-0 group-hover:opacity-100` to ensure keyboard focus visibility.

---
*PR created automatically by Jules for task [15164813383810245560](https://jules.google.com/task/15164813383810245560) started by @ToolchainLab*