### PR TITLE
🎨 Palette: [UX improvement] Add skip-to-content and aria-labels to Layout

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility on Responsive Layout elements
+**Learning:** Added skip-to-main-content hidden element and updated ARIA labels. I also noticed tests using `getByRole` need to handle multiple items like `getAllByRole(...)[0]` when components have duplicated elements hidden by CSS for responsive modes.
+**Action:** When making accessible changes that impact responsive layout menus or toggle elements which exist in desktop vs. mobile, update associated vitest RTL checks to target explicitly the first element using `getAllByRole(...)[0]`.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
-    fireEvent.click(button);
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" });
+    fireEvent.click(button[0] as HTMLElement);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,18 +75,19 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" });
 
-    fireEvent.click(button);
+    fireEvent.click(button[0] as HTMLElement);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0],
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(button);
+    const buttonDark = screen.getAllByRole("button", { name: "Theme: dark" });
+    fireEvent.click(buttonDark[0] as HTMLElement);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,12 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-4 focus:bg-surface focus:text-text"
+      >
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -192,6 +198,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +214,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-expanded={isMobileMenuOpen}
+                aria-label={isMobileMenuOpen ? "Close mobile menu" : "Open mobile menu"}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +279,7 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main id="main-content" tabIndex={-1} className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 outline-none">
         <Outlet />
       </main>
 


### PR DESCRIPTION
💡 What: Added a visually hidden but programmatically focusable skip-to-main-content link, and added explicit `aria-label` and `aria-expanded` attributes to mobile layout nav buttons. Updated test suites and journals.
🎯 Why: Skip-to-content supports keyboard-only navigation users jumping immediately past dense repeated navigation, while the Aria additions explicitly identify interactive icons to screen readers correctly matching the elements intent.
📸 Before/After: Visual changes demonstrated via playwright capture, focusing the skip link explicitly shows it layered over content.
♿ Accessibility: High impact - provides fundamental navigation skipping feature and labels unlabeled interactive icons for assistive tooling.

---
*PR created automatically by Jules for task [13139146205955490475](https://jules.google.com/task/13139146205955490475) started by @ToolchainLab*