### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-25 - Prevent User Enumeration Timing Attack
+**Vulnerability:** User enumeration timing attack in `authenticate_user`. When a user was not found or had no password, the function returned immediately without verifying a password. This allowed an attacker to determine if an email address was registered by measuring the response time (which would be significantly shorter for non-existent users since argon2id hashing takes measurable time).
+**Learning:** Early returns in authentication flows leak information through timing differences. Security features like password hashing, intentionally designed to be slow, amplify this side channel.
+**Prevention:** Always ensure constant-time processing in authentication flows. For operations with variable work like password verification, perform a dummy verification against a pre-computed constant hash if the actual required work is skipped (e.g., when a user is not found).

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -72,13 +72,23 @@ async def register_user(
     return user
 
 
+# Pre-computed dummy hash to prevent user enumeration timing attacks
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$8sYO0NU/qk5tbu5p5vD6ag"
+    "$3fzOFlBSLLwPkhkV0YKzQ+KaguqvHshcxzs5ns++EVw"
+)
+
+
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    if user is None or not user.password_hash:
+        # Dummy verification to prevent timing attacks
+        verify_password(password, _DUMMY_HASH)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User enumeration timing attack in `authenticate_user`. Because argon2id hashing takes a measurable amount of time, returning early when a user is not found or has no password allowed attackers to determine if an email is registered by timing the response.
🎯 Impact: Attackers could enumerate registered users, which can be used for targeted phishing or credential stuffing attacks.
🔧 Fix: Add a dummy verification step using a pre-computed constant hash when the required work is skipped (e.g., user not found). This normalizes response times.
✅ Verification: Ran `uv run pytest` and verified the logic is now structurally uniform regardless of whether a user is found or not.

---
*PR created automatically by Jules for task [13034268167288102411](https://jules.google.com/task/13034268167288102411) started by @ToolchainLab*