### PR TITLE
🎨 Palette: Add keyboard focus indicator to theme radio buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-22 - Add keyboard focus indicator to visually hidden theme radio buttons
+**Learning:** When using Tailwind's `sr-only` to visually hide native `<input type="radio">` elements, the browser's default keyboard focus indicator is lost. This makes it impossible for keyboard users to see which option is currently focused.
+**Action:** Always apply `has-[:focus-visible]:ring-2` (or similar focus ring utilities) to the visible parent wrapper (e.g., `<label>`) of visually hidden inputs to ensure keyboard focus indicators are preserved and displayed around the visible component.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -290,7 +290,7 @@ export function Settings() {
               <label
                 key={option}
                 className={cn(
-                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all",
+                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-offset-2",
                   themePreference === option
                     ? "border-primary bg-primary/5"
                     : "border-border",


### PR DESCRIPTION
💡 What: Added `has-[:focus-visible]:` utility classes to the `<label>` wrapping the visually hidden (`sr-only`) theme preference radio inputs in the Settings page.

🎯 Why: When using Tailwind's `sr-only` to visually hide native inputs for custom UI, the browser's default keyboard focus indicator is lost. This prevents keyboard-only users from seeing which theme option is currently focused when navigating with the Tab key.

📸 Before/After: Visual verification was completed locally using Playwright to confirm the focus ring appears around the entire label card when focused.

♿ Accessibility: Restores standard keyboard focus visibility to a custom form control, improving WCAG compliance and overall usability for keyboard-navigating users.

---
*PR created automatically by Jules for task [4773781659682924774](https://jules.google.com/task/4773781659682924774) started by @ToolchainLab*