### PR TITLE
🧭 Atlas: Generate env var docs to prevent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env docs
+        run: uv run --locked scripts/generate_env_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var documentation drifts from Config schema
+
+**Learning:** Environment variables in `README.md` easily drift from `Settings` in `src/h4ckath0n/config.py`. Using Pydantic's `Field(description="...")` allows the `Settings` class to act as the single source of truth for generating docs.
+
+**Action:** Whenever a configuration drift is identified, generate a markdown table from the source configuration class (`pydantic.Settings`) and use a check script (`generate_env_docs.py --check`) in CI to enforce parity.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -173,8 +174,26 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of using Redis |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web template frontend |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode constraints (e.g. disable config changes) |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that all configuration options are documented in README.md.
+
+Usage (from repo root):
+    uv run scripts/generate_env_docs.py --update
+    uv run scripts/generate_env_docs.py --check
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add src to sys.path to allow imports from local source tree
+SRC_PATH = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC_PATH))
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def format_default(val: Any) -> str:
+    """Format default value for display in markdown."""
+    if val == "":
+        return "empty"
+    if isinstance(val, list):
+        if not val:
+            return "`[]`"
+        return f"`{json.dumps(val)}`"
+    if isinstance(val, bool):
+        return f"`{str(val).lower()}`"
+    return f"`{val}`"
+
+
+def generate_table() -> str:
+    """Generate the markdown table based on Settings."""
+    rows = []
+    rows.append("| Variable | Default | Description |")
+    rows.append("|---|---|---|")
+
+    for field_name, field_info in Settings.model_fields.items():
+        env_var_name = f"H4CKATH0N_{field_name.upper()}"
+        default_val = format_default(field_info.default)
+        desc = field_info.description or ""
+
+        # specific hardcoded additions based on existing docs to not break them
+        if env_var_name == "H4CKATH0N_RP_ID":
+            default_val = "`localhost` in development"
+        elif env_var_name == "H4CKATH0N_ORIGIN":
+            default_val = "`http://localhost:8000` in development"
+
+        rows.append(f"| `{env_var_name}` | {default_val} | {desc} |")
+
+    # Also add OPENAI_API_KEY as it's documented but not prefixed
+    rows.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+
+    return "\n".join(rows) + "\n"
+
+
+def update_readme() -> None:
+    readme_text = README.read_text(encoding="utf-8")
+    table = generate_table()
+
+    # We use a non-greedy match to replace everything between markers
+    pattern = re.compile(r"(<!-- BEGIN ENV VARS -->\n).*?(<!-- END ENV VARS -->)", re.DOTALL)
+
+    if not pattern.search(readme_text):
+        print(
+            "❌ Could not find <!-- BEGIN ENV VARS --> and <!-- END ENV VARS --> "
+            "markers in README.md."
+        )
+        sys.exit(1)
+
+    new_text = pattern.sub(rf"\g<1>{table}\g<2>", readme_text)
+    README.write_text(new_text, encoding="utf-8")
+    print("✅ README.md updated successfully.")
+
+
+def check_readme() -> None:
+    readme_text = README.read_text(encoding="utf-8")
+    table = generate_table()
+
+    pattern = re.compile(r"(<!-- BEGIN ENV VARS -->\n)(.*?)(<!-- END ENV VARS -->)", re.DOTALL)
+
+    match = pattern.search(readme_text)
+    if not match:
+        print(
+            "❌ Could not find <!-- BEGIN ENV VARS --> and <!-- END ENV VARS --> "
+            "markers in README.md."
+        )
+        sys.exit(1)
+
+    current_table = match.group(2)
+    if current_table != table:
+        print("❌ Configuration documentation in README.md is out of sync with Settings.")
+        print("Run `uv run scripts/generate_env_docs.py --update` to fix it.")
+        sys.exit(1)
+
+    print("✅ Configuration documentation is up to date.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--update", action="store_true", help="Update README.md with generated env docs"
+    )
+    group.add_argument(
+        "--check", action="store_true", help="Check if README.md env docs are up to date"
+    )
+
+    args = parser.parse_args()
+
+    if args.update:
+        update_readme()
+    elif args.check:
+        check_readme()

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,82 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline in development instead of using Redis"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes (default 50MB)"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the web template frontend"
+    )
+    email_backend: str = Field(default="file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(default="noreply@localhost", description="Sender email address")
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file email backend"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(
+        default=False, description="Enable demo mode constraints (e.g. disable config changes)"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Moved the source of truth for the `README.md` Configuration section directly into the `pydantic-settings` `Settings` class by utilizing `Field(description="...")`. A new script `generate_env_docs.py` parses these settings to maintain a Markdown table automatically.
🎯 Why: Environment variables configured in the codebase were not consistently represented in documentation. Relying on hand-written tables invites configuration drift (several properties like SMTP and Storage were already missing from the doc).
🧪 Verification: Tested by running `uv run scripts/generate_env_docs.py --update` and executing the full locked test suite locally.
🔒 Drift Prevention: Added `generate_env_docs.py --check` as a step in `.github/workflows/ci.yml`. This enforces that `README.md` must accurately reflect the code state.
🗺️ Evidence: `src/h4ckath0n/config.py` acts as the definitive source of truth.

---
*PR created automatically by Jules for task [14458684011557187054](https://jules.google.com/task/14458684011557187054) started by @ToolchainLab*