### PR TITLE
⚡ Bolt: Use db.get() for primary key lookup

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup to utilize the identity map
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup to utilize the identity map
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,11 +148,11 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use session.get() for primary key lookup to utilize the identity map
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        return session.execute(stmt).scalars().first()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 **What:** Replaced ORM `select().where(Model.id == pk)` queries with `db.get(Model, pk)` when looking up records by primary key in `cli.py` and `passkeys/service.py`. Enforced user ownership checks explicitly in code for the passkey operations.
🎯 **Why:** Bypassing the SQLAlchemy Identity Map for primary key lookups incurs unnecessary database roundtrips and parsing overhead. Utilizing `db.get()` is faster and leverages existing session state.
📊 **Impact:** Reduces database load and latency for primary key lookups (e.g. resolving users and looking up credentials).
🔬 **Measurement:** Verify tests run successfully without any regression and ensure `db.get()` is called directly without invoking `execute(select(...))`.

All existing functional validations and ownership assertions remain preserved. Tested locally.

---
*PR created automatically by Jules for task [3508317934211554634](https://jules.google.com/task/3508317934211554634) started by @ToolchainLab*