### PR TITLE
⚡ Bolt: Use db.get() for passkey lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-24 - Optimize DB queries by combining db.get() and Python logic
+
+**Learning:** When looking up a database record using both its primary key and a secondary attribute (e.g., verifying ownership `id == key_id AND user_id == user.id`), using a combined SQL `filter()` bypasses the SQLAlchemy Identity Map. This forces a database trip even if the object is already loaded, and creates unnecessary SQL generation overhead.
+
+**Action:** When querying by both a primary key and a secondary attribute, optimize by fetching with `await db.get(Model, primary_key)` to utilize the Identity Map, and then validate the secondary attribute in Python (e.g., `if cred is None or cred.user_id != user.id:`).

--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup and check secondary attribute in Python
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup and check secondary attribute in Python
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 **What:** Replaced `db.execute(select(WebAuthnCredential).filter(...))` with `await db.get(WebAuthnCredential, key_id)` in `rename_passkey` and `revoke_passkey`, migrating the secondary attribute (`user_id`) ownership check to Python.

🎯 **Why:** Bypassing the SQLAlchemy Identity Map with a `.filter()` query forces a full database roundtrip and query generation overhead, even when the `WebAuthnCredential` object is already in memory or when looking up purely by its primary key.

📊 **Impact:** Reduces database calls for passkey management lookups by leveraging the SQLAlchemy session cache. Minor reduction in SQL parsing and generation overhead.

🔬 **Measurement:** Code changes verified safe; test suite continues to pass (`pytest` 188/188). The `.jules/bolt.md` journal has been updated with this specific insight about avoiding combining primary keys and secondary attributes in queries that could benefit from `db.get()`.

---
*PR created automatically by Jules for task [9501088954819748361](https://jules.google.com/task/9501088954819748361) started by @ToolchainLab*