### PR TITLE
🧭 Atlas: Auto-generate environment variable docs from config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-02 - Pydantic Field metadata enables doc generation
+
+**Learning:** When environment variables drift in READMEs, manually syncing them is error-prone. In projects using Pydantic `BaseSettings`, Pydantic's `Field(description=...)` can be used to add descriptions directly to the settings models without affecting runtime logic.
+**Action:** Always prefer parsing Pydantic `model_fields` to extract config defaults and descriptions, using HTML comments as markers in the Markdown file, to automatically generate accurate documentation that cannot drift. Hook a check script into CI.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of enqueuing |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to store file-based emails |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script to keep README.md environment variables in sync with config.py."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Import Settings to access its fields
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+START_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+
+def generate_markdown_table() -> str:
+    """Generate the markdown table for configuration variables."""
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    # Process each field in Settings
+    for name, field in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+
+        # Handle default values appropriately
+        default_val = field.default
+        if default_val == "":
+            default_str = "empty"
+        elif isinstance(default_val, bool):
+            default_str = f"`{str(default_val).lower()}`"
+        elif isinstance(default_val, list):
+            default_str = f"`{str(default_val)}`"
+        elif isinstance(default_val, str):
+            default_str = f"`{default_val}`"
+        else:
+            default_str = f"`{default_val}`"
+
+        description = getattr(field, "description", None) or ""
+
+        lines.append(f"| `{var_name}` | {default_str} | {description} |")
+
+    return "\n".join(lines)
+
+
+def update_readme(table: str) -> None:
+    """Rewrite README.md with the new table."""
+    content = README.read_text(encoding="utf-8")
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print(
+            f"Error: Could not find '{START_MARKER}' and '{END_MARKER}' markers in README.md",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    start_idx = content.find(START_MARKER) + len(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    new_content = content[:start_idx] + "\n" + table + "\n" + content[end_idx:]
+    README.write_text(new_content, encoding="utf-8")
+
+
+def check_readme(table: str) -> bool:
+    """Check if the README.md needs updating."""
+    content = README.read_text(encoding="utf-8")
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print(
+            f"Error: Could not find '{START_MARKER}' and '{END_MARKER}' markers in README.md",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    start_idx = content.find(START_MARKER) + len(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    current_table = content[start_idx:end_idx].strip()
+    return current_table == table.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Manage environment variable docs.")
+    parser.add_argument("--update", action="store_true", help="Update the README.md")
+    parser.add_argument("--check", action="store_true", help="Check if README.md is up to date")
+    args = parser.parse_args()
+
+    if not args.update and not args.check:
+        parser.print_help()
+        return 1
+
+    table = generate_markdown_table()
+
+    if args.check:
+        if not check_readme(table):
+            print(
+                "❌ README.md environment variables are out of sync with config.py.",
+                file=sys.stderr,
+            )
+            print("Run 'uv run scripts/generate_env_docs.py --update' to fix.", file=sys.stderr)
+            return 1
+        print("✅ README.md environment variables are up to date.")
+        return 0
+
+    if args.update:
+        update_readme(table)
+        print("✅ README.md updated successfully.")
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,84 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline in development instead of enqueuing"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(
+        default="local", description="Storage backend to use (`local` or `s3`)"
+    )
+    storage_dir: str = Field(default="./.h4ckath0n_storage", description="Local storage directory")
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field(
+        default="file", description="Email backend to use (`file` or `smtp`)"
+    )
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory to store file-based emails"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP authentication username")
+    smtp_password: str = Field(default="", description="SMTP authentication password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP connections")
+    smtp_ssl: bool = Field(default=False, description="Use SSL for SMTP connections")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the manually maintained environment variable table in `README.md` with an auto-generated table driven by Pydantic's `Field` descriptions in `src/h4ckath0n/config.py`.
🎯 Why: The configuration docs were prone to drift as new settings were added or defaults changed. By making `config.py` the single source of truth, we ensure new contributors always see accurate, verifiable settings.
🧪 Verification: Run `uv run scripts/generate_env_docs.py --check` locally to verify parity, or `uv run scripts/generate_env_docs.py --update` to rewrite the README block.
🔒 Drift Prevention: Added an automated `Check doc env vars` step to the backend CI workflow (`ci.yml`) that fails if `config.py` and `README.md` diverge.
🗺️ Evidence: `src/h4ckath0n/config.py` is the verified source of truth for all runtime configuration.

---
*PR created automatically by Jules for task [377690537074552568](https://jules.google.com/task/377690537074552568) started by @ToolchainLab*