### PR TITLE
🧭 Atlas: Document all environment variables and add drift prevention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2026-02-28 - Env vars drift check prevents forgotten configuration docs
+
+**Learning:** When new configuration variables are added to a Pydantic `Settings` model, developers frequently forget to document them in `README.md` or `.env.example`. This leads to a severe drift between the repo's behavior and the documentation.
+**Action:** Always maintain a docs drift check script (like `check_env_vars.py`) that parses the Pydantic `Settings` class and validates that every field is explicitly documented in the README table. Integrate this script into the CI pipeline to prevent regressions.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline without Redis in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | `local` or `s3` (s3 not fully implemented) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max file upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Frontend base URL for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based emails |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    """Return environment variables from Settings."""
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    prefix = Settings.model_config.get("env_prefix", "")
+    env_vars: list[str] = []
+
+    for field in Settings.model_fields:
+        env_vars.append(f"{prefix}{field}".upper())
+
+    if "OPENAI_API_KEY" not in env_vars:
+        env_vars.append("OPENAI_API_KEY")
+
+    return sorted(env_vars)
+
+
+def check_env_vars_in_readme(env_vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for var in env_vars:
+        pattern = rf"`{var}`"
+        if not re.search(pattern, readme_text):
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Documented all unlisted configuration environment variables (like `H4CKATH0N_REDIS_URL`, `H4CKATH0N_SMTP_HOST`, etc.) in `README.md` and created an automated check script (`scripts/check_env_vars.py`) to keep them synced with the `Settings` model.
🎯 Why: Environment variables often drift as new features (like Redis or SMTP) are added but forgotten in documentation. This leads to user frustration and onboarding difficulties.
🧪 Verification: Run `uv run --locked pytest -v` for general tests and `uv run --locked scripts/check_env_vars.py` to locally verify the new drift check script passes.
🔒 Drift Prevention: `scripts/check_env_vars.py` was added, and it inspects `src/h4ckath0n/config.py` using `Settings.model_fields` and confirms every field is listed in `README.md`. It has been wired up to run as part of `.github/workflows/ci.yml`.
🗺️ Evidence: `src/h4ckath0n/config.py` (the `Settings` class definition was parsed), `README.md` (the "Configuration" section was examined), and `.github/workflows/ci.yml` (the GitHub Action was checked).

---
*PR created automatically by Jules for task [7872668355361319362](https://jules.google.com/task/7872668355361319362) started by @ToolchainLab*