### PR TITLE
⚡ Bolt: Use session.get() and db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,9 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    cred = await db.get(WebAuthnCredential, key_id)
+    if cred is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +371,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        cred = await db.get(WebAuthnCredential, key_id)
+        if cred is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -147,10 +147,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         _err("specify exactly one of --user-id or --email")
         return None
 
+    # ⚡ Bolt: Use session.get() for primary key lookup
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        return session.get(User, user_id)
+    stmt = select(User).where(User.email == email)
 
     return session.execute(stmt).scalars().first()
 


### PR DESCRIPTION
💡 What: Replaced `execute(select(Model).filter(...)).scalars().first()` and `.where()` queries with `db.get(Model, pk)` and `session.get(Model, pk)` for primary key lookups in `h4ckath0n/cli.py` and `h4ckath0n/auth/passkeys/service.py`.

🎯 Why: Querying objects by their primary key via `execute(select(...))` bypasses the SQLAlchemy Identity Map, forcing a roundtrip to the database and compiling the statement every time. Using `get()` allows SQLAlchemy to serve the record from the session cache if it's already loaded, and skips statement compilation.

📊 Impact: Reduces database latency and memory overhead by leveraging the session identity map and avoiding unnecessary query execution and hydration for single-record lookups by primary key.

🔬 Measurement: Local tests and CI pass. The changes apply directly to performance bottlenecks documented in the bolt.md journal.

---
*PR created automatically by Jules for task [4395632982591765593](https://jules.google.com/task/4395632982591765593) started by @ToolchainLab*