### PR TITLE
🧭 Atlas: Sync env vars docs with config loader and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check environment variables
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Config field drift without automation
+
+**Learning:** Environment variables and settings drift silently when not programmatically synced with documentation. Checking whether a Pydantic `Settings` model's fields are documented prevents configuration options from becoming "hidden knowledge".
+
+**Action:** Always generate or explicitly check Pydantic model configuration fields against their documentation counterparts using a CI script.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (if using Redis extra) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline without workers in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default background job queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local`, etc.) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50MB default) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email sending backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode features and restrictions |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable from Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    sys.path.insert(0, str(REPO_ROOT / "src"))  # noqa: E402
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    readme_text = README.read_text()
+
+    missing = []
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            continue
+
+        env_var = f"H4CKATH0N_{field_name.upper()}"
+        if f"`{env_var}`" not in readme_text:
+            missing.append(env_var)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for m in missing:
+            print(f"  {m}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(
+        f"✅ All {len(Settings.model_fields)} environment variables are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Documented all missing environment variables in `README.md` and added a script `scripts/check_env_vars.py` to automatically check for configuration drift in the future.
🎯 Why: Configuration drift leads to "hidden knowledge" where deployment options exist in `src/h4ckath0n/config.py` but are not documented, frustrating new users and causing debugging pain.
🧪 Verification: Run `uv run scripts/check_env_vars.py` locally and observe the CI checks pass.
🔒 Drift Prevention: Added `scripts/check_env_vars.py` to the GitHub Actions CI workflow to ensure that any new Pydantic `Settings` fields must be documented.
🗺️ Evidence: Treated `src/h4ckath0n/config.py` `Settings.model_fields` as the source of truth.

---
*PR created automatically by Jules for task [13032613084297193236](https://jules.google.com/task/13032613084297193236) started by @ToolchainLab*