### PR TITLE
⚡ Bolt: Use db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What: Replaced explicit `select().filter(...)` queries for retrieving single WebAuthn credentials with SQLAlchemy's `db.get()` in the passkeys service (`rename_passkey`, `revoke_passkey`). Ownership checks are shifted to the Python level.

🎯 Why: `db.get()` checks the Session's Identity Map first, potentially avoiding a database roundtrip entirely if the object is already loaded, and generates simpler queries when a roundtrip is needed. The previous implementation bypassed the Identity Map.

📊 Impact: Reduces database latency and query parsing overhead for critical and high-frequency paths like credential renaming and revoking.

🔬 Measurement: Verifiable by monitoring database query counts/latencies for these specific routes under load. The test suite (`uv run pytest tests/test_passkeys.py`) ensures correctness is preserved.

---
*PR created automatically by Jules for task [1505446742138169130](https://jules.google.com/task/1505446742138169130) started by @ToolchainLab*