### PR TITLE
🧭 Atlas: Generate configuration environment variables documentation from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-05-11 - Generated env vars docs
+
+**Learning:** Environment variables documented in README.md quickly fall out of sync with actual configuration loading (Pydantic `Settings`).
+**Action:** Always replace handwritten environment variable documentation with a generated section derived directly from the source of truth (the configuration loader), and add a check script to CI to prevent regressions.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
-| `H4CKATH0N_ENV` | `development` | `development` or `production` |
+| `H4CKATH0N_ENV` | `development` | development or production |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY / H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of Redis |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend ('local' or 's3') |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web frontend for emails |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend ('file' or 'smtp') |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default From address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for local file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host for email delivery |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that env vars in README.md match pydantic Settings.
+
+Usage (from repo root):
+    uv run scripts/generate_env_docs.py --check
+    uv run scripts/generate_env_docs.py --update
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+SRC_PATH = REPO_ROOT / "src"
+
+sys.path.insert(0, str(SRC_PATH))
+from h4ckath0n.config import Settings  # noqa: E402
+
+BEGIN_MARKER = "<!-- BEGIN ENV VARS -->"
+END_MARKER = "<!-- END ENV VARS -->"
+
+
+def get_markdown_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        if name == "openai_api_key":
+            env_name = "OPENAI_API_KEY / H4CKATH0N_OPENAI_API_KEY"
+        else:
+            env_name = f"H4CKATH0N_{name.upper()}"
+
+        desc = field.description or "TODO"
+
+        default = field.default
+        if default == "" or default is None:
+            default_str = "empty"
+        elif isinstance(default, bool):
+            default_str = f"`{'true' if default else 'false'}`"
+        elif isinstance(default, list):
+            default_str = f"`{default}`".replace("'", '"')
+        else:
+            default_str = f"`{default}`"
+
+        lines.append(f"| `{env_name}` | {default_str} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in ("--check", "--update"):
+        print("Usage: scripts/generate_env_docs.py [--check|--update]")
+        sys.exit(1)
+
+    table = get_markdown_table()
+    content = README.read_text()
+
+    if BEGIN_MARKER not in content or END_MARKER not in content:
+        print(f"Error: {BEGIN_MARKER} and {END_MARKER} not found in README.md")
+        sys.exit(1)
+
+    pattern = re.compile(f"({BEGIN_MARKER}\\n).*?({END_MARKER})", re.DOTALL)
+    new_content = pattern.sub(f"\\1{table}\\n\\2", content)
+
+    if sys.argv[1] == "--check":
+        if content != new_content:
+            print("❌ Environment variables in README.md are out of date.")
+            print("Run `uv run scripts/generate_env_docs.py --update` to fix.")
+            sys.exit(1)
+        print("✅ Environment variables in README.md match configuration.")
+    elif sys.argv[1] == "--update":
+        README.write_text(new_content)
+        print("✅ README.md updated with latest environment variables.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,74 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="development or production")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection string for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run jobs inline in development instead of Redis"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend ('local' or 's3')")
+    storage_dir: str = Field("./.h4ckath0n_storage", description="Directory for local storage")
+    max_upload_bytes: int = Field(50 * 1024 * 1024, description="Maximum upload size in bytes")
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the web frontend for emails"
+    )
+    email_backend: str = Field("file", description="Email backend ('file' or 'smtp')")
+    email_from: str = Field("noreply@localhost", description="Default From address for emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for local file email backend"
+    )
+    smtp_host: str = Field("", description="SMTP host for email delivery")
+    smtp_port: int = Field(587, description="SMTP port")
+    smtp_username: str = Field("", description="SMTP username")
+    smtp_password: str = Field("", description="SMTP password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Use SSL for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode (restricts certain actions)")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the handwritten env vars table in README.md with a generated section driven by Pydantic's Settings model.
🎯 Why: The documentation for environment variables drifts from the actual configuration fields (e.g. new variables are added to config but not README). Generating them ensures the documentation is always correct.
🔬 Verification: Run `uv run scripts/generate_env_docs.py --check`
🔒 Drift Prevention: Added `scripts/generate_env_docs.py` which checks that the README markers contain exactly what the Settings model defines, and added this check to the CI pipeline.
🗺️ Evidence: `src/h4ckath0n/config.py` was used as the single source of truth for the environment configuration.

---
*PR created automatically by Jules for task [1668694852868927478](https://jules.google.com/task/1668694852868927478) started by @ToolchainLab*