### PR TITLE
🎨 Palette: Add focus ring to password visibility toggle

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-r-xl"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
- 💡 What: Added `focus-visible:ring-2`, `focus-visible:ring-primary`, and `rounded-r-xl` to the password visibility toggle button.
- 🎯 Why: Previously, when navigating forms using the keyboard, reaching the password visibility toggle provided no clear visual focus indicator, making it difficult for keyboard users to know where their focus was.
- 📸 Before/After: The button now displays the primary colored focus ring mirroring other form elements, bounded perfectly within the right corner of the input.
- ♿ Accessibility: Improves keyboard navigation (WCAG 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [8327098599603370617](https://jules.google.com/task/8327098599603370617) started by @ToolchainLab*