### PR TITLE
🧭 Atlas: Enforce environment variable documentation parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars doc parity
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-05-18 - Enforce Environment Variable Parity with Settings.model_fields
+**Learning:** Checking documentation drift for environment variables against Pydantic settings requires using `Settings.model_fields` (in Pydantic V2) instead of accessing `.keys()` or iterating on the class directly to avoid `PydanticDeprecatedSince211` warnings.
+**Action:** Always parse the source of truth (e.g., `model_fields` in `h4ckath0n.config.Settings`) dynamically and verify it against markdown documentation iteratively to prevent silent drift of env var documentation.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development without a worker |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend: `local` or `s3` (if extra installed) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend: `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every env var in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Fix: Dynamically insert SRC_PATH to find local modules before importing them,
+# otherwise "uv run scripts/check_env_vars.py" or just calling it may fail
+# if the app isn't installed. We use # noqa: E402 on subsequent imports.
+SRC_PATH = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC_PATH))
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    readme_text = README.read_text()
+    missing = []
+
+    # Extract all documented variables from the Configuration table
+    # Matches lines like: | `H4CKATH0N_ENV` | `development` | ...
+    documented_vars = set()
+    for line in readme_text.splitlines():
+        match = re.match(r"^\|\s*`([A-Z0-9_]+)`\s*\|", line)
+        if match:
+            documented_vars.add(match.group(1))
+
+    prefix = "H4CKATH0N_"
+    # Access model_fields to avoid PydanticDeprecatedSince211 warnings
+    for field_name in Settings.model_fields:
+        env_name = f"{prefix}{field_name.upper()}"
+        if env_name not in documented_vars:
+            missing.append(env_name)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nPlease add them to the Configuration table in README.md.")
+        return 1
+
+    print("✅ All environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added a new automated script (`scripts/check_env_vars.py`) that uses Pydantic's `Settings.model_fields` to verify that all environment variables are documented in the `README.md` Configuration table, and wired it into CI. Also added the previously missing environment variables to the documentation.
🎯 Why: To prevent silent drift between the application's configuration surface and its documentation, ensuring users and contributors have an accurate source of truth for all environment variables.
🧪 Verification: Locally run `uv run scripts/check_env_vars.py`.
🔒 Drift Prevention: Added `uv run --locked scripts/check_env_vars.py` to `.github/workflows/ci.yml`.
🗺️ Evidence: `src/h4ckath0n/config.py` (specifically `Settings.model_fields`) is treated as the source of truth.

---
*PR created automatically by Jules for task [3908940023637813190](https://jules.google.com/task/3908940023637813190) started by @ToolchainLab*