### PR TITLE
🧭 Atlas: Automate env var documentation from pydantic to prevent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-05-04 - Env var documentation frequently drifts
+
+**Learning:** Manually keeping `README.md` in sync with `src/h4ckath0n/config.py` environment variables leads to omitted variables (e.g., Redis, Email, Storage settings were missing). Pydantic allows defining descriptions on fields themselves using `Field(description="...")`.
+
+**Action:** Treat the Pydantic `Settings` model as the source of truth for both code and documentation. Use `scripts/generate_env_docs.py` to parse Pydantic `Field` descriptions and automatically generate/check the `README.md` table in CI between `<!-- BEGIN ENV VARS -->` and `<!-- END ENV VARS -->` markers.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` or `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use explicit SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that env vars in config.py match README.md."""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+BEGIN_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+
+def generate_table() -> str:
+    from h4ckath0n.config import Settings
+
+    fields = Settings.model_fields
+
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for name, field in fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+        if name == "openai_api_key":
+            var_name = f"`{var_name}` or `OPENAI_API_KEY`"
+        else:
+            var_name = f"`{var_name}`"
+
+        default = field.default
+        if default == "":
+            default_str = "empty"
+        elif default is False:
+            default_str = "`false`"
+        elif default is True:
+            default_str = "`true`"
+        elif default == []:
+            default_str = "`[]`"
+        else:
+            default_str = f"`{default}`"
+
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        if name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        desc = field.description or ""
+
+        lines.append(f"| {var_name} | {default_str} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def update_readme():
+    text = README.read_text()
+    if BEGIN_MARKER not in text or END_MARKER not in text:
+        print("Markers not found in README.md")
+        return False
+
+    start = text.index(BEGIN_MARKER) + len(BEGIN_MARKER)
+    end = text.index(END_MARKER)
+
+    new_text = text[:start] + "\n" + generate_table() + "\n" + text[end:]
+    README.write_text(new_text)
+    return True
+
+
+def check_readme():
+    text = README.read_text()
+    if BEGIN_MARKER not in text or END_MARKER not in text:
+        print("Markers not found in README.md")
+        return False
+
+    start = text.index(BEGIN_MARKER) + len(BEGIN_MARKER)
+    end = text.index(END_MARKER)
+
+    current_table = text[start:end].strip()
+    expected_table = generate_table().strip()
+
+    return current_table == expected_table
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+    if args.update:
+        if update_readme():
+            print("README.md updated.")
+            sys.exit(0)
+        else:
+            sys.exit(1)
+    elif args.check:
+        if check_readme():
+            print("✅ Environment variables in README.md are up to date.")
+            sys.exit(0)
+        else:
+            print("❌ Environment variables in README.md are out of date.")
+            print("Run `uv run scripts/generate_env_docs.py --update` to fix.")
+            sys.exit(1)
+    else:
+        print("Usage: --update or --check")
+        sys.exit(1)

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,86 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run background jobs inline in development"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(
+        default="local", description="Storage backend to use (`local` or `s3`)"
+    )
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum allowed upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field(
+        default="file", description="Email backend to use (`file` or `smtp`)"
+    )
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file email backend"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP authentication username")
+    smtp_password: str = Field(default="", description="SMTP authentication password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(default=False, description="Use explicit SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Migrates the handwritten environment variables table in `README.md` to be automatically generated from Pydantic `Field` descriptions in `src/h4ckath0n/config.py`.
🎯 Why: The environment variable documentation in the README frequently drifts or omits variables (e.g., Redis, Storage, and Email settings were missing). By moving the documentation directly to the configuration code and generating the table, we establish a single source of truth and eliminate drift risk.
🧪 Verification: `uv run scripts/generate_env_docs.py --check`
🔒 Drift Prevention: Added a `Check env docs` step to `.github/workflows/ci.yml` that will fail the build if the README table diverges from the code.
🗺️ Evidence: `src/h4ckath0n/config.py`

---
*PR created automatically by Jules for task [15475323878852662101](https://jules.google.com/task/15475323878852662101) started by @ToolchainLab*