### PR TITLE
🎨 Palette: Add focus visible styles to password toggle

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 rounded-r-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus visible styles (`focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2`) and right border radius (`rounded-r-xl`) to the password visibility toggle button in `PasswordField.tsx`.
🎯 Why: Keyboard users had no visual indication when they tabbed to the "Show password" button because it lacked focus styles, making the form harder to navigate using only a keyboard. The added border radius ensures the focus ring perfectly hugs the right edge of the input field.
📸 Before/After: Before, tabbing over the button did nothing visually. After, it shows a clear primary-colored focus ring that aligns with the input's rounded right edge.
♿ Accessibility: Improves keyboard navigation visibility (WCAG 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [17913359557705815649](https://jules.google.com/task/17913359557705815649) started by @ToolchainLab*