### PR TITLE
🎨 Palette: Improve Layout accessibility with ARIA labels and skip link

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/.jules/palette.md
+++ b/packages/create-h4ckath0n/templates/fullstack/web/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Missing responsive ARIA labels and skip link
+**Learning:** Responsive icon buttons (like mobile menus and theme switchers) need explicit `aria-label`s and tests using `getByRole` must handle duplicate hidden elements. Also, missing skip-to-content links break keyboard navigation.
+**Action:** Always verify mobile views for screen reader accessibility, provide explicit `aria-label`s for icon buttons, ensure test resilience against responsive hidden elements, and include skip links.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0] as HTMLElement;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0] as HTMLElement;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0],
       ).toBeInTheDocument();
     });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,12 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:top-4 focus:left-4 focus:p-4 focus:bg-surface focus:text-primary focus:rounded-lg focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -192,6 +198,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +214,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +279,11 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 focus:outline-none"
+      >
         <Outlet />
       </main>
 


### PR DESCRIPTION
- 💡 What: Added missing `aria-label`s to mobile icon-only buttons (theme toggle and menu) and introduced a keyboard-accessible "Skip to main content" link. Fixed RTL tests to accommodate duplicate elements.
- 🎯 Why: To improve screen reader compatibility for mobile navigation controls and to allow keyboard-only users to bypass the navigation header.
- 📸 Before/After: See generated Playwright video/screenshots showing the skip link behavior.
- ♿ Accessibility: Fixes several WCAG accessibility violations (missing ARIA labels on buttons, missing mechanism to bypass blocks).

---
*PR created automatically by Jules for task [5845144760132402387](https://jules.google.com/task/5845144760132402387) started by @ToolchainLab*