### PR TITLE
🧭 Atlas: Enforce environment variable documentation parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var docs drift and generation
+
+**Learning:** When using Pydantic Settings, environment variables often drift from the documentation because there's no native link between the model and the markdown file. I used a custom script (`check_env_vars.py`) to reflect on the `Settings` model fields and check if the resulting env vars exist in the README.
+**Action:** When adding or modifying environment variables in Pydantic `Settings`, ensure to also document them in the `README.md` Configuration table. Create and run automated checks (like `scripts/check_env_vars.py`) on CI to ensure the parity between code and documentation is strictly maintained.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development environment |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection directly |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (e.g., restricts certain destructive actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every env var in h4ckath0n.config is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    readme_text = README.read_text()
+
+    missing = []
+
+    # We prefix with H4CKATH0N_ unless field explicitly overrides it
+    prefix = Settings.model_config.get("env_prefix", "H4CKATH0N_")
+
+    for field_name in Settings.model_fields:
+        env_var = f"{prefix}{field_name}".upper()
+
+        # Check if the env_var is mentioned in the table in README
+        # Look for it wrapped in backticks
+        if not re.search(rf"`{env_var}`", readme_text):
+            missing.append(env_var)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  {env_var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(
+        f"✅ All {len(Settings.model_fields)} environment variables are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Documented 17 missing environment variables in `README.md` and added a `check_env_vars.py` script to enforce environment variable documentation parity in CI.
🎯 Why: Environment variables defined in Pydantic `Settings` often drift from the documentation, leading to incorrect local configurations and production issues. This ensures that the documentation is always fully aligned with the codebase's settings model.
🧪 Verification: Run `uv run scripts/check_env_vars.py` locally and verify that it passes. Run the full test suite with `uv run pytest tests/`.
🔒 Drift Prevention: The `check_env_vars.py` script is now executed on CI (`.github/workflows/ci.yml`), failing the build if any environment variable exists in `h4ckath0n.config.Settings` but isn't documented in `README.md`.
🗺️ Evidence: `src/h4ckath0n/config.py` was used as the source of truth for the available environment variables.

---
*PR created automatically by Jules for task [7995433561801919460](https://jules.google.com/task/7995433561801919460) started by @ToolchainLab*