### PR TITLE
🎨 Palette: Add focus styles to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-07 - Added focus-visible styles with matching border-radius to PasswordField toggle
+**Learning:** When adding focus rings to absolute positioned interactive elements overlaying input fields, explicitly match the parent's border radius (e.g., `rounded-r-xl`) so the focus ring doesn't overflow visually.
+**Action:** Use matching `rounded-*` utilities on absolutely positioned elements inside rounded containers.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-r-xl disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What:
Added visible focus styles (`focus-visible:ring-2 focus-visible:ring-primary rounded-r-xl`) to the password visibility toggle (the eye icon) within the `PasswordField` component.

🎯 Why:
To ensure keyboard users receive clear visual feedback when tabbing to the toggle button. Previously, the toggle lacked distinct focus states, making it difficult to tell when it was active via keyboard navigation.

📸 Before/After:
Before: Tabbing to the password visibility toggle showed no visual indicator.
After: Tabbing to the toggle displays a distinct primary color focus ring that cleanly matches the right-side border radius of the input field.

♿ Accessibility:
Directly improves WCAG 2.4.7 (Focus Visible) compliance by providing a clear, highly visible focus indicator for interactive elements within form fields.

---
*PR created automatically by Jules for task [5048665532025634292](https://jules.google.com/task/5048665532025634292) started by @ToolchainLab*