### PR TITLE
🎨 Palette: [Accessibility improvement] Add skip to main content link and missing ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - [Skip-to-content and multiple elements testing]
+ **Learning:** When adding ARIA labels to responsive UI elements that are duplicated (like the theme toggle button for desktop vs mobile), existing tests using `getByRole` will break because it now matches multiple elements instead of one.
+ **Action:** Update test logic to account for multiple matching elements using `getAllByRole(...)[0]` or similar query combinations when duplicating attributes for responsive design.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
-    fireEvent.click(button);
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0];
+    fireEvent.click(button as HTMLElement);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,24 +75,23 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0];
 
-    fireEvent.click(button);
+    fireEvent.click(button as HTMLElement);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0],
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(button);
+    fireEvent.click(button as HTMLElement);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
-      expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+      const buttons = screen.queryAllByRole("button", { name: /Theme: system/ });
+      expect(buttons).toHaveLength(0);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,12 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-4 focus:bg-surface focus:text-text focus:font-medium focus:border-b focus:border-border"
+      >
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -192,6 +198,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +214,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-expanded={isMobileMenuOpen}
+                aria-label="Toggle mobile menu"
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +279,7 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main id="main-content" className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <Outlet />
       </main>
 


### PR DESCRIPTION
💡 What: Added a skip-to-main-content link, missing `id="main-content"` on the main wrapper, and ARIA labels for the mobile navigation toggle buttons.
🎯 Why: To improve keyboard navigation usability (skip repetitive nav links) and to ensure screen reader users have proper context for icon-only mobile toggle buttons.
📸 Before/After: Visual regression screenshot attached in verification steps. "Skip to main content" becomes visible on keyboard focus.
♿ Accessibility: Directly addresses WCAG success criterion 2.4.1 (Bypass Blocks) and 4.1.2 (Name, Role, Value) for interactive elements without visible text.

---
*PR created automatically by Jules for task [14886571281799745916](https://jules.google.com/task/14886571281799745916) started by @ToolchainLab*