### PR TITLE
🎨 Palette: [UX improvement] Add skip to main content link and explicit ARIA labels to mobile toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,9 @@
+## 2026-06-12 - Explicit ARIA Labels on Responsive Elements Fail Strict Testing Queries
+
+**Learning:** When adding explicit `aria-label` attributes to responsive UI components (e.g., adding labels to icon-only mobile menu toggles or duplicate desktop/mobile theme toggles), `getByRole` assertions in tests will fail because they find multiple elements with identical accessible names (one visible, one visually hidden by CSS media queries).
+**Action:** When adding responsive duplicate elements with identical accessible names for accessibility, explicitly update the associated testing queries from `getByRole` to `getAllByRole(...)[0]` (and `queryByRole` to `queryAllByRole(...).length === 0`) to handle the duplication gracefully in JSDOM, where CSS-based visibility is often ignored.
+
+## 2026-06-12 - Skip to Main Content Pattern
+
+**Learning:** A standard accessibility pattern for keyboard navigation requires a "Skip to main content" link that becomes visible on focus.
+**Action:** When working on application layout structures, ensure there is an anchor link targeting `id="main-content"` at the very top of the DOM tree that becomes visually evident only on `focus-visible:` or `focus:` state.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,17 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", {
+      name: "Theme: system (dark)",
+    })[0];
+    if (!button) throw new Error("Button not found");
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,24 +78,27 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0];
+    if (!button) throw new Error("Button not found");
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0],
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(button);
+    const buttonDark = screen.getAllByRole("button", { name: "Theme: dark" })[0];
+    if (!buttonDark) throw new Error("Dark button not found");
+    fireEvent.click(buttonDark);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+        screen.queryAllByRole("button", { name: /Theme: system/ }).length,
+      ).toBe(0);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,12 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-white focus:rounded-b-lg focus:outline-none focus:ring-2 focus:ring-primary-hover focus:ring-offset-2 focus:ring-offset-surface"
+      >
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -192,6 +198,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +214,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label="Toggle mobile menu"
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +279,10 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main
+        id="main-content"
+        className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8"
+      >
         <Outlet />
       </main>
 


### PR DESCRIPTION
- 💡 What: Added a visually hidden "Skip to main content" link for keyboard navigation that becomes visible on focus. Also added explicit `aria-label`s to the icon-only mobile toggles for the menu and theme switcher in the layout component, and updated test files to accommodate duplicate aria-labels generated for responsive screens.
- 🎯 Why: Screen reader users and keyboard navigators require a clear path to skip repetitive navigation links directly to the main content area. Furthermore, icon-only buttons require explicit `aria-label`s so screen readers announce their function properly.
- 📸 Before/After: Not visibly changed unless using keyboard navigation.
- ♿ Accessibility: Improved keyboard accessibility via a skip-to-content link, and improved screen-reader accessibility for the mobile navbar toggle buttons.

---
*PR created automatically by Jules for task [17533678850834576960](https://jules.google.com/task/17533678850834576960) started by @ToolchainLab*