### PR TITLE
🧭 Atlas: Document missing environment variables and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2023-11-20 - Ensure environment variables are documented and synchronized in README.md
+
+**Learning:** We discovered that a significant number of environment variables defined in `src/h4ckath0n/config.py` using `pydantic-settings` were not documented in the `README.md`. It's easy for the documentation of configuration values to drift from the actual code.
+**Action:** Created `scripts/check_env_vars.py` to enforce parity between configuration fields defined in `Settings` and those documented in `README.md`. Also added it to the CI pipeline to prevent future regressions. We should always check for undocumented config options using similar scripts.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs (optional extra) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+
+The script imports the Settings class, enumerates all fields, and checks that
+README.md mentions each one in the Configuration table.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings_env_vars() -> list[str]:
+    """Return a list of environment variable names from Settings."""
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    env_vars = []
+    # Hardcoded or special environment variables
+    env_vars.append("OPENAI_API_KEY")
+
+    # Access model_fields on the class itself to avoid PydanticDeprecatedSince211
+    for field_name in Settings.model_fields:
+        env_vars.append(f"H4CKATH0N_{field_name.upper()}")
+
+    return sorted(env_vars)
+
+
+def check_env_vars_in_readme(env_vars: list[str]) -> list[str]:
+    """Return env vars that are not mentioned in README.md."""
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for var in env_vars:
+        # Check if var is in the markdown text (specifically as code block)
+        pattern = rf"`{var}`"
+        if not re.search(pattern, readme_text):
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_settings_env_vars()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
* 💡 **What**: Documented all missing environment variables in `README.md` and added a drift-prevention script (`scripts/check_env_vars.py`).
* 🎯 **Why**: A significant number of environment variables defined in `src/h4ckath0n/config.py` using `pydantic-settings` were not documented in the README. It's easy for configuration documentation to drift from the actual code, leaving users unaware of available settings.
* 🧪 **Verification**: Run `uv run scripts/check_env_vars.py` locally to verify that all environment variables found in `Settings` are documented in the README.
* 🔒 **Drift Prevention**: The `scripts/check_env_vars.py` script has been added to the backend CI job in `.github/workflows/ci.yml`. It parses `Settings.model_fields` and fails if any environment variable is missing from the `README.md`, ensuring they stay synchronized.
* 🗺️ **Evidence**: The fields defined in `src/h4ckath0n/config.py` via `pydantic-settings` `BaseSettings` class are used as the source of truth for all available application environment variables.

---
*PR created automatically by Jules for task [2291140139705292221](https://jules.google.com/task/2291140139705292221) started by @ToolchainLab*