### PR TITLE
⚡ Bolt: [performance improvement] Optimize CLI user lookup with session.get()

### DIFF
--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,10 +148,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        # ⚡ Bolt: Use session.get() for primary key lookup
+        return session.get(User, user_id)
 
+    stmt = select(User).where(User.email == email)
     return session.execute(stmt).scalars().first()
 
 


### PR DESCRIPTION
- 💡 What: Replaced `select(User).where(User.id == user_id)` with `session.get(User, user_id)` in `_resolve_user` in `src/h4ckath0n/cli.py`.
- 🎯 Why: Using `session.get()` utilizes the SQLAlchemy session identity map. This skips a database query completely if the object is already loaded in the session. Furthermore, even when hitting the database, `get()` is optimally designed for primary key lookups compared to building a custom `.where()` filter expression.
- 📊 Impact: O(1) in-memory lookup overhead if the user is already loaded in the session identity map, saving a full database roundtrip during CLI operations that lookup users by ID.
- 🔬 Measurement: Observe SQLAlchemy query logs to confirm that primary key queries are effectively routed through the identity map caching logic (where applicable in identical session lifecycles). Tests verify correct retrieval behavior remains unchanged.

---
*PR created automatically by Jules for task [7643018023100154651](https://jules.google.com/task/7643018023100154651) started by @ToolchainLab*