### PR TITLE
🎨 Palette: Add keyboard focus indicators to theme picker

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Preserve keyboard focus indicators on custom radio buttons with sr-only inputs
+**Learning:** When using Tailwind's `sr-only` to visually hide native inputs (e.g., in custom radio buttons), the focus ring is lost, severely hurting keyboard accessibility.
+**Action:** Always apply `has-focus-visible:` or `has-[:focus-visible]:` utility classes (e.g., `has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-offset-2`) to the visible parent wrapper (e.g., `<label>`) to ensure keyboard focus indicators are preserved.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -290,7 +290,7 @@ export function Settings() {
               <label
                 key={option}
                 className={cn(
-                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all",
+                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all has-focus-visible:ring-2 has-focus-visible:ring-primary has-focus-visible:ring-offset-2",
                   themePreference === option
                     ? "border-primary bg-primary/5"
                     : "border-border",


### PR DESCRIPTION
💡 What: Added focus ring styles (`has-focus-visible:ring-2`, etc.) to the labels that wrap the visually hidden `sr-only` theme preference radio inputs.
🎯 Why: When native radio inputs are hidden using `sr-only`, they lose their native focus ring. This makes it impossible for keyboard users to tell which theme option has focus when tabbing through the settings page. Adding the `has-focus-visible:` pseudo-class to the parent label restores a clear, accessible focus indicator.
📸 Before/After: Visually invisible for mouse users, but keyboard tab navigation now correctly shows the primary focus ring around the selected theme card.
♿ Accessibility: Restores critical focus visibility for keyboard-only users interacting with custom radio buttons.

---
*PR created automatically by Jules for task [12248167729711334901](https://jules.google.com/task/12248167729711334901) started by @ToolchainLab*