### PR TITLE
⚡ Bolt: Use session.get() for primary key lookup in CLI

### DIFF
--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,10 +148,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        # ⚡ Bolt: Use session.get() for primary key lookup
+        return session.get(User, user_id)
 
+    stmt = select(User).where(User.email == email)
     return session.execute(stmt).scalars().first()
 
 


### PR DESCRIPTION
💡 What: Replaced a `select(User).where(User.id == ...)` query with `session.get(User, user_id)` in the CLI's `_resolve_user` function.
🎯 Why: Using `session.get()` is more efficient for primary key lookups because it checks the SQLAlchemy session's identity map first. If the entity is already loaded, it avoids a round-trip to the database and bypassing parsing overhead. This was an unoptimized hotpath in the CLI tool.
📊 Impact: Eliminates unnecessary DB queries for CLI commands looking up users by ID when the entity might already be in the session, reducing latency and DB load.
🔬 Measurement: Verify by running `uv run pytest tests/` and ensuring all CLI integration tests pass. Check the code in `src/h4ckath0n/cli.py` around line 150.

---
*PR created automatically by Jules for task [1916290567820211161](https://jules.google.com/task/1916290567820211161) started by @ToolchainLab*