### PR TITLE
🧭 Atlas: Generate environment variable docs to prevent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## $(date +%Y-%m-%d) - Environment Variable Doc Drift Prevention
+**Learning:** Hardcoding environment variable default values and descriptions in the `README.md` leads to inevitable drift when variables are added, modified, or when defaults are empty/lists/booleans.
+**Action:** When working with Pydantic `Settings`, migrate plain type hints to `Field(description=...)` and automate generating the documentation markdown directly from the `Settings` schema. This creates a mathematically precise single source of truth.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL (e.g., redis://localhost:6379) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline synchronously in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use (e.g. `local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory path for storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes (default 50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the application for emails/links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable implicit SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (e.g. disable some destructive actions) |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script: generate and check environment variable docs.
+
+Usage:
+    uv run scripts/generate_env_docs.py --update
+    uv run scripts/generate_env_docs.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+
+def generate_table() -> str:
+    """Generate the markdown table of environment variables from Settings."""
+    from h4ckath0n.config import Settings
+
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for name, field in Settings.model_fields.items():
+        env_var_name = f"H4CKATH0N_{name.upper()}"
+        default = field.default
+
+        if default == "":
+            default_str = "empty"
+        elif default == []:
+            default_str = "`[]`"
+        elif default is False:
+            default_str = "`false`"
+        elif default is True:
+            default_str = "`true`"
+        else:
+            default_str = f"`{default}`"
+
+        description = field.description or ""
+        lines.append(f"| `{env_var_name}` | {default_str} | {description} |")
+
+    return "\n".join(lines)
+
+
+def update_readme(table_content: str) -> None:
+    """Update the README with the generated table."""
+    content = README.read_text(encoding="utf-8")
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print(
+            f"❌ Error: README.md is missing the {START_MARKER} or {END_MARKER} markers.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    start_idx = content.find(START_MARKER) + len(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    new_content = content[:start_idx] + "\n" + table_content + "\n" + content[end_idx:]
+    README.write_text(new_content, encoding="utf-8")
+
+
+def check_readme(table_content: str) -> bool:
+    """Check if the README contains the up-to-date generated table."""
+    content = README.read_text(encoding="utf-8")
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print(
+            f"❌ Error: README.md is missing the {START_MARKER} or {END_MARKER} markers.",
+            file=sys.stderr,
+        )
+        return False
+
+    start_idx = content.find(START_MARKER) + len(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    current_table = content[start_idx:end_idx].strip()
+    expected_table = table_content.strip()
+
+    if current_table != expected_table:
+        print("❌ Environment variables in README.md are out of date.")
+        print("Run `uv run scripts/generate_env_docs.py --update` to fix.", file=sys.stderr)
+        return False
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate environment variable docs.")
+    parser.add_argument("--update", action="store_true", help="Update README.md in place.")
+    parser.add_argument("--check", action="store_true", help="Check if README.md is up to date.")
+    args = parser.parse_args()
+
+    if not args.update and not args.check:
+        parser.print_help()
+        return 1
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    table_content = generate_table()
+
+    if args.update:
+        update_readme(table_content)
+        print("✅ README.md updated with latest environment variables.")
+        return 0
+
+    if args.check:
+        if check_readme(table_content):
+            print("✅ README.md environment variables are up to date.")
+            return 0
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,81 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL (e.g., redis://localhost:6379)")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run jobs inline synchronously in development mode"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend to use (e.g. `local`)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Local directory path for storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum allowed upload size in bytes (default 50 MB)"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the application for emails/links"
+    )
+    email_backend: str = Field("file", description="Email backend to use (`file` or `smtp`)")
+    email_from: str = Field("noreply@localhost", description="Default sender email address")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox",
+        description="Directory to save emails when using `file` backend",
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP authentication username")
+    smtp_password: str = Field("", description="SMTP authentication password")
+    smtp_starttls: bool = Field(True, description="Enable STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(False, description="Enable implicit SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(
+        False, description="Enable demo mode (e.g. disable some destructive actions)"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Converted Pydantic `Settings` in `src/h4ckath0n/config.py` to use `Field(description=...)` and added a script `scripts/generate_env_docs.py` to automatically generate the markdown table of environment variables for `README.md`.
🎯 Why: Environment variables in `README.md` were incomplete (missing new options like storage and email settings) and drifting from the actual codebase. Hardcoded defaults in Markdown were incorrect (e.g. `localhost` vs `empty`). This creates a single source of truth and automates correctness.
🧪 Verification: Run `uv run scripts/generate_env_docs.py --check` locally or `pytest`.
🔒 Drift Prevention: Added `generate_env_docs.py --check` to the `.github/workflows/ci.yml` backend job. `README.md` now uses `<!-- BEGIN ENV VARS -->` delimiters that are generated from source.
🗺️ Evidence: `src/h4ckath0n/config.py`, `scripts/generate_env_docs.py`, `README.md`, `.github/workflows/ci.yml`.

---
*PR created automatically by Jules for task [18288575153349263882](https://jules.google.com/task/18288575153349263882) started by @ToolchainLab*