### PR TITLE
⚡ Bolt: Use db.get() for passkey primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,9 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    cred = await db.get(WebAuthnCredential, key_id)
+    if cred is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +371,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        cred = await db.get(WebAuthnCredential, key_id)
+        if cred is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
- 💡 What: Replaced `db.execute(select(...))` with `await db.get(...)` for retrieving `WebAuthnCredential` objects by primary key (`key_id`) in both `rename_passkey` and `revoke_passkey`, followed by an explicit Python-level check for authorization (`cred.user_id != user.id`).
- 🎯 Why: Lookups using `db.execute(select(...))` bypass the SQLAlchemy Identity Map and always hit the database. By switching to `db.get(...)`, we first check if the requested credential is already fully hydrated in the current session's Identity Map. If it is, the database round-trip and parsing overhead are completely avoided. If it isn't, the resulting query is still optimized for a direct primary key retrieval.
- 📊 Impact: Eliminates unnecessary database queries and SQLAlchemy hydration overhead during operations that follow previous credential lookups or exist within hot paths, providing a marginal but measurable performance boost with no loss of security.
- 🔬 Measurement: Observe SQLAlchemy query logs to confirm fewer redundant queries are executed during passkey lifecycle operations. Verify test coverage ensures authorization remains strictly enforced.

---
*PR created automatically by Jules for task [668105431494639316](https://jules.google.com/task/668105431494639316) started by @ToolchainLab*