### PR TITLE
🧭 Atlas: Sync env vars docs with config.py and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2026-05-25 - Prevent Environment Variable Documentation Drift
+**Learning:** In a fast-moving repo with centralized configuration via pydantic-settings (`src/h4ckath0n/config.py`), new configuration fields are frequently added (e.g. email, storage, redis, demo mode) but the README.md documentation drifts out of sync.
+**Action:** Created `scripts/check_env_vars.py` to introspect `Settings.model_fields` and assert that every configuration variable exists in `README.md`. Will add this script to the CI quality gates.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend to use |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Email sender address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable config is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+CONFIG_FILE = REPO_ROOT / "src" / "h4ckath0n" / "config.py"
+
+
+def get_config_vars() -> list[str]:
+    # Modify sys.path dynamically and use no_qa to prevent Ruff errors
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    vars_list = []
+    # Avoid SIM118 per style memory
+    for field in Settings.model_fields:
+        if field == "openai_api_key":
+            vars_list.append("OPENAI_API_KEY")
+            vars_list.append("H4CKATH0N_OPENAI_API_KEY")
+        else:
+            vars_list.append(f"H4CKATH0N_{field.upper()}")
+    return sorted(set(vars_list))
+
+
+def check_vars_in_readme(vars_list: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing = []
+    for var in vars_list:
+        pattern = rf"`{var}`"
+        if not re.search(pattern, readme_text):
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    vars_list = get_config_vars()
+    missing = check_vars_in_readme(vars_list)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(vars_list)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 **What**: Added all missing environment variables found in `src/h4ckath0n/config.py` to `README.md`. It also creates a new drift prevention script, `scripts/check_env_vars.py`, that uses Pydantic's introspectable fields to assert that every environment variable in the application's configuration is listed in `README.md`. This script has been integrated into the `.github/workflows/ci.yml` pipeline.

🎯 **Why**: In a fast-moving repo with centralized configuration via pydantic-settings, new configuration fields are frequently added, but the README.md documentation drifts out of sync. This leaves users confused about how to configure the application.

🧪 **Verification**: Ran `uv run scripts/check_env_vars.py` and the backend CI checks (`uv run --locked pytest -v`, `uv run --locked ruff check .`, `uv run --locked ruff format .`, `uv run --locked mypy src`) to verify all variables are documented and no regressions were introduced.

🔒 **Drift Prevention**: Created a `scripts/check_env_vars.py` script that statically evaluates the Pydantic `Settings` model. Integrated this check as a mandatory step in `.github/workflows/ci.yml`.

🗺️ **Evidence**: The true state of configuration was sourced directly from `src/h4ckath0n/config.py`.

---
*PR created automatically by Jules for task [7715113677169523137](https://jules.google.com/task/7715113677169523137) started by @ToolchainLab*