### PR TITLE
⚡ Bolt: Use session.get() for primary key lookup in _resolve_user

### DIFF
--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,11 +148,11 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use session.get() for primary key lookup
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        return session.execute(stmt).scalars().first()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 **What:** Replaced the `select(User).where(User.id == user_id)` query with `session.get(User, user_id)` inside the `_resolve_user` function in `src/h4ckath0n/cli.py`.
🎯 **Why:** To improve performance. `session.get()` is optimized for primary key lookups because it checks the SQLAlchemy Identity Map (the session's local cache) first. If the object is present, it entirely avoids a roundtrip to the database.
📊 **Impact:** Speeds up user resolution in the CLI by skipping an unnecessary database roundtrip when the user model is already in the active session cache.
🔬 **Measurement:** The test suite passes. The improvement could be measured by profiling the query counts before and after the change in a trace session where the user entity is accessed multiple times.

---
*PR created automatically by Jules for task [10213444096624062732](https://jules.google.com/task/10213444096624062732) started by @ToolchainLab*