### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-21 - User Enumeration Timing Attack
+**Vulnerability:** User enumeration timing attack vulnerability in `authenticate_user` function.
+**Learning:** Returning early when a user isn't found or has no password hash creates a timing difference, allowing an attacker to determine if an email is registered by timing the login request.
+**Prevention:** Always perform constant-time validation paths. Execute a dummy verification step with a pre-computed constant hash when returning early to normalize response times.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -35,6 +35,13 @@ def _require_password_extra() -> tuple:  # type: ignore[type-arg]
         ) from exc
 
 
+# A dummy Argon2id hash for constant-time dummy verification.
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$ZMXrA1zoWqQof8GDQOXUNQ"
+    "$kQ8oDk3uKKtdNf2odSygXW9PBeZTMndNfWCFnQAHMdA"
+)
+
+
 async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) -> bool:
     """Decide whether a newly-registered user should be admin."""
     if email in settings.bootstrap_admin_emails:
@@ -75,10 +82,14 @@ async def register_user(
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    # To prevent user enumeration timing attacks, perform a dummy verification
+    # if the user doesn't exist or doesn't have a password set.
+    if user is None or not user.password_hash:
+        verify_password(password, _DUMMY_HASH)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User Enumeration via Timing Attack. Returning early when an email isn't registered creates a noticeable timing difference compared to when an email is registered and the Argon2id hash is computed.
🎯 Impact: Attackers can determine if specific email addresses are registered in the system, compromising user privacy and aiding targeted attacks.
🔧 Fix: Implemented constant-time validation paths by adding a pre-computed dummy Argon2id hash (`_DUMMY_HASH`) and executing a dummy verification step (`verify_password(password, _DUMMY_HASH)`) when returning early for invalid/non-existent users to normalize response times.
✅ Verification: Ran `pytest` suite ensuring all tests still pass and login flows remain functional without timing differences.

---
*PR created automatically by Jules for task [18349090407527842795](https://jules.google.com/task/18349090407527842795) started by @ToolchainLab*