### PR TITLE
⚡ Bolt: Optimize passkey lookup with db.get()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-22 - Optimize Passkey Authorization Checks
+
+**Learning:** In SQLAlchemy, executing `db.execute(select(Model).filter(Model.id == pk, Model.user_id == user.id))` forces a database query and parses a fresh model. Because primary key lookups can utilize the session identity map via `db.get()`, fetching the object by primary key first and then validating secondary authorization attributes (like `user_id`) in Python avoids unnecessary database trips when the object is already loaded in the current session.
+
+**Action:** For authorization checks that query by primary key and a secondary attribute, prioritize using `db.get(Model, pk)` and validate the secondary attribute using Python logic (`obj.user_id == user.id`) to maximize identity map hits.

--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What
Replaced complex `select(WebAuthnCredential).filter(id==..., user_id==...)` queries with `await db.get(WebAuthnCredential, key_id)` followed by a Python validation for ownership (`cred.user_id != user.id`) in both `rename_passkey` and `revoke_passkey`.

🎯 Why
Using `db.get()` allows SQLAlchemy to check the Identity Map first. If the passkey credential is already loaded in the session memory, it completely bypasses a roundtrip to the database, preventing ORM parsing and hydration overhead.

📊 Impact
Reduces database roundtrips and hydration overhead in passkey rename and revoke operations. This minimizes time spent executing DB queries on these paths.

🔬 Measurement
Verify by running unit tests `uv run pytest tests/test_passkeys.py` which passes, indicating functionality is preserved. A profiler could trace SQLAlchemy execution showing fewer distinct queries emitted on cache hits.

---
*PR created automatically by Jules for task [13520619499365741818](https://jules.google.com/task/13520619499365741818) started by @ToolchainLab*