### PR TITLE
🎨 Palette: Add keyboard focus state to password visibility toggle

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-r-xl text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ring-offset-surface disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added keyboard focus styling (`focus-visible` utilities) to the password visibility toggle button in `PasswordField.tsx`.
🎯 Why: The button previously lacked a visible focus indicator, making it difficult for keyboard users to know when it was focused.
📸 Before/After: Visual focus ring now appears when navigating via keyboard (tabbing).
♿ Accessibility: Improves keyboard navigation accessibility by providing a clear, visually distinct focus state, addressing a common a11y failure. Added `rounded-r-xl` to ensure the focus ring respects the parent input's border radius.

---
*PR created automatically by Jules for task [15829060611505245859](https://jules.google.com/task/15829060611505245859) started by @ToolchainLab*