### PR TITLE
⚡ Bolt: [performance improvement] Use db.get() for primary key lookup in passkey mutations

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
**💡 What:** 
Replaced `db.execute(select(WebAuthnCredential).filter(...))` with `db.get(WebAuthnCredential, key_id)` in the `rename_passkey` and `revoke_passkey` functions in `src/h4ckath0n/auth/passkeys/service.py`. Ownership validation (`user_id`) is handled efficiently in Python post-fetch.

**🎯 Why:**
When looking up models by their Primary Key, `db.get()` is substantially more performant because it checks the current session's Identity Map first. If the object was already loaded in the transaction, this avoids an unnecessary network roundtrip to the database entirely, which is valuable in hot paths like authentication flows.

**📊 Impact:**
Reduces database roundtrips during passkey modifications when the credential object might already exist in the session cache, preventing unnecessary parsing and hydration overhead.

**🔬 Measurement:**
This improvement was verified using existing tests ensuring authorization controls correctly prevent users from modifying or viewing credentials they do not own.

All backend tests pass locally with `uv run pytest tests/` and code passes all locked CI constraints (`ruff format`, `ruff check`, and `mypy`).

---
*PR created automatically by Jules for task [1687554858167221952](https://jules.google.com/task/1687554858167221952) started by @ToolchainLab*