### PR TITLE
⚡ Bolt: Use db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,10 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None:
+        raise ValueError("Credential not found")
+    if cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +372,10 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None:
+            raise ValueError("Credential not found")
+        if cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,10 +148,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        return session.get(User, user_id)
 
+    stmt = select(User).where(User.email == email)
     return session.execute(stmt).scalars().first()
 
 


### PR DESCRIPTION
💡 What: Refactored primary key lookup queries in `src/h4ckath0n/auth/passkeys/service.py` and `src/h4ckath0n/cli.py` to use `db.get(Model, pk)` instead of `select(Model).filter(Model.id == pk)`. 
🎯 Why: Utilizing `db.get()` bypasses database round-trips and full hydration overhead if the object is already present in the session's identity map. For instances where a row-lock is needed, the `with_for_update()` queries have been kept intact. 
📊 Impact: Reduces DB overhead and speeds up the authentication and user lookup hot paths. 
🔬 Measurement: Verified functionality using `uv run pytest tests/` which completed successfully with zero regressions.

---
*PR created automatically by Jules for task [3960272086685135016](https://jules.google.com/task/3960272086685135016) started by @ToolchainLab*