### PR TITLE
∴ Vector: Centralize and functionalize scope normalization

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Centralize and functionalize scope normalization
+**Learning:** The CLI tool implicitly mutated state by adding `args.scope` values into an existing unordered `set` of scopes, which meant the final serialized string lost its original order. We can avoid this and related non-determinism bugs by enforcing functional-first data processing.
+**Action:** Prefer explicitly ordered immutable operations (like `existing + args.scope`) feeding into a pure format/deduplication pipeline rather than scattered ad hoc collections (like Python sets) when serializing deterministically ordered strings.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.schemas import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -86,8 +87,7 @@ def require_scopes(*scopes: str) -> Any:
     needed: set[str] = set(filter(None, map(str.strip, scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
-        if missing := needed.difference(user_scopes):
+        if missing := needed.difference(parse_scopes(user.scopes)):
             missing_scopes = ", ".join(missing)
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a deterministic list."""
+    return list(dict.fromkeys(filter(None, map(str.strip, raw.split(",")))))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of scopes into a normalized comma-separated string."""
+    return ",".join(dict.fromkeys(filter(None, map(str.strip, scopes))))
 
 
 def _validate_display_name(v: str | None) -> str | None:

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends
 
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
-from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.schemas import SessionResponse, parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +22,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.schemas import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,9 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
-            for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+            existing = parse_scopes(user.scopes)
+            # Retain existing order, append new scopes at the end
+            user.scopes = format_scopes(existing + args.scope)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +473,9 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
             to_remove = {s.strip() for s in args.scope}
-            remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            remaining = [s for s in parse_scopes(user.scopes) if s not in to_remove]
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +501,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,11 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.schemas import format_scopes, parse_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert format_scopes(parse_scopes("a,b,c")) == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert format_scopes(parse_scopes("a,b,a")) == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert format_scopes(parse_scopes(" a , b , c ")) == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert format_scopes(parse_scopes("a,,b,,")) == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert format_scopes(parse_scopes("")) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Extracted `parse_scopes` and `format_scopes` into `src/h4ckath0n/auth/schemas.py`. Replaced scattered occurrences of inline string splitting (`.split(",")`) and mutable scope operations in the CLI and auth router with these pure functional helpers.
- 🎯 Why: Scope parsing and serialization was duplicated across `dependencies.py`, `session_router.py`, and `cli.py`, leading to inconsistent normalization patterns. The CLI tool also suffered from a subtle non-determinism bug where it loaded existing scopes into an unordered `set`, destroying the original comma-separated ordering before reserializing.
- 🧠 Design: Placing the pure functional logic in `schemas.py` allows it to be imported safely across `cli.py`, models, routes, and services without causing circular dependencies.
- λ FP Angle: Migrates mutation-heavy local tracking logic (like updating a `set` and joining inline) into clean data transformation pipelines (e.g. `format_scopes(existing + args.scope)`). Centralizes the semantics of formatting and deduplicating so the rest of the application no longer has to handle edge cases manually.
- ✅ Verification: Updated existing assertions in `test_cli.py` to assert against the composite functional pipeline. Ran `uv run pytest tests/`, `uv run ruff format .`, `uv run ruff check .`, and `uv run mypy src`.
- 🧪 Edge cases: `parse_scopes` explicitly strips whitespace, drops empty segments, and stably deduplicates the input without losing array order.
- ⚠️ Risk: Very low. Semantics remain unchanged for end-users, aside from scope output ordering being strictly deterministic.

---
*PR created automatically by Jules for task [12798009485770399427](https://jules.google.com/task/12798009485770399427) started by @ToolchainLab*