### PR TITLE
🎨 Palette: [UX improvement] Add skip link and responsive ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Adding Skip Links and Responsive ARIA Labels
+**Learning:** When adding `aria-label` to identical desktop and mobile UI elements (like theme or menu toggles), test queries utilizing `getByRole` might fail due to multiple matches. Skip links should utilize a hidden but focusable strategy like `sr-only focus:not-sr-only`.
+**Action:** When adding ARIA labels to components duplicated for responsive design, immediately check and update the corresponding frontend tests to use `getAllByRole(...)[0] as HTMLElement` or similar array access. Always use `#main-content` paired with `tabIndex={-1}` for the main document skip-link target.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0] as HTMLElement;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0] as HTMLElement;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0],
       ).toBeInTheDocument();
     });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,12 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-4 focus:bg-surface focus:text-primary focus:font-medium focus:ring-2 focus:ring-primary focus:outline-none focus:rounded-br-xl"
+      >
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -192,6 +198,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +214,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label="Toggle mobile menu"
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +279,11 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 focus:outline-none"
+      >
         <Outlet />
       </main>
 


### PR DESCRIPTION
* 💡 **What:** Added a hidden-until-focused "Skip to main content" link at the top of the application layout targeting the main content area (`<main>`). Added explicit `aria-label` attributes to the mobile theme and menu toggle buttons. Updated frontend tests to use `getAllByRole` array indexing when ARIA labels are duplicated across responsive variants.
* 🎯 **Why:** Keyboard-only users and screen readers need a quick way to bypass repeated navigation links to reach the core content, fulfilling a critical accessibility requirement. Mobile screen reader users need explicit ARIA labels on icon-only buttons to understand their purpose, since visual icons alone are insufficient.
* 📸 **Before/After:** No visible changes unless interacting with a keyboard or screen reader. The skip link appears gracefully upon `Tab` focus.
* ♿ **Accessibility:**
  - Skip link added (`href="#main-content"`).
  - Main content area explicitly identified with `id="main-content"` and `tabIndex={-1}` for programmatic focus without a default focus ring (`focus:outline-none`).
  - Added `aria-label` to the mobile theme toggle matching its desktop counterpart.
  - Added `aria-label` and `aria-expanded` to the mobile menu button.
  - Resolved resulting test duplication issues by safely selecting the first match via `getAllByRole(...)[0]`.

---
*PR created automatically by Jules for task [8819972037120530926](https://jules.google.com/task/8819972037120530926) started by @ToolchainLab*