### PR TITLE
🧭 Atlas: Sync env vars and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var drift prevention via Settings.model_fields
+
+**Learning:** Environment variables documented in READMEs often drift from the actual application configuration. Pydantic's `Settings.model_fields` is the source of truth for the config schema in this repository.
+
+**Action:** Write scripts that extract all expected environment variables directly from `Settings.model_fields` and verify that they are mentioned in the `README.md` to guarantee documentation parity.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max file upload size in bytes (50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that env vars in the Settings model are documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+SRC_PATH = REPO_ROOT / "src"
+sys.path.insert(0, str(SRC_PATH))
+
+
+def get_config_env_vars() -> list[str]:
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    env_vars: list[str] = []
+    for field_name in Settings.model_fields:
+        env_vars.append(f"H4CKATH0N_{field_name.upper()}")
+
+    return env_vars
+
+
+def check_env_vars_in_readme(env_vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for var in env_vars:
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_config_env_vars()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added a script to enforce documentation parity for all environment variables defined in Pydantic's `Settings.model_fields`, and updated `README.md` to document the 17 previously missing variables.
🎯 Why: Environment variables documented in READMEs frequently drift from the actual application configuration. Missing configuration documentation slows down onboarding and makes the codebase harder to navigate. This resolves a major mismatch where over half of the application's configuration options were undocumented.
🧪 Verification: `uv run --locked scripts/check_env_vars.py` verifies that all environment variables are present in the README. `uv run --locked pytest -v` runs the full test suite.
🔒 Drift Prevention: `scripts/check_env_vars.py` was added to the backend CI job in `.github/workflows/ci.yml`. Any future un-documented configuration additions to `src/h4ckath0n/config.py` will now break the build, preventing regressions.
🗺️ Evidence: `src/h4ckath0n/config.py` (`Settings.model_fields`) and `README.md` (Configuration table).

---
*PR created automatically by Jules for task [4183744986075554920](https://jules.google.com/task/4183744986075554920) started by @ToolchainLab*