### PR TITLE
🧭 Atlas: Auto-generate environment variable docs from config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
 
   frontend:
     runs-on: ubuntu-latest

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var docs drift prevention using Pydantic Settings
+
+**Learning:** Environment variable documentation frequently drifts because it's handwritten in the README, while the actual implementation lives in a Pydantic `BaseSettings` class (e.g., `src/h4ckath0n/config.py`).
+**Action:** Replace handwritten env var lists with a script (like `generate_env_docs.py`) that introspects the Pydantic Settings fields (via `model_fields` and `pydantic.Field` descriptions) to automatically generate the markdown table. Inject this table between HTML comment markers (`<!-- BEGIN ENV VARS -->` and `<!-- END ENV VARS -->`) and add a `--check` flag to the script. Enforce this check in the CI pipeline to completely eliminate config documentation drift.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline instead of enqueueing in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env -S uv run python
+"""Generate environment variable documentation from Pydantic Settings."""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add src to sys.path
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / 'src'))
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+def generate_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        var_name = f"`H4CKATH0N_{name.upper()}`"
+
+        default = field.default
+        if default == "" or default is None:
+            default_str = "empty"
+        elif default == [] or str(default) == "PydanticUndefined":
+            default_str = "`[]`"
+        else:
+            default_str = f"`{default}`"
+
+        # Handle booleans properly for bash
+        if isinstance(default, bool):
+            default_str = f"`{'true' if default else 'false'}`"
+
+        # Special overrides to match old docs
+        if name == "rp_id":
+            default_str = "`localhost` in development"
+        elif name == "origin":
+            default_str = "`http://localhost:8000` in development"
+
+        desc = field.description or ""
+        lines.append(f"| {var_name} | {default_str} | {desc} |")
+
+        # Also, openai_api_key needs an extra un-prefixed one based on previous readme
+        if name == "openai_api_key":
+            lines.insert(-1, "| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+            lines[-1] = (
+                "| `H4CKATH0N_OPENAI_API_KEY` | empty | "
+                "Alternate OpenAI API key for the LLM wrapper |"
+            )
+
+    return "\n".join(lines)
+
+def update_readme(new_content: str, check_only: bool = False) -> int:
+    readme_text = README.read_text()
+    if START_MARKER not in readme_text or END_MARKER not in readme_text:
+        print("❌ Could not find BEGIN/END ENV VARS markers in README.md")
+        return 1
+
+    start_idx = readme_text.index(START_MARKER) + len(START_MARKER)
+    end_idx = readme_text.index(END_MARKER)
+
+    current_content = readme_text[start_idx:end_idx].strip()
+
+    if current_content == new_content.strip():
+        print("✅ README.md is up to date.")
+        return 0
+
+    if check_only:
+        print("❌ README.md environment variables are out of date!")
+        print("Run `uv run scripts/generate_env_docs.py --update` to fix.")
+        return 1
+
+    new_readme = (
+        readme_text[:start_idx] +
+        "\n" + new_content + "\n" +
+        readme_text[end_idx:]
+    )
+    README.write_text(new_readme)
+    print("✅ Updated README.md with latest environment variables.")
+    return 0
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate env vars doc")
+    parser.add_argument("--update", action="store_true", help="Update README.md")
+    parser.add_argument("--check", action="store_true", help="Check if README.md is up to date")
+    args = parser.parse_args()
+
+    table = generate_table()
+
+    if args.update or args.check:
+        return update_readme(table, check_only=args.check)
+    else:
+        print(table)
+        return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 # Add src to sys.path
 REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT / 'src'))
+sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from h4ckath0n.config import Settings  # noqa: E402
 
 README = REPO_ROOT / "README.md"
 START_MARKER = "<!-- BEGIN ENV VARS -->"
 END_MARKER = "<!-- END ENV VARS -->"
+
 
 def generate_table() -> str:
     lines = ["| Variable | Default | Description |", "|---|---|---|"]
@@ -51,6 +52,7 @@ def generate_table() -> str:
 
     return "\n".join(lines)
 
+
 def update_readme(new_content: str, check_only: bool = False) -> int:
     readme_text = README.read_text()
     if START_MARKER not in readme_text or END_MARKER not in readme_text:
@@ -71,14 +73,11 @@ def update_readme(new_content: str, check_only: bool = False) -> int:
         print("Run `uv run scripts/generate_env_docs.py --update` to fix.")
         return 1
 
-    new_readme = (
-        readme_text[:start_idx] +
-        "\n" + new_content + "\n" +
-        readme_text[end_idx:]
-    )
+    new_readme = readme_text[:start_idx] + "\n" + new_content + "\n" + readme_text[end_idx:]
     README.write_text(new_readme)
     print("✅ Updated README.md with latest environment variables.")
     return 0
+
 
 def main():
     parser = argparse.ArgumentParser(description="Generate env vars doc")
@@ -93,6 +92,7 @@ def main():
     else:
         print(table)
         return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,83 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline instead of enqueueing in development"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes (default 50 MB)"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field(default="file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use implicit SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
- 💡 What: Replaced the handwritten environment variables table in `README.md` with an automatically generated one derived from the application's configuration.
- 🎯 Why: To completely eliminate documentation drift risk for configuration. Previously, developers would have to remember to update `README.md` manually whenever a setting was added or changed in `config.py`.
- 🧪 Verification: Locally run `uv run python scripts/generate_env_docs.py --check` and verify it passes. `README.md` is updated and tests/linting pass.
- 🔒 Drift Prevention: Added `scripts/generate_env_docs.py --check` to the `.github/workflows/ci.yml` pipeline. CI will now fail if the documentation does not perfectly match the source code.
- 🗺️ Evidence: Uses `src/h4ckath0n/config.py` (which uses `pydantic-settings`) as the definitive source of truth for the available environment variables and their default configurations.

---
*PR created automatically by Jules for task [1225042674033141300](https://jules.google.com/task/1225042674033141300) started by @ToolchainLab*