### PR TITLE
⚡ Bolt: [performance improvement] Use session.get() for user lookup by ID

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-24 - Utilize `session.get()` for Synchronous DB ID Lookups
+
+**Learning:** Just like with `await db.get()` for async database contexts, using `session.execute(select(Model).where(Model.id == pk)).scalars().first()` in a synchronous context (e.g. CLI operations) forces SQLAlchemy to query the database and re-hydrate the full object even if it's already in the session's identity map. This adds parsing and querying overhead.
+
+**Action:** Use `session.get(Model, pk)` for all primary key lookups in synchronous contexts as well. This fetches from the identity map first, significantly reducing overhead for already-loaded entities.

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,10 +148,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        # ⚡ Bolt: Use session.get() for primary key lookup
+        return session.get(User, user_id)
 
+    stmt = select(User).where(User.email == email)
     return session.execute(stmt).scalars().first()
 
 


### PR DESCRIPTION
💡 What: Replaced the SQLAlchemy `select` and `execute` pattern with `session.get(User, user_id)` in `_resolve_user` within the CLI.
🎯 Why: Using `session.get()` for primary key lookups checks the session's identity map first. This avoids unnecessary database roundtrips and bypasses parsing/hydration overhead if the object is already loaded, making user resolution significantly faster.
📊 Impact: Eliminates database query overhead for already-loaded users and avoids hydration parsing during ID-based user lookups.
🔬 Measurement: Confirm tests pass and check execution time locally for ID-based user operations in the CLI.

---
*PR created automatically by Jules for task [13714537052526591807](https://jules.google.com/task/13714537052526591807) started by @ToolchainLab*