### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-05 - User Enumeration Timing Attack in Authentication
+**Vulnerability:** The password authentication endpoint was susceptible to user enumeration via timing attack. It returned immediately when an email was not found, but performed an expensive Argon2 hash verification when the user was found.
+**Learning:** This is a classic timing attack vulnerability, where the response time reveals whether an email is registered or not. It existed because the early return optimization bypassed the hash verification.
+**Prevention:** Always ensure constant-time processing for authentication requests, even for invalid users. When an early return is necessary, execute a dummy verification (e.g., using a pre-computed dummy hash) to normalize response times.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -17,6 +17,12 @@ from h4ckath0n.auth.models import Device, PasswordResetToken, User
 from h4ckath0n.config import Settings
 from h4ckath0n.rng import token_urlsafe as _rng_urlsafe
 
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4"
+    "$V0lwBWTx985dpN0ZURTC7g"
+    "$gOgIbGUPgWe5qA947M8JyxrItb8umIsGJOSj0fWy4oo"
+)
+
 
 def _hash_token(token: str) -> str:
     """SHA-256 hash a token for storage."""
@@ -76,8 +82,10 @@ async def authenticate_user(db: AsyncSession, email: str, password: str) -> User
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
     if (user := result.scalars().first()) is None:
+        verify_password(password, _DUMMY_HASH)
         return None
     if not user.password_hash:
+        verify_password(password, _DUMMY_HASH)
         return None
     if not verify_password(password, user.password_hash):
         return None


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** User Enumeration Timing Attack. The password authentication endpoint returned immediately when an email was not found, but performed an expensive Argon2 hash verification when the user was found. This timing difference allows attackers to determine if an email is registered in the system.
🎯 **Impact:** Attackers could enumerate registered users, facilitating targeted phishing, credential stuffing, or other social engineering attacks.
🔧 **Fix:** Introduced a constant-time dummy password verification (using a pre-computed valid Argon2 hash) that executes when a user is not found or lacks a password hash. This normalizes the response time regardless of whether the email exists.
✅ **Verification:** Verified that tests pass via `uv run pytest tests/` and confirmed constant-time execution behavior.

---
*PR created automatically by Jules for task [15130421725133493423](https://jules.google.com/task/15130421725133493423) started by @ToolchainLab*