### PR TITLE
🧭 Atlas: enforce environment variable documentation parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars documentation
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var documentation parity
+
+**Learning:** Environment variables frequently drift between config definitions and documentation, especially when using auto-populating config mechanisms like Pydantic settings. Adding a check script that compares `Settings.model_fields` against the `README.md` documentation reliably catches this drift.
+
+**Action:** Add drift prevention checks that map config variables generated from the source code directly to the documentation (e.g., using a custom script like `check_env_vars.py`) and wire them into CI.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend: `local` or other supported options |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max file upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web frontend for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend: `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using file backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable implicit SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every configuration setting in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings_fields() -> list[str]:
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    return list(Settings.model_fields)
+
+
+def check_env_vars_in_readme(fields: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+
+    for field in fields:
+        env_var_name = f"H4CKATH0N_{field.upper()}"
+        if field == "openai_api_key":
+            has_openai = re.search(r"`OPENAI_API_KEY`", readme_text)
+            has_h4ck = re.search(r"`H4CKATH0N_OPENAI_API_KEY`", readme_text)
+            if not has_openai and not has_h4ck:
+                missing.append(field)
+            continue
+
+        combined = rf"`{env_var_name}`"
+        if not re.search(combined, readme_text):
+            missing.append(field)
+
+    return missing
+
+
+def main() -> int:
+    fields = get_settings_fields()
+    missing = check_env_vars_in_readme(fields)
+
+    if missing:
+        print("❌ The following configuration variables are NOT documented in README.md:\n")
+        for field in missing:
+            env_var_name = f"H4CKATH0N_{field.upper()}"
+            print(f"  {env_var_name}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(fields)} configuration variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Documented all missing `H4CKATH0N_` environment variables in `README.md` and introduced a drift-prevention script.
🎯 Why: Environment variables often drift between config definitions and documentation. This ensures developers have a complete and accurate reference for configuring the application, reducing confusion during onboarding and deployment.
🧪 Verification: Run `uv run scripts/check_env_vars.py` to locally verify that all fields in `h4ckath0n.config.Settings` are documented in `README.md`.
🔒 Drift Prevention: Added `scripts/check_env_vars.py` and integrated it into the backend CI pipeline in `.github/workflows/ci.yml`. It will fail the build if a new variable is added to the settings model without being documented.
🗺️ Evidence: Checked against the source of truth in `src/h4ckath0n/config.py` (`Settings.model_fields`).

---
*PR created automatically by Jules for task [60492410862708657](https://jules.google.com/task/60492410862708657) started by @ToolchainLab*