### PR TITLE
🎨 Palette: [UX improvement] Add native tooltips to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-09 - [Icon Button Tooltips]
+**Learning:** Found multiple icon-only buttons (like the theme toggler and mobile menu in `Layout.tsx`, and visibility toggle in `PasswordField.tsx`) that lack visual tooltips explaining their function. While they have ARIA labels for screen readers, sighted users don't get hover feedback about what the button does.
+**Action:** Always consider adding `title` attributes (or a Tooltip component) to icon-only buttons to improve discoverability for sighted mouse users.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,15 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0];
+    if (!button) throw new Error("Button not found");
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +76,15 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0];
+    if (!button) throw new Error("Button not found");
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0],
       ).toBeInTheDocument();
     });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -151,6 +151,11 @@ export function Layout() {
                       ? `Theme: system (${effectiveTheme})`
                       : `Theme: ${themePreference}`
                   }
+                title={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
                 >
                   {effectiveTheme === "dark" ? (
                     <Sun className="w-4 h-4" />
@@ -192,6 +197,16 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
+                title={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +218,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+                title={isMobileMenuOpen ? "Close menu" : "Open menu"}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -87,6 +87,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           <button
             type="button"
             aria-label={visible ? "Hide password" : "Show password"}
+            title={visible ? "Hide password" : "Show password"}
             aria-pressed={visible}
             onClick={handleToggle}
             onPointerDown={handlePointerDown}


### PR DESCRIPTION
- 💡 What: Added `title` and `aria-label` attributes to the icon-only buttons (theme toggle and menu toggle in `Layout.tsx`, and visibility toggle in `PasswordField.tsx`).
- 🎯 Why: Icon-only buttons lack context on hover. This change gives sighted users hover tooltips to understand what the buttons do, and improves screen reader compatibility by explicitly providing accessible names where they were missing.
- 📸 Before/After: Visual tooltips now appear on hover over icon buttons.
- ♿ Accessibility: Screen reader compatibility on mobile menu enhanced with explicitly provided accessible names (`aria-label`).

---
*PR created automatically by Jules for task [113315347846952181](https://jules.google.com/task/113315347846952181) started by @ToolchainLab*