### PR TITLE
⚡ Bolt: [performance improvement] Optimize primary key lookups using db.get()

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,9 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup and check user_id in Python
+    cred = await db.get(WebAuthnCredential, key_id)
+    if cred is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +371,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup and check user_id in Python
+        cred = await db.get(WebAuthnCredential, key_id)
+        if cred is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,7 +148,8 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use session.get() for primary key lookup
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
 


### PR DESCRIPTION
- 💡 What: Replaced `select(Model).where(Model.id == pk)` and `select(Model).filter(...)` queries with `session.get(Model, pk)` and `await db.get(Model, pk)` in `src/h4ckath0n/cli.py` (`_resolve_user`) and `src/h4ckath0n/auth/passkeys/service.py` (`rename_passkey`, `revoke_passkey`).
- 🎯 Why: Using `db.get()` utilizes the SQLAlchemy session Identity Map. This avoids an unnecessary database query if the object is already cached in the current session. Even on cache misses, it uses a more optimized query compilation path for primary key lookups.
- 📊 Impact: Eliminates unnecessary database queries on cache hits, reducing database load and network latency. Slightly speeds up cache misses.
- 🔬 Measurement: Observe database logs and general request latency for endpoints/CLI commands fetching these entities by ID.

---
*PR created automatically by Jules for task [11014023745794328208](https://jules.google.com/task/11014023745794328208) started by @ToolchainLab*