### PR TITLE
⚡ Bolt: Use db.get() for primary key lookup in _resolve_user

### DIFF
--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,11 +148,11 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        return session.execute(stmt).scalars().first()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Refactored `_resolve_user` in `src/h4ckath0n/cli.py` to use `session.get(User, user_id)` for primary key lookup instead of building a full query with `session.execute(select(User).where(User.id == user_id)).scalars().first()`.
🎯 Why: Using `db.get()` utilizes the session's identity map to prevent unnecessary database queries when the object is already loaded, and it skips the overhead of parsing and hydration for primary key lookups.
📊 Impact: Faster user lookups in CLI operations.
🔬 Measurement: Verify tests run successfully using `uv run pytest tests/` which checks the CLI behavior for regressions.

---
*PR created automatically by Jules for task [12888877483502219891](https://jules.google.com/task/12888877483502219891) started by @ToolchainLab*