### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - Prevent User Enumeration Timing Attacks in Authentication
+**Vulnerability:** Timing attack allowing user enumeration in `authenticate_user` because password hashing was skipped when a user or password hash was missing.
+**Learning:** Early returns in authentication flows leak information via response timing.
+**Prevention:** Always execute a constant-time dummy password verification using a pre-computed hash if the user doesn't exist, to normalize response times.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -72,13 +72,22 @@ async def register_user(
     return user
 
 
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4$"
+    "etdCr/dM6sO627jPclRkgQ$e18ZnJGL024vyzWOYwjgKxCxMTS+yfuw0kfUrK7aUGU"
+)
+
+
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    # 🛡️ Sentinel: Prevent user enumeration timing attacks by always performing a verification
+    if user is None or not user.password_hash:
+        verify_password(password, _DUMMY_HASH)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: User enumeration via timing attack in `authenticate_user`.
* 🎯 Impact: An attacker could guess valid registered emails by measuring the response time differences between valid and invalid usernames (since password hashing was skipped for invalid users).
* 🔧 Fix: Always execute a constant-time dummy password verification using a valid, pre-computed Argon2 hash if the user doesn't exist, to normalize response times across all paths.
* ✅ Verification: Ran tests locally to ensure no functionality is broken. Timing analysis would now show similar latency regardless of user existence.

---
*PR created automatically by Jules for task [10345423089906348873](https://jules.google.com/task/10345423089906348873) started by @ToolchainLab*