### PR TITLE
🎨 Palette: Add skip to content link and menu ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-26 - Responsive Hidden Accessibility
+**Learning:** When adding ARIA labels to components that have responsive duplicates (e.g. desktop vs mobile toggles), existing tests using getByRole will fail because they find duplicate elements.
+**Action:** Ensure tests use getAllByRole()[0] when querying elements that exist in both desktop and mobile layouts.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        (screen.getAllByRole("button", { name: "Theme: system (dark)" })[0] as HTMLElement),
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = (screen.getAllByRole("button", { name: "Theme: system (dark)" })[0] as HTMLElement);
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        (screen.getAllByRole("button", { name: "Theme: light" })[0] as HTMLElement),
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = (screen.getAllByRole("button", { name: "Theme: light" })[0] as HTMLElement);
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        (screen.getAllByRole("button", { name: "Theme: dark" })[0] as HTMLElement),
       ).toBeInTheDocument();
     });
 
@@ -91,7 +91,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
+        (screen.queryAllByRole("button", { name: /Theme: system/ }).length === 0 ? null : screen.queryAllByRole("button", { name: /Theme: system/ })[0]),
       ).not.toBeInTheDocument();
     });
   });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,9 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a href="#main-content" className="sr-only focus:not-sr-only px-4 py-2 bg-primary text-primary-foreground absolute z-50">
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -192,6 +195,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +211,7 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label="Toggle mobile menu"
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +275,7 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main id="main-content" tabIndex={-1} className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 outline-none">
         <Outlet />
       </main>
 


### PR DESCRIPTION
- 💡 What: Added a visually hidden "Skip to main content" link at the top of the application layout, designated the main content area to receive programmatic focus, and added missing `aria-label`s to the mobile theme and menu toggle icon buttons.
- 🎯 Why: To significantly improve keyboard navigation flow for screen readers and power users, and to ensure icon-only buttons clearly announce their purpose to assistive technology on mobile viewports.
- 📸 Before/After: Visual changes were successfully verified via headless Playwright, confirming the skip link becomes visible when focused.
- ♿ Accessibility: Fixes missing context on mobile interactive elements and provides an essential bypass mechanism for repetitive navigation links.

---
*PR created automatically by Jules for task [3700019377642067730](https://jules.google.com/task/3700019377642067730) started by @ToolchainLab*