### PR TITLE
🛡️ Sentinel: [HIGH] Fix User Enumeration Timing Attack in Authentication

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Timing Attack in Password Authentication
+**Vulnerability:** User enumeration is possible because `authenticate_user` returns early without performing a password hash verification when a user does not exist or lacks a password.
+**Learning:** When using `argon2-cffi` to mitigate timing attacks by hashing a dummy password, the dummy hash must be a structurally valid Argon2id string (e.g., `$argon2id$v=19$...`). Using an invalid format triggers an early `InvalidHashError`, bypassing the timing mitigation.
+**Prevention:** Always define and use a structurally valid dummy hash in authentication routines to ensure consistent computation times.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -17,6 +17,11 @@ from h4ckath0n.auth.models import Device, PasswordResetToken, User
 from h4ckath0n.config import Settings
 from h4ckath0n.rng import token_urlsafe as _rng_urlsafe
 
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$WWMZ9co/uIIIEVlHGeqTHA"
+    "$8Q3lXNvbj9/T4strxcDPkOw8jsyLj6op6fHDgDOXLAY"
+)
+
 
 def _hash_token(token: str) -> str:
     """SHA-256 hash a token for storage."""
@@ -75,11 +80,13 @@ async def register_user(
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
-        return None
-    if not user.password_hash:
-        return None
-    if not verify_password(password, user.password_hash):
+    user = result.scalars().first()
+
+    hash_to_verify = user.password_hash if user and user.password_hash else _DUMMY_HASH
+
+    is_valid = verify_password(password, hash_to_verify)
+
+    if not user or not user.password_hash or not is_valid:
         return None
     return user
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** User enumeration is possible because the `authenticate_user` function returns early without performing a password hash verification when a user does not exist or lacks a password. By measuring response times, an attacker can determine if an email is registered.
🎯 **Impact:** Allows attackers to harvest valid email addresses from the system, which can be used for targeted phishing or brute-force attacks.
🔧 **Fix:** Introduced a structurally valid Argon2id `_DUMMY_HASH` and updated `authenticate_user` to always verify either the real user's hash or the dummy hash, ensuring consistent computation time across all login attempts.
✅ **Verification:** Run `uv run pytest tests/` and verify all tests pass, including new/existing auth tests. Verified that `verify_password` is called in all execution paths regardless of user existence.

---
*PR created automatically by Jules for task [13723218216951917785](https://jules.google.com/task/13723218216951917785) started by @ToolchainLab*