### PR TITLE
🧭 Atlas: Add drift prevention for config environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env var drift prevention
+
+**Learning:** Environment variables documented in README configuration tables frequently drift from the actual Pydantic `Settings` model fields as new features (like redis, storage, emails) are added.
+
+**Action:** Added a drift-prevention script `scripts/check_env_vars.py` that iterates over `Settings.model_fields` to verify each variable is present in `README.md`.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Frontend application base URL |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+This script ensures that all fields defined in the Pydantic Settings model are explicitly
+mentioned in the README.md file to prevent drift between the code and the documentation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings_fields() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    fields = []
+    for field in Settings.model_fields:
+        fields.append(f"H4CKATH0N_{field.upper()}")
+    if "OPENAI_API_KEY" not in fields:
+        fields.append("OPENAI_API_KEY")
+    return fields
+
+
+def check_env_vars_in_readme(env_vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing = []
+    for env_var in env_vars:
+        if env_var == "H4CKATH0N_OPENAI_API_KEY":
+            continue
+        # We look for `VAR_NAME` or just VAR_NAME
+        if f"`{env_var}`" not in readme_text and env_var not in readme_text:
+            missing.append(env_var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_settings_fields()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  {env_var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added a new `scripts/check_env_vars.py` script that iterates over `Settings.model_fields` and verifies that all environment variables are explicitly mentioned in the `README.md` configuration table. Updated the README with missing fields, and added the script to the GitHub Actions CI workflow.

🎯 Why: Environment variables documented in README configuration tables frequently drift from the actual Pydantic `Settings` model fields as new features (like redis, storage, emails) are added. This mismatch misleads developers and causes onboarding/configuration pain.

🧪 Verification: Run `uv run scripts/check_env_vars.py` locally. It should output `✅ All X environment variables are documented in README.md.` Run `uv run pytest -v` to ensure no functionality is broken.

🔒 Drift Prevention: The `scripts/check_env_vars.py` script is now executed as part of the `backend` job in `.github/workflows/ci.yml`. Any new variable added to `src/h4ckath0n/config.py` that is not documented in the README will fail the CI.

🗺️ Evidence: `src/h4ckath0n/config.py` (specifically `Settings.model_fields`) is the authoritative source for environment variable configuration.

---
*PR created automatically by Jules for task [7739904741484283671](https://jules.google.com/task/7739904741484283671) started by @ToolchainLab*