### PR TITLE
∴ Vector: Centralize display name validation logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Centralize display name validation logic
+**Learning:** The logic to clean and validate `display_name` is duplicated across schemas in `auth` and `auth/passkeys`.
+**Action:** Extract a centralized, pure helper function or validator that acts as a single source of truth for display name normalization.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, clean_display_name
 
 # -- Registration --
 
@@ -21,10 +21,7 @@ class PasskeyRegisterStartRequest(BaseModel):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return clean_display_name(v)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -18,6 +18,14 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def clean_display_name(v: str) -> str:
+    """Trim whitespace and reject empty-after-trim values for required fields."""
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict | None = Field(
         None,
@@ -38,10 +46,7 @@ class RegisterRequest(DeviceBindingMixin):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return clean_display_name(v)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted duplicated `display_name` whitespace trimming and empty-string validation into a single, centralized pure helper function (`clean_display_name` in `src/h4ckath0n/auth/schemas.py`).
- 🎯 Why: To enforce a single source of truth for display name normalization. Previously, identical validation logic lived in both the password registration schema and the passkey registration schema.
- 🧠 Design: Replacing repeated inline imperative mutation with a shared, pure transformation helper reduces duplication and makes the semantics clearer. Both schemas now simply delegate their `@field_validator` to this central function.
- λ FP Angle: Reduces scattered, mutation-heavy ad hoc validation by moving the transformation into a pure helper with a clear contract, aligning with FP-style centralization of semantics.
- ✅ Verification: Ran the full backend test suite (`uv run pytest`) and all backend quality gates (`ruff format`, `ruff check`, `mypy`). All checks pass.
- 🧪 Edge cases: Preserves exact original behavior for whitespace-only strings (they are trimmed and then correctly rejected as empty).
- ⚠️ Risk: Minimal. This is a pure refactor of existing behavior into a shared function.

---
*PR created automatically by Jules for task [6382979486578450464](https://jules.google.com/task/6382979486578450464) started by @ToolchainLab*