### PR TITLE
∴ Vector: Centralise scope normalisation and parsing helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,4 @@
+
+## 2024-05-14 - Centralise scope normalisation and parsing
+**Learning:** The project stores scopes as comma-separated strings in the database, leading to ad hoc `scopes.split(",")` and local normalisation logic scattered across the codebase.
+**Action:** Extract and standardise string normalisation into pure helpers (`parse_scopes`, `format_scopes`, `normalize_scope_list`) within a dedicated `scopes.py` module to ensure consistent semantics, deterministic ordering, and reusability, especially for authorization dependencies and CLI mutation logic.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import normalize_scope_list, parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -83,10 +84,10 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[str] = set(filter(None, map(str.strip, scopes)))
+    needed: set[str] = set(normalize_scope_list(scopes))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,29 @@
+"""Pure helpers for scope normalization, parsing, and formatting.
+
+This module centralizes the string transformations for user scopes,
+which are stored as comma-separated strings in the database.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a deduplicated list of trimmed scopes.
+
+    Order is preserved based on first occurrence.
+    """
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """Format an iterable of scopes into a normalized comma-separated string."""
+    return ",".join(normalize_scope_list(scopes))
+
+
+def normalize_scope_list(scopes: Iterable[str]) -> list[str]:
+    """Normalize an iterable of scopes by trimming and deduplicating."""
+    parts = filter(None, map(str.strip, scopes))
+    return list(dict.fromkeys(parts))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,9 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
-            for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+            existing = parse_scopes(user.scopes)
+            existing.extend(args.scope)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +473,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +502,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -130,23 +129,6 @@ class TestAlembicUrlNormalization:
 # ---------------------------------------------------------------------------
 # Scopes normalization
 # ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,0 +1,28 @@
+from h4ckath0n.auth.scopes import format_scopes, normalize_scope_list, parse_scopes
+
+
+def test_parse_scopes():
+    assert parse_scopes("a,b,c") == ["a", "b", "c"]
+    assert parse_scopes("a,b,a") == ["a", "b"]
+    assert parse_scopes(" a , b , c ") == ["a", "b", "c"]
+    assert parse_scopes("a,,b,,") == ["a", "b"]
+    assert parse_scopes("") == []
+    assert parse_scopes("   ") == []
+
+
+def test_normalize_scope_list():
+    assert normalize_scope_list(["a", "b", "c"]) == ["a", "b", "c"]
+    assert normalize_scope_list(["a", "b", "a"]) == ["a", "b"]
+    assert normalize_scope_list([" a ", " b ", " c "]) == ["a", "b", "c"]
+    assert normalize_scope_list(["a", "", "b", ""]) == ["a", "b"]
+    assert normalize_scope_list([]) == []
+    assert normalize_scope_list(["   "]) == []
+
+
+def test_format_scopes():
+    assert format_scopes(["a", "b", "c"]) == "a,b,c"
+    assert format_scopes(["a", "b", "a"]) == "a,b"
+    assert format_scopes([" a ", " b ", " c "]) == "a,b,c"
+    assert format_scopes(["a", "", "b", ""]) == "a,b"
+    assert format_scopes([]) == ""
+    assert format_scopes(["   "]) == ""


### PR DESCRIPTION
- 💡 **What**: Extracted and standardized scope string normalization into pure helpers (`parse_scopes`, `format_scopes`, `normalize_scope_list`) within a dedicated `scopes.py` module. Refactored the CLI and API auth routes to use these helpers.
- 🎯 **Why**: The project stores user scopes as comma-separated strings in the database. Ad hoc `scopes.split(",")` and scattered `_normalize_scopes` logic led to duplicated transformation rules and inconsistent edge-case handling across the codebase.
- 🧠 **Design**: Creates a single source of truth for scope parsing, replacing scattered mutations with pure data-in/data-out transformations.
- λ **FP Angle**: Replaces scattered string mutation and imperative deduplication with composable, deterministic, and pure transformation pipelines.
- ✅ **Verification**: Ran `pytest tests/` locally to ensure identical behavior. All checks (ruff format, ruff check, mypy) pass successfully.
- 🧪 **Edge cases**: Added unit tests to explicitly lock in handling for empty strings, repeated delimiters, and surrounding whitespace.
- ⚠️ **Risk**: Very low. Behavior is identical; this is a pure semantic cleanup.

---
*PR created automatically by Jules for task [5517920471978894720](https://jules.google.com/task/5517920471978894720) started by @ToolchainLab*