### PR TITLE
⚡ Bolt: Optimize primary key lookups with db.get()

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,10 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None:
+        raise ValueError("Credential not found")
+    if cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +372,10 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None:
+            raise ValueError("Credential not found")
+        if cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,11 +148,11 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        return session.execute(stmt).scalars().first()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Replaced `execute(select(...).filter(...)).scalars().first()` queries with `await db.get(...)` or `session.get(...)` for primary key lookups in `h4ckath0n/auth/passkeys/service.py` (`rename_passkey` and `revoke_passkey`) and `h4ckath0n/cli.py` (`_fetch_user`). Added inline validation for secondary criteria like `user_id`.

🎯 Why: Querying full ORM objects by their primary key with `select().filter(id == pk)` bypasses the SQLAlchemy Identity Map and always hits the database. Using `db.get()` first checks the Identity Map and, if the object is already cached, skips the database roundtrip entirely. 

📊 Impact: Reduces unnecessary database queries and hydration overhead during common operations like passkey revocation, renaming, and CLI user fetching.

🔬 Measurement: Verifiable by monitoring database query logs. Re-running the `pytest` suite guarantees no logic or validation was skipped by shifting the ownership check (`user_id`) to Python memory.

---
*PR created automatically by Jules for task [4523630709234234704](https://jules.google.com/task/4523630709234234704) started by @ToolchainLab*