### PR TITLE
🎨 Palette: Add keyboard focus state to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Add focus styles to absolute interactive elements
+**Learning:** When adding focus rings (`focus-visible:ring-*`) to absolutely positioned interactive elements overlaying input fields (e.g., password visibility toggles), the focus ring causes visual overflow if the container has rounded corners.
+**Action:** Explicitly apply border-radius utilities (e.g., `rounded-r-xl`) that match the parent container's shape to prevent visual overflow and maintain design cohesiveness.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-r-xl disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added a visible focus ring (`focus-visible:ring-2`) and right-rounded border radius (`rounded-r-xl`) to the password visibility toggle button.
🎯 Why: Keyboard users previously lacked visual feedback when navigating to the show/hide password button. The `rounded-r-xl` ensures the focus ring matches the container's shape and avoids visual overflow.
📸 Before/After: Before, tabbing to the button showed no outline. After, a primary-colored focus ring perfectly traces the right edge of the input.
♿ Accessibility: Ensures WCAG compliance for focus visibility (Success Criterion 2.4.7) for keyboard navigators.

---
*PR created automatically by Jules for task [13441124112311095559](https://jules.google.com/task/13441124112311095559) started by @ToolchainLab*