### PR TITLE
🧭 Atlas: Generate env var docs from Pydantic models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs drift
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var documentation drift
+
+**Learning:** Environment variables documented in README.md quickly drift from the Pydantic Settings class which serves as the source of truth for the configuration.
+**Action:** Always generate the environment variables documentation directly from the Pydantic Settings model using `scripts/generate_env_docs.py` to prevent drift.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -173,8 +174,26 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the application, used in emails |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,23 @@
+1. **Create `scripts/generate_env_docs.py`**
+   - Implement the script to parse `src/h4ckath0n/config.py` using Pydantic, and generate the Markdown table for environment variables.
+   - It will support `--check` to verify the README is up to date, and `--update` to rewrite the README with the generated table between `<!-- BEGIN ENV VARS -->` and `<!-- END ENV VARS -->` markers.
+
+2. **Update `src/h4ckath0n/config.py`**
+   - Add `from pydantic import Field` to the file.
+   - Update the `Settings` class to use `Field(description="...")` for all settings, to provide docstrings that will be pulled into the README.
+
+3. **Update `README.md`**
+   - Replace the hand-written table with the `<!-- BEGIN ENV VARS -->` and `<!-- END ENV VARS -->` markers.
+   - Run `uv run scripts/generate_env_docs.py --update` to inject the generated table.
+
+4. **Add CI Check in `.github/workflows/ci.yml`**
+   - Add a step to run `uv run scripts/generate_env_docs.py --check` in the backend job to ensure environment variables drift check is performed in CI.
+
+5. **Log Atlas critical learning**
+   - Update `.jules/atlas.md` with an entry explaining that the repo's Pydantic settings are the source of truth for config, and a drift-prevention script is needed to keep the README table up to date.
+
+6. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+   - Run `pre_commit_instructions` and follow them.
+
+7. **Submit the PR**
+   - Call the `submit` tool to push changes to a branch and submit the PR.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -31,11 +31,11 @@ def generate_markdown_table() -> str:
         # Handle default value representation
         default_val = field_info.default
         if field_name == "rp_id":
-             default_str = "`localhost` in development"
+            default_str = "`localhost` in development"
         elif field_name == "origin":
-             default_str = "`http://localhost:8000` in development"
+            default_str = "`http://localhost:8000` in development"
         elif field_name == "env":
-             default_str = "`development`"
+            default_str = "`development`"
         elif field_name == "database_url":
             default_str = "`sqlite:///./h4ckath0n.db`"
         elif default_val == "":

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script to generate environment variable documentation from Pydantic models.
+
+Usage:
+    uv run scripts/generate_env_docs.py --check
+    uv run scripts/generate_env_docs.py --update
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Need to import Settings from src to parse it
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- BEGIN ENV VARS -->\n"
+END_MARKER = "<!-- END ENV VARS -->\n"
+
+
+def generate_markdown_table() -> str:
+    """Generate a Markdown table describing all environment variables."""
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+    for field_name, field_info in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{field_name.upper()}"
+
+        # Handle default value representation
+        default_val = field_info.default
+        if field_name == "rp_id":
+             default_str = "`localhost` in development"
+        elif field_name == "origin":
+             default_str = "`http://localhost:8000` in development"
+        elif field_name == "env":
+             default_str = "`development`"
+        elif field_name == "database_url":
+            default_str = "`sqlite:///./h4ckath0n.db`"
+        elif default_val == "":
+            default_str = "empty"
+        elif default_val is False:
+            default_str = "`false`"
+        elif default_val is True:
+            default_str = "`true`"
+        elif default_val == []:
+            default_str = "`[]`"
+        else:
+            default_str = f"`{default_val}`"
+
+        desc = field_info.description or ""
+        lines.append(f"| `{var_name}` | {default_str} | {desc} |")
+
+    # Add exceptions documented manually
+    lines.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+
+    return "\n".join(lines) + "\n"
+
+
+def read_readme() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def write_readme(content: str) -> None:
+    README.write_text(content, encoding="utf-8")
+
+
+def update_readme(table_content: str) -> bool:
+    content = read_readme()
+    start_idx = content.find(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    if start_idx == -1 or end_idx == -1:
+        print(
+            "Error: Could not find BEGIN ENV VARS or END ENV VARS markers in README.md",
+            file=sys.stderr,
+        )
+        return False
+
+    start_idx += len(START_MARKER)
+
+    new_content = content[:start_idx] + table_content + content[end_idx:]
+    if new_content == content:
+        return False  # No change needed
+    write_readme(new_content)
+    return True
+
+
+def check_readme(table_content: str) -> bool:
+    content = read_readme()
+    start_idx = content.find(START_MARKER)
+    end_idx = content.find(END_MARKER)
+
+    if start_idx == -1 or end_idx == -1:
+        print(
+            "Error: Could not find BEGIN ENV VARS or END ENV VARS markers in README.md",
+            file=sys.stderr,
+        )
+        return False
+
+    start_idx += len(START_MARKER)
+    current_table = content[start_idx:end_idx]
+
+    return current_table == table_content
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate/check environment variable documentation."
+    )
+    parser.add_argument("--check", action="store_true", help="Check if README.md is up to date.")
+    parser.add_argument(
+        "--update", action="store_true", help="Update README.md with generated documentation."
+    )
+    args = parser.parse_args()
+
+    if not args.check and not args.update:
+        parser.print_help()
+        return 1
+
+    table_content = generate_markdown_table()
+
+    if args.update:
+        if update_readme(table_content):
+            print("✅ README.md updated successfully.")
+        else:
+            print("✅ README.md is already up to date.")
+        return 0
+
+    if args.check:
+        if check_readme(table_content):
+            print("✅ README.md environment variables documentation is up to date.")
+            return 0
+        else:
+            print("❌ README.md environment variables documentation is out of date.")
+            print("Run `uv run scripts/generate_env_docs.py --update` to fix it.")
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,78 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        [], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="Alternate OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(True, description="Run background jobs inline in development")
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend to use (`local` or `s3`)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum allowed file upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the application, used in emails"
+    )
+    email_backend: str = Field("file", description="Email backend to use (`file` or `smtp`)")
+    email_from: str = Field(
+        "noreply@localhost", description="Default sender address for outbound emails"
+    )
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email backend"
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP server username")
+    smtp_password: str = Field("", description="SMTP server password")
+    smtp_starttls: bool = Field(True, description="Enable STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Enable SSL for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replace the hand-written environment variables table in README.md with a table generated directly from the Pydantic `Settings` model using a new `scripts/generate_env_docs.py` tool.
🎯 Why: Environment variable documentation frequently drifts from the true code configuration. This ensures 100% parity and prevents onboarding errors.
🧪 Verification: Run `uv run scripts/generate_env_docs.py --check` and `uv run pytest tests/`.
🔒 Drift Prevention: Added `uv run scripts/generate_env_docs.py --check` to the `.github/workflows/ci.yml` pipeline.
🗺️ Evidence: `src/h4ckath0n/config.py` is the source of truth.

---
*PR created automatically by Jules for task [10866567564132629444](https://jules.google.com/task/10866567564132629444) started by @ToolchainLab*