### PR TITLE
⚡ Bolt: [performance improvement] Use session.get() for primary key lookup in CLI

### DIFF
--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,10 +148,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        # ⚡ Bolt: Use session.get() for primary key lookup
+        return session.get(User, user_id)
 
+    stmt = select(User).where(User.email == email)
     return session.execute(stmt).scalars().first()
 
 


### PR DESCRIPTION
- 💡 What: Replaced `session.execute(select(User).where(User.id == user_id)).scalars().first()` with `session.get(User, user_id)` in the `_resolve_user` function in `src/h4ckath0n/cli.py`.
- 🎯 Why: Using `session.get()` is faster because it first checks the SQLAlchemy Identity Map. If the object is already loaded in the current session, it avoids a database roundtrip entirely. If not, it falls back to a primary key lookup.
- 📊 Impact: Faster user resolution in CLI commands when using `--user-id`, reducing database queries if the object is already in the session.
- 🔬 Measurement: Observe the number of database queries executed during CLI command execution when resolving users by ID. Run tests to ensure no regressions in functionality.

---
*PR created automatically by Jules for task [1404556247029598656](https://jules.google.com/task/1404556247029598656) started by @ToolchainLab*