### PR TITLE
🧭 Atlas: Auto-generate environment variable docs from config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of via Redis |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend type (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use direct SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script to generate environment variable documentation.
+
+Usage:
+    uv run scripts/generate_env_docs.py --check
+    uv run scripts/generate_env_docs.py --update
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Add src to sys.path so we can import h4ckath0n
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+
+def generate_markdown_table() -> str:
+    """Generate a markdown table from Settings fields."""
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    # We want to iterate through the model fields to document them
+    for name, field in Settings.model_fields.items():
+        env_name = f"H4CKATH0N_{name.upper()}"
+
+        # Determine the default value correctly
+        if getattr(field, "default_factory", None) is not None:
+            # We use repr() on an instance of the default_factory to get `[]` or `{}`
+            default_val = field.default_factory()
+            default = f"`{repr(default_val)}`"
+        elif field.default is not None:
+            default_val = field.default
+            if isinstance(default_val, bool):
+                default = "`true`" if default_val else "`false`"
+            elif default_val == "":
+                default = "empty"
+            else:
+                default = f"`{default_val}`"
+        else:
+            default = "empty"
+
+        desc = field.description or ""
+        lines.append(f"| `{env_name}` | {default} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def update_readme(new_table: str) -> None:
+    """Update README.md with the new environment variables table."""
+    content = README.read_text()
+
+    pattern = re.compile(rf"{START_MARKER}.*?{END_MARKER}", re.DOTALL)
+    new_content = pattern.sub(f"{START_MARKER}\n{new_table}\n{END_MARKER}", content)
+
+    README.write_text(new_content)
+
+
+def check_readme(new_table: str) -> bool:
+    """Check if README.md is up-to-date with the environment variables table."""
+    content = README.read_text()
+    pattern = re.compile(rf"{START_MARKER}\n(.*?)\n{END_MARKER}", re.DOTALL)
+    match = pattern.search(content)
+
+    if not match:
+        print("❌ Markers not found in README.md")
+        return False
+
+    current_table = match.group(1).strip()
+    new_table_stripped = new_table.strip()
+
+    if current_table != new_table_stripped:
+        print("❌ Environment variables documentation is out of date.")
+        print("Run `uv run scripts/generate_env_docs.py --update` to fix it.")
+        return False
+
+    print("✅ Environment variables documentation is up to date.")
+    return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if README.md is up-to-date")
+    parser.add_argument("--update", action="store_true", help="Update README.md inline")
+    args = parser.parse_args()
+
+    table = generate_markdown_table()
+
+    if args.update:
+        update_readme(table)
+        print("✅ README.md updated.")
+    elif args.check:
+        if not check_readme(table):
+            sys.exit(1)
+    else:
+        print("Use --check or --update")

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,79 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run jobs inline in development instead of via Redis"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend type (`local` or `s3`)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum allowed file upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field("file", description="Email backend type (`file` or `smtp`)")
+    email_from: str = Field("noreply@localhost", description="Default sender address for emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email backend"
+    )
+    smtp_host: str = Field("", description="SMTP server hostname")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP server username")
+    smtp_password: str = Field("", description="SMTP server password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(False, description="Use direct SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode (restricts certain actions)")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replace the hand-written, incomplete list of environment variables in the README with a Pydantic-driven, generated markdown table. Add a drift check and inline updater.
🎯 Why: The previous env var list had drifted (missing email, Redis, and storage configs). Generating the documentation straight from the code enforces single-source-of-truth configuration management.
🧪 Verification: `uv run scripts/generate_env_docs.py --check`
🔒 Drift Prevention: Added `.github/workflows/ci.yml` `generate_env_docs.py --check` validation step during CI.
🗺️ Evidence: `src/h4ckath0n/config.py`

---
*PR created automatically by Jules for task [9557710586245677135](https://jules.google.com/task/9557710586245677135) started by @ToolchainLab*