### PR TITLE
🧭 Atlas: Auto-generate configuration table from Pydantic models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2025-05-01 - Prevent Configuration Drift
+
+**Learning:** Env vars and configuration tables in documentation easily drift from the source of truth (`pydantic` models). While `scripts/generate_env_docs.py` existed in my head, the actual script didn't exist in the repo.
+**Action:** When updating config docs, use a generated table powered by the config loader or add a check in CI that generates and compares the docs to prevent drift.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
+
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -173,8 +175,27 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default background job queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type (e.g. `local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
+| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that env vars in config.py match the README.md table."""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+START_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+DESCRIPTIONS = {
+    "env": "`development` or `production`",
+    "database_url": "SQLAlchemy connection string",
+    "auto_upgrade": "Auto-run packaged DB migrations to head on startup",
+    "rp_id": "WebAuthn relying party ID, required in production",
+    "origin": "WebAuthn origin, required in production",
+    "webauthn_ttl_seconds": "WebAuthn challenge TTL in seconds",
+    "user_verification": "WebAuthn user verification requirement",
+    "attestation": "WebAuthn attestation preference",
+    "password_auth_enabled": "Enable password routes when the extra is installed",
+    "password_reset_expire_minutes": "Password reset token expiry in minutes",
+    "bootstrap_admin_emails": "JSON list of emails that become admin on password signup",
+    "first_user_is_admin": "First password signup becomes admin",
+    "openai_api_key": "Alternate OpenAI API key for the LLM wrapper",
+    "redis_url": "Redis connection string (optional)",
+    "jobs_inline_in_dev": "Run background jobs inline in development",
+    "jobs_default_queue": "Default background job queue name",
+    "storage_backend": "Storage backend type (e.g. `local`)",
+    "storage_dir": "Directory for local storage",
+    "max_upload_bytes": "Maximum upload size in bytes",
+    "app_base_url": "Base URL of the web application",
+    "email_backend": "Email backend (`file` or `smtp`)",
+    "email_from": "Default from address for emails",
+    "email_outbox_dir": "Directory for file-based email outbox",
+    "smtp_host": "SMTP server host",
+    "smtp_port": "SMTP server port",
+    "smtp_username": "SMTP server username",
+    "smtp_password": "SMTP server password",
+    "smtp_starttls": "Enable STARTTLS for SMTP",
+    "smtp_ssl": "Enable SSL for SMTP",
+    "demo_mode": "Enable demo mode",
+}
+
+
+def generate_table() -> str:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from h4ckath0n.config import Settings
+
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for name, field in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+        default = "empty" if field.default == "" else f"`{field.default}`"
+        default = default.replace("False", "false").replace("True", "true")
+        if name == "rp_id":
+            default = "`localhost` in development"
+        if name == "origin":
+            default = "`http://localhost:8000` in development"
+        description = field.description or DESCRIPTIONS.get(name, "")
+        lines.append(f"| `{var_name}` | {default} | {description} |")
+
+    lines.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+
+    return "\n".join(lines)
+
+
+def update_readme(check: bool = False) -> int:
+    readme_text = README.read_text()
+
+    if START_MARKER not in readme_text or END_MARKER not in readme_text:
+        print(f"❌ Could not find {START_MARKER} and {END_MARKER} in README.md")
+        return 1
+
+    start_idx = readme_text.find(START_MARKER) + len(START_MARKER)
+    end_idx = readme_text.find(END_MARKER)
+
+    table = generate_table()
+    new_readme = readme_text[:start_idx] + "\n\n" + table + "\n\n" + readme_text[end_idx:]
+
+    if check:
+        if readme_text != new_readme:
+            print(
+                "❌ README.md environment variables table is out of date. "
+                "Run `uv run scripts/generate_env_docs.py` to update it."
+            )
+            return 1
+        print("✅ README.md environment variables table is up to date.")
+        return 0
+    else:
+        README.write_text(new_readme)
+        print("✅ README.md environment variables table updated.")
+        return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check", action="store_true", help="Check if the README.md table is up to date"
+    )
+    args = parser.parse_args()
+    sys.exit(update_readme(args.check))


### PR DESCRIPTION
💡 What: Replaces the hand-written configuration table in README.md with an auto-generated table produced by a new script (`scripts/generate_env_docs.py`).
🎯 Why: Environment variables often drift between the `pydantic` model and the documentation, causing developer confusion.
🧪 Verification: Run `uv run scripts/generate_env_docs.py --check` locally, which ensures README is aligned.
🔒 Drift Prevention: Added `uv run --locked scripts/generate_env_docs.py --check` step to the CI backend job.
🗺️ Evidence: `src/h4ckath0n/config.py` is the source of truth used to map fields and defaults to the markdown output.

---
*PR created automatically by Jules for task [13313472270480192932](https://jules.google.com/task/13313472270480192932) started by @ToolchainLab*