### PR TITLE
⚡ Bolt: [performance improvement] Use db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,10 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None:
+        raise ValueError("Credential not found")
+    if cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,11 +148,11 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        return session.execute(stmt).scalars().first()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 **What**: Changed primary key lookups in `src/h4ckath0n/cli.py` (`_resolve_user`) and `src/h4ckath0n/auth/passkeys/service.py` (`rename_passkey`) from `select(Model).filter(Model.id == pk)` to `session.get(Model, pk)` / `await db.get(Model, pk)`.

🎯 **Why**: Using `select().filter().first()` forces SQLAlchemy to always execute a database query and hydrate a new model. Using `get()` leverages the session's Identity Map, meaning if the object is already loaded, it avoids the query and parsing overhead entirely. For queries that need a secondary condition (like `user_id == user.id`), this optimization does the `get()` first and then verifies the `user_id` attribute in Python.

📊 **Impact**: Reduces unnecessary database queries and SQLAlchemy hydration overhead during common operations like passkey renaming and CLI user resolution.

🔬 **Measurement**: Verified with the `test_passkeys.py` and `test_cli.py` test suite and ruff linter/formatter, ensuring identical functionality while taking a faster path for loaded records.

---
*PR created automatically by Jules for task [11930355926034733808](https://jules.google.com/task/11930355926034733808) started by @ToolchainLab*