### PR TITLE
🧭 Atlas: Add drift-prevention script for environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars parity
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-05-26 - Prevent Environment Variable Drift
+**Learning:** Environment variables frequently diverge between the code (`src/h4ckath0n/config.py`) and documentation (`README.md`), leading to onboarding confusion and missing configurations.
+**Action:** Always implement a dedicated drift-prevention check (like `scripts/check_env_vars.py`) that explicitly verifies documentation parity with the source of truth config structures (e.g. `Settings.model_fields` in pydantic-settings), and enforce it in CI alongside existing documentation checks.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline (without Redis) in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default RQ queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application (used in emails) |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for the `file` email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that all configuration settings in Settings are documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+
+The script imports the h4ckath0n app Settings, extracts all setting fields, and checks that
+README.md documents each one (prefixing them with H4CKATH0N_ or OPENAI_).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+SRC_PATH = REPO_ROOT / "src"
+
+sys.path.insert(0, str(SRC_PATH))
+
+
+def get_settings_keys() -> list[str]:
+    """Return all setting keys from Settings."""
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    # Avoid SIM118 errors by iterating directly over the dictionary
+    keys: list[str] = []
+    for key in Settings.model_fields:
+        keys.append(key)
+    return sorted(keys)
+
+
+def check_env_vars_in_readme(
+    keys: list[str],
+) -> list[str]:
+    """Return env vars that are not documented in the configuration table."""
+    readme_text = README.read_text()
+    missing: list[str] = []
+
+    # We look for ``H4CKATH0N_ENV`` etc in the markdown file
+    for key in keys:
+        env_var = key.upper() if key.startswith("openai_") else f"H4CKATH0N_{key.upper()}"
+
+        # Build a pattern to find `ENV_VAR` in the markdown file
+        combined = rf"`{re.escape(env_var)}`"
+        if not re.search(combined, readme_text, re.IGNORECASE):
+            missing.append(env_var)
+
+    return missing
+
+
+def main() -> int:
+    keys = get_settings_keys()
+    missing = check_env_vars_in_readme(keys)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  {env_var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(keys)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added a script to enforce environment variable parity between `src/h4ckath0n/config.py` and `README.md` and updated the `README.md` with the missing variables.
🎯 Why: Environment variables often drift between code and documentation, causing onboarding issues and missing configurations.
🧪 Verification: `uv run scripts/check_env_vars.py` passes and CI is updated to run it.
🔒 Drift Prevention: Added `scripts/check_env_vars.py` which dynamically extracts fields from Pydantic and enforces their presence in the `README.md` documentation, run automatically in GitHub Actions.
🗺️ Evidence: `src/h4ckath0n/config.py`, `README.md`, `.github/workflows/ci.yml`.

---
*PR created automatically by Jules for task [15230620234513849824](https://jules.google.com/task/15230620234513849824) started by @ToolchainLab*