### PR TITLE
🎨 Palette: [UX improvement] Add skip to main content link and ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Duplicate Responsive Controls A11y Testing
+**Learning:** When ensuring mobile responsive UI elements (e.g. mobile vs desktop theme toggle buttons) have accessible names (`aria-label`), `getByRole` will fail in React Testing Library if the test assumes only one component is present.
+**Action:** When an interface has both mobile and desktop variants of the same control in the DOM, ensure RTL tests handle multiple elements (e.g., using `getAllByRole(...)[0] as HTMLElement` and `.length > 0` assertions).

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,8 +49,8 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
-      ).toBeInTheDocument();
+        screen.getAllByRole("button", { name: "Theme: system (dark)" }).length,
+      ).toBeGreaterThan(0);
     });
   });
 
@@ -58,15 +58,15 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
-    fireEvent.click(button);
+    const buttons = screen.getAllByRole("button", { name: "Theme: system (dark)" });
+    fireEvent.click(buttons[0] as HTMLElement);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
-      ).toBeInTheDocument();
+        screen.getAllByRole("button", { name: "Theme: light" }).length,
+      ).toBeGreaterThan(0);
     });
   });
 
@@ -75,24 +75,24 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const buttons = screen.getAllByRole("button", { name: "Theme: light" });
 
-    fireEvent.click(button);
+    fireEvent.click(buttons[0] as HTMLElement);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
-      ).toBeInTheDocument();
+        screen.getAllByRole("button", { name: "Theme: dark" }).length,
+      ).toBeGreaterThan(0);
     });
 
-    fireEvent.click(button);
+    fireEvent.click(screen.getAllByRole("button", { name: "Theme: dark" })[0] as HTMLElement);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+        screen.queryAllByRole("button", { name: /Theme: system/ }).length,
+      ).toBe(0);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,12 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-surface focus:text-primary"
+      >
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -191,6 +197,11 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={toggleTheme}
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
                 className="mr-2"
               >
                 {effectiveTheme === "dark" ? (
@@ -203,6 +214,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-expanded={isMobileMenuOpen}
+                aria-label={isMobileMenuOpen ? "Close main menu" : "Open main menu"}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +279,7 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main id="main-content" className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <Outlet />
       </main>
 


### PR DESCRIPTION
💡 What: 
- Added a visually-hidden, keyboard-focusable "Skip to main content" link to the layout.
- Added `aria-label` to the mobile theme toggle to match its desktop counterpart.
- Added `aria-expanded` and `aria-label` to the mobile menu toggle button.
- Updated `Layout.test.tsx` to handle testing duplicated responsive elements.
- Documented testing learning in `.jules/palette.md`.

🎯 Why: 
Keyboard-only users need an easy way to bypass redundant navigation links and access the primary content directly. Screen reader users need proper context when interacting with icon-only buttons like the mobile theme and menu toggles. Testing React environments with responsive DOM duplication requires handling element arrays correctly.

📸 Before/After:
Before: Mobile icon buttons had no accessible names, navigation couldn't be easily skipped via keyboard.
After: Focus states cleanly reveal a "Skip to main content" link that directs the browser to `<main id="main-content">`, and all buttons are labeled semantically for assistive tech.

♿ Accessibility:
- "Skip to main content" link.
- `aria-label` on icon-only buttons.
- State communication via `aria-expanded`.
- Keyboard navigation verified via `.focus` classes.

---
*PR created automatically by Jules for task [8290739811120869020](https://jules.google.com/task/8290739811120869020) started by @ToolchainLab*