### PR TITLE
🎨 Palette: [UX improvement] Add focus ring to password visibility toggle

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-r-xl"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
- 💡 What: Added `focus-visible` outline, ring, and matching border radius to the password visibility toggle button in `PasswordField.tsx`.
- 🎯 Why: The button previously lacked a visible focus state, making it difficult for keyboard users to know when they had tabbed to it. The matching border radius prevents the ring from overflowing the input container's rounded corners.
- 📸 Before/After: 
  - Before: Tabbing to the eye icon showed no visual change.
  - After: Tabbing to the eye icon shows the standard primary-colored focus ring, matching the input field's styling.
- ♿ Accessibility: Improved keyboard accessibility (WCAG 2.1 SC 2.4.7 Focus Visible) by providing a clear visual indicator of focus.

---
*PR created automatically by Jules for task [4283952661159285505](https://jules.google.com/task/4283952661159285505) started by @ToolchainLab*