### PR TITLE
🧭 Atlas: Auto-generate environment variable docs to prevent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env vars table in README drifts from Pydantic Settings
+
+**Learning:** The `README.md` hand-written environment variable table gets out of sync with `src/h4ckath0n/config.py` (e.g. missing Redis, Storage, and Email settings).
+**Action:** Replaced the hand-written table with a generated section using `scripts/generate_env_docs.py` and `Pydantic` field descriptions. Added a CI step to enforce `--check`.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline synchronously in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default background job queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type (local or s3) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory path for file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload file size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend type (file or smtp) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script to generate environment variable documentation.
+
+This script parses `src/h4ckath0n/config.py` using Pydantic, extracts the fields
+and their descriptions, and updates the configuration table in `README.md`
+between the marker comments:
+<!-- BEGIN ENV VARS -->
+<!-- END ENV VARS -->
+
+Usage (from repo root):
+    uv run scripts/generate_env_docs.py [--check]
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Add src/ to sys.path so we can import the app modules
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- BEGIN ENV VARS -->\n"
+END_MARKER = "<!-- END ENV VARS -->\n"
+
+
+def format_default(val) -> str:
+    if val == "":
+        return "empty"
+    if isinstance(val, bool):
+        return f"`{str(val).lower()}`"
+    if isinstance(val, list):
+        return f"`{json.dumps(val)}`"
+    return f"`{val}`"
+
+
+def build_markdown_table() -> str:
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for name, field in Settings.model_fields.items():
+        var_name = f"`H4CKATH0N_{name.upper()}`"
+
+        # Exception for OPENAI_API_KEY
+        if name == "openai_api_key":
+            # Add OPENAI_API_KEY as an alias first
+            lines.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+            desc = "Alternate OpenAI API key for the LLM wrapper"
+        else:
+            desc = field.description or "Configuration variable"
+
+        default_str = format_default(field.default)
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        lines.append(f"| {var_name} | {default_str} | {desc} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate environment variable docs.")
+    parser.add_argument("--check", action="store_true", help="Check if docs are up to date.")
+    args = parser.parse_args()
+
+    content = README.read_text()
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print("❌ Could not find BEGIN ENV VARS or END ENV VARS markers in README.md")
+        return 1
+
+    start_idx = content.find(START_MARKER) + len(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    new_table = build_markdown_table()
+
+    new_content = content[:start_idx] + new_table + content[end_idx:]
+
+    if args.check:
+        if content != new_content:
+            print("❌ README.md environment variables are out of date!")
+            print("Run `uv run scripts/generate_env_docs.py` to update them.")
+            return 1
+        print("✅ README.md environment variables are up to date.")
+        return 0
+    else:
+        README.write_text(new_content)
+        print("✅ Updated environment variable docs in README.md")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,85 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline synchronously in development mode"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default background job queue name"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend type (local or s3)")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Local directory path for file uploads"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload file size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the application"
+    )
+    email_backend: str = Field(
+        default="file", description="Email backend type (file or smtp)"
+    )  # "file" or "smtp"
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox",
+        description="Local directory for file-based email outbox",
+    )
+    smtp_host: str = Field(default="", description="SMTP server hostname")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP server username")
+    smtp_password: str = Field(default="", description="SMTP server password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(default=False, description="Use SSL for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the manual environment variable table in `README.md` with a generated section powered by `scripts/generate_env_docs.py`, which extracts descriptions directly from Pydantic `Field` definitions in `src/h4ckath0n/config.py`.
🎯 Why: The hand-written table was missing several settings (e.g., Redis, Storage, Email configuration) and was prone to drifting as new configuration was added.
🧪 Verification: Ran `uv run ruff check .`, `uv run pytest tests/`, and verified the generated docs using `uv run scripts/generate_env_docs.py --check`.
🔒 Drift Prevention: Added `uv run --locked scripts/generate_env_docs.py --check` to the backend CI workflow.
🗺️ Evidence: `src/h4ckath0n/config.py`, `scripts/generate_env_docs.py`, `.github/workflows/ci.yml`

---
*PR created automatically by Jules for task [1944538747199440130](https://jules.google.com/task/1944538747199440130) started by @ToolchainLab*