### PR TITLE
🧭 Atlas: Replace manual environment variables documentation with generated table from config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check environment variables docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2025-05-07 - Generate env vars table from pydantic.Field
+**Learning:** Environment variable descriptions in README.md quickly drift from the actual settings configuration in `src/h4ckath0n/config.py` when managed manually.
+**Action:** Always prefer dynamically generating markdown tables of config properties by reading defaults and descriptions directly from Python type declarations and using explicit doc-generation scripts protected by CI drift checks.

--- a/README.md
+++ b/README.md
@@ -159,22 +159,41 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
 | `H4CKATH0N_PASSWORD_AUTH_ENABLED` | `false` | Enable password routes when the extra is installed |
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
-| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
+| `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | empty | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline synchronously during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use direct SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that README.md documents all environment variables."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Add src directory to sys.path to ensure absolute imports work
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+MARKER_BEGIN = "<!-- BEGIN ENV VARS -->"
+MARKER_END = "<!-- END ENV VARS -->"
+
+
+def generate_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    # We instantiate to get defaults, but pydantic model_fields also has them
+    for field_name, field_info in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{field_name.upper()}"
+        default_val = field_info.default
+        if default_val == "" or default_val == []:
+            default_str = "empty"
+        elif default_val is None:
+            default_str = "null"
+        else:
+            if isinstance(default_val, bool):
+                default_str = f"`{'true' if default_val else 'false'}`"
+            else:
+                default_str = f"`{default_val}`"
+
+        description = field_info.description or ""
+        lines.append(f"| `{var_name}` | {default_str} | {description} |")
+
+        # Special case for OpenAI API Key (based on original README)
+        if field_name == "openai_api_key":
+            lines.append(
+                "| `OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |"
+            )
+
+    return "\n".join(lines)
+
+
+def check_docs() -> int:
+    readme_content = README.read_text()
+    if MARKER_BEGIN not in readme_content or MARKER_END not in readme_content:
+        print("❌ Markers not found in README.md")
+        return 1
+
+    table_content = generate_table()
+
+    # Extract current table
+    pattern = re.compile(rf"{MARKER_BEGIN}\n(.*?)\n{MARKER_END}", re.DOTALL)
+    match = pattern.search(readme_content)
+    if not match:
+        print("❌ Could not extract current environment variables table")
+        return 1
+
+    current_table = match.group(1).strip()
+    if current_table != table_content.strip():
+        print("❌ Environment variables documentation is out of date.")
+        print("Run `uv run scripts/generate_env_docs.py --update` to fix.")
+        return 1
+
+    print("✅ Environment variables documentation is up to date.")
+    return 0
+
+
+def update_docs() -> int:
+    readme_content = README.read_text()
+    if MARKER_BEGIN not in readme_content or MARKER_END not in readme_content:
+        print("❌ Markers not found in README.md")
+        return 1
+
+    table_content = generate_table()
+
+    pattern = re.compile(rf"({MARKER_BEGIN}\n)(.*?)(\n{MARKER_END})", re.DOTALL)
+    new_content = pattern.sub(rf"\1{table_content}\3", readme_content)
+
+    README.write_text(new_content)
+    print("✅ Updated environment variables documentation in README.md.")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if docs are up to date")
+    parser.add_argument("--update", action="store_true", help="Update docs")
+    args = parser.parse_args()
+
+    if args.update:
+        return update_docs()
+    elif args.check:
+        return check_docs()
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,82 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline synchronously during development"
+    )
+    jobs_default_queue: str = Field(default="default", description="Default queue name for jobs")
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend type")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum allowed upload size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field(
+        default="file", description="Email backend to use (`file` or `smtp`)"
+    )  # "file" or "smtp"
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender email address"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use direct SSL for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 **What**: Replaced the manually maintained environment variables configuration table in `README.md` with a dynamically generated table powered by `pydantic.Field` descriptions in `src/h4ckath0n/config.py`.
- 🎯 **Why**: Environment variable documentation in `README.md` often drifts out of sync with actual configuration settings when managed manually. This ensures that the Python application code is the single source of truth for configuration and documentation.
- 🧪 **Verification**: Ran `uv run pytest tests/` and `uv run ruff check .` locally, along with `uv run scripts/generate_env_docs.py --check` which succeeded and proved parity.
- 🔒 **Drift Prevention**: Added `scripts/generate_env_docs.py` which can both update `README.md` (`--update`) and verify its contents (`--check`). Added a step to `.github/workflows/ci.yml` to enforce this check on all PRs.
- 🗺️ **Evidence**: `src/h4ckath0n/config.py` is treated as the source of truth, and `README.md` sections are clearly delimited by `<!-- BEGIN ENV VARS -->` and `<!-- END ENV VARS -->` markers.

---
*PR created automatically by Jules for task [15213287422412829489](https://jules.google.com/task/15213287422412829489) started by @ToolchainLab*