### PR TITLE
🎨 Palette: [UX improvement] Add focus rings to theme settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-12 - The sr-only Trap
+ **Learning:** Custom UI components (like radio buttons) that visually hide the native `<input>` using Tailwind's `sr-only` will completely hide browser focus indicators from keyboard users.
+ **Action:** Always use Tailwind's `has-[:focus-visible]:` or `has-focus-visible:` on the visible parent wrapper (e.g., `<label>`) when hiding native inputs to restore a visible focus state for keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -291,6 +291,7 @@ export function Settings() {
                 key={option}
                 className={cn(
                   "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all",
+                  "has-focus-visible:ring-2 has-focus-visible:ring-primary has-focus-visible:ring-offset-2 has-focus-visible:ring-offset-surface",
                   themePreference === option
                     ? "border-primary bg-primary/5"
                     : "border-border",


### PR DESCRIPTION
- 💡 **What**: Added Tailwind `has-focus-visible` ring styles to the theme selection radio buttons in `Settings.tsx`.
- 🎯 **Why**: The native radio inputs were visually hidden using `sr-only`, which completely removes the browser's default focus outline. This made the theme selection unusable for keyboard users as they had no visual indication of which option was currently focused.
- 📸 **Before/After**: See attached Playwright verification recording.
- ♿ **Accessibility**: Restores WCAG standard keyboard focus indicators (Focus Visible) for custom UI elements that obscure native inputs.

---
*PR created automatically by Jules for task [3307116827527383679](https://jules.google.com/task/3307116827527383679) started by @ToolchainLab*