### PR TITLE
∴ Vector: Centralize auth scopes parsing into pure helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-26 - Import `Iterable` from `collections.abc`
+**Learning:** The project uses Ruff which enforces UP035. Importing `Iterable` from `typing` will fail the CI linting gate.
+**Action:** Always import abstract base classes like `Iterable`, `Sequence`, or `Mapping` from `collections.abc` instead of `typing`.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import normalize_scope_list, parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -83,12 +84,12 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[str] = set(filter(None, map(str.strip, scopes)))
+    needed: set[str] = set(normalize_scope_list(scopes))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
-            missing_scopes = ", ".join(missing)
+            missing_scopes = ", ".join(sorted(missing))
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Missing scope(s): {missing_scopes}",

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,28 @@
+"""Pure functional helpers for parsing, validating, and formatting scopes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def normalize_scope_list(scopes: Iterable[str]) -> list[str]:
+    """
+    Clean and deduplicate a sequence of scope strings, preserving order.
+    Whitespace is stripped, and empty strings are ignored.
+    """
+    parts = filter(None, (s.strip() for s in scopes if s is not None))
+    return list(dict.fromkeys(parts))
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """
+    Parse a comma-separated scopes string into a cleaned list.
+    """
+    return normalize_scope_list(raw.split(","))
+
+
+def format_scopes(scopes: Iterable[str]) -> str:
+    """
+    Format an iterable of scope strings into a normalized comma-separated string.
+    """
+    return ",".join(normalize_scope_list(scopes))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,12 +23,11 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,
         role=user.role,
-        scopes=scopes,
+        scopes=parse_scopes(user.scopes),
         display_name=user.display_name,
         email=user.email,
     )

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import format_scopes, parse_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -122,13 +123,6 @@ def _get_db_url(args: argparse.Namespace) -> str:
 
 def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
     return create_sync_engine(url)
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +445,9 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
-            for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+            existing = parse_scopes(user.scopes)
+            existing.extend(args.scope)
+            user.scopes = format_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +473,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
             to_remove = {s.strip() for s in args.scope}
+            existing = parse_scopes(user.scopes)
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = format_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -509,7 +502,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            user.scopes = _normalize_scopes(args.scopes)
+            user.scopes = format_scopes(parse_scopes(args.scopes))
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_auth_scopes.py
+++ b/tests/test_auth_scopes.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from h4ckath0n.auth.scopes import format_scopes, normalize_scope_list, parse_scopes
+
+
+def test_normalize_scope_list() -> None:
+    # Handles empty/null/whitespace inputs
+    assert normalize_scope_list(["", "  ", None]) == []  # type: ignore
+
+    # Strips whitespace
+    assert normalize_scope_list(["  a  ", "b\n"]) == ["a", "b"]
+
+    # Deduplicates while preserving order
+    assert normalize_scope_list(["c", "a", "c", "b", "a"]) == ["c", "a", "b"]
+
+
+def test_parse_scopes() -> None:
+    # Handles empty and whitespace-only strings
+    assert parse_scopes("") == []
+    assert parse_scopes("   ") == []
+
+    # Handles commas and whitespace
+    assert parse_scopes("a, b ,c") == ["a", "b", "c"]
+
+    # Handles trailing/leading commas and duplicates
+    assert parse_scopes(",a,b,a,,c,") == ["a", "b", "c"]
+
+
+def test_format_scopes() -> None:
+    # Handles empty lists
+    assert format_scopes([]) == ""
+
+    # Normalizes, deduplicates, and formats correctly
+    assert format_scopes([" c", "a ", "c", "", "b"]) == "c,a,b"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -125,28 +124,6 @@ class TestAlembicUrlNormalization:
         exit_code = cli_module._cmd_db_migrate_current(args)
         assert exit_code == 0
         assert make_url(captured["sqlalchemy.url"]) == make_url("sqlite:///./test.db")
-
-
-# ---------------------------------------------------------------------------
-# Scopes normalization
-# ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Extracted scattered, ad hoc scope string normalization into a centralized, pure `h4ckath0n.auth.scopes` module with `parse_scopes`, `format_scopes`, and `normalize_scope_list` helpers.
- 🎯 Why: Scope parsing and normalization was duplicated across the CLI, session router, and auth dependencies. The implementations varied slightly in execution (e.g. the CLI using sets which drop order) making bug hunting difficult.
- 🧠 Design: Replacing multiple list comprehensions and scattered logic across routes and CLI with pure helpers ensures that the security-relevant scoping logic maintains deterministic order and identical stripping across the entire application boundary.
- λ FP Angle: Reduces side-effects and mutation by pushing formatting and deduping logic into pure, testable transformation functions.
- ✅ Verification: Run full pytest suite, mypy strict type checking, and ruff formatter/linter.
- 🧪 Edge cases: Tested empty, null, space-padded, and duplicated scope configurations in a new `test_auth_scopes.py` file.
- ⚠️ Risk: Extremely low risk since this only pulls out identical list-comprehension/set operations. Order is now strictly maintained in the CLI where it previously relied on arbitrary set evaluation.

---
*PR created automatically by Jules for task [5686592804769068485](https://jules.google.com/task/5686592804769068485) started by @ToolchainLab*