### PR TITLE
🧭 Atlas: Prevent environment variable documentation drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-05-17 - Prevent Env Var Documentation Drift
+**Learning:** Adding new fields to Pydantic Settings (config) without documenting them in the README Configuration section is a common drift pattern. This makes it difficult for users to know what configuration options are available.
+**Action:** Created `scripts/check_env_vars.py` to introspect `Settings.model_fields` and verify that each `H4CKATH0N_{FIELD}` appears in `README.md`. Integrated this into CI so that any new configuration variable must be explicitly documented.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend, either 'file' or 'smtp' |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every configuration variable is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+
+The script imports the Settings class from h4ckath0n.config, enumerates all fields,
+and checks that README.md mentions each one in the Configuration table.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+SRC_PATH = REPO_ROOT / "src"
+
+sys.path.insert(0, str(SRC_PATH))
+from h4ckath0n.config import Settings  # noqa: E402
+
+
+def check_env_vars_in_readme() -> list[str]:
+    """Return env vars that are not mentioned anywhere in README.md."""
+    readme_text = README.read_text()
+    missing: list[str] = []
+
+    for field in Settings.model_fields:
+        # Construct the expected environment variable name
+        env_var = f"H4CKATH0N_{field.upper()}"
+
+        # We look for the env var enclosed in backticks in the README
+        pattern = rf"`{env_var}`"
+        if not re.search(pattern, readme_text):
+            missing.append(env_var)
+
+    return missing
+
+
+def main() -> int:
+    missing = check_env_vars_in_readme()
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  {env_var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(
+        f"✅ All {len(Settings.model_fields)} environment variables are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added missing environment variables to the Configuration table in README.md and implemented a script (`scripts/check_env_vars.py`) to prevent future drift.

🎯 Why: Users were unable to easily discover configuration options because new Pydantic Settings fields were frequently added without updating the README. This creates a painful onboarding and troubleshooting experience.

🧪 Verification: 
- `uv run scripts/check_env_vars.py`
- `uv run --locked ruff format .`
- `uv run --locked ruff check .`
- `uv run --locked mypy src scripts`
- `uv run --locked pytest -v`

🔒 Drift Prevention: Added `scripts/check_env_vars.py` and integrated it into the GitHub Actions CI (`.github/workflows/ci.yml`). This script ensures that every `H4CKATH0N_` variable defined in the `Settings` model is documented in `README.md`.

🗺️ Evidence: 
- `src/h4ckath0n/config.py` (Source of truth for configuration variables via Pydantic Settings)

---
*PR created automatically by Jules for task [15144740295840783964](https://jules.google.com/task/15144740295840783964) started by @ToolchainLab*