### PR TITLE
⚡ Bolt: Use Identity Map for Passkey lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+## 2026-03-24 - Secondary Attribute Lookups Can Piggyback on Identity Map
+
+**Learning:** When needing to load an object by a primary key and verify a secondary attribute (like `user_id == user.id`), querying both in `select().filter(id == pk, user_id == uid)` defeats the `db.get()` optimization because SQLAlchemy treats it as a complex query and hits the database every time.
+
+**Action:** In these cases, it is much faster to use `await db.get(Model, pk)` to leverage the Identity Map and avoid the database roundtrip. If the object exists, the secondary attribute can then be checked locally in Python (`if cred.user_id != user.id:`).

--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,9 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize Identity Map
+    cred = await db.get(WebAuthnCredential, key_id)
+    if cred is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +371,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup to utilize Identity Map
+        cred = await db.get(WebAuthnCredential, key_id)
+        if cred is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What: Replaced `db.execute(select(...).filter(...))` with `await db.get(...)` for passkey lookups in `rename_passkey` and `revoke_passkey`, migrating the `user_id` check to standard Python evaluation post-fetch.

🎯 Why: Querying by primary key using a `select().filter(...)` bypasses the SQLAlchemy Identity Map and forces a full database roundtrip, as well as parsing and hydration overhead.

📊 Impact: Reduces database query latency and overhead for these common credential mutation operations by leveraging the session Identity Map.

🔬 Measurement: Verify changes in `src/h4ckath0n/auth/passkeys/service.py` where `db.get()` is now used, and confirm test suite passes to ensure invariant validation (like unowned object checks) still functions properly.

---
*PR created automatically by Jules for task [17299474141157708081](https://jules.google.com/task/17299474141157708081) started by @ToolchainLab*