### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,10 +148,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        # ⚡ Bolt: Use session.get() for primary key lookup
+        return session.get(User, user_id)
 
+    stmt = select(User).where(User.email == email)
     return session.execute(stmt).scalars().first()
 
 


### PR DESCRIPTION
**💡 What**
Optimized the primary key lookup in `src/h4ckath0n/cli.py`'s `_resolve_user` function. Replaced the explicit `select(User).where(User.id == user_id)` query with `session.get(User, user_id)`.

**🎯 Why**
When looking up a database model by its primary key using `session.get()`, SQLAlchemy first checks the local Session Identity Map. If the object is already present in the current session, it returns the object immediately without issuing a database query. This optimization avoids redundant database calls and improves the overall performance of the CLI commands that resolve users by ID.

**📊 Impact**
Reduces database round-trips for CLI operations where the user object might have already been loaded or when running consecutive operations in scripts that hit the CLI.

**🔬 Measurement**
Verify by running the CLI command `uv run python -m h4ckath0n.cli users get --user-id <id>` with SQLAlchemy query logging enabled (e.g., `ECHO_SQL=1`). The database lookup will not issue a `SELECT` statement if the object is already present in the identity map. All existing tests pass.

---
*PR created automatically by Jules for task [13149023759524936018](https://jules.google.com/task/13149023759524936018) started by @ToolchainLab*