### PR TITLE
🧭 Atlas: Add env vars parity drift prevention script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars parity
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-05-20 - Ensure Config and Env Vars Docs Drift Parity
+
+**Learning:** Pydantic models (like `Settings`) are the source of truth for application configuration, but their corresponding environment variable forms often drift in documentation. Relying on manual updates or searching for the exact doc variable string can lead to missing properties.
+
+**Action:** Add scripts that iterate over the Pydantic `Settings.model_fields` to programmatically generate the expected environment variable keys (e.g. `H4CKATH0N_` + field name), then verify their explicit existence inside `README.md` and include this drift-prevention script in CI.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory path for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max allowed upload size in bytes (50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web frontend for links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails in `file` mode |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings_vars() -> list[str]:
+
+    # Ensure src is in the path to import h4ckath0n
+    sys.path.insert(0, str(REPO_ROOT / "src"))  # noqa: E402
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    vars = []
+    # Using dictionary iteration per memory style guidelines
+    for field in Settings.model_fields:
+        vars.append(f"H4CKATH0N_{field.upper()}")
+    return sorted(vars)
+
+
+def check_vars_in_readme(vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing = []
+    for var in vars:
+        if rf"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    vars = get_settings_vars()
+    missing = check_vars_in_readme(vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added a script `scripts/check_env_vars.py` that reads Pydantic `Settings.model_fields` and validates their presence in `README.md`. Documented the missing environment variables in `README.md` and added the script execution to `.github/workflows/ci.yml`.
🎯 Why: Environment variables often drift between actual code configuration and documentation. This automates the check to ensure no new config keys go undocumented.
🧪 Verification: Run `uv run --locked scripts/check_env_vars.py`. This script is now verified during CI as well.
🔒 Drift Prevention: Added `scripts/check_env_vars.py` to `.github/workflows/ci.yml` so CI fails if any environment variables drift from documentation.
🗺️ Evidence: `src/h4ckath0n/config.py` uses Pydantic `Settings` as the definitive source of truth for configuration keys.

---
*PR created automatically by Jules for task [14995608569897872695](https://jules.google.com/task/14995608569897872695) started by @ToolchainLab*