### PR TITLE
🧭 Atlas: Sync environment variable documentation with source of truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-05-28 - Env vars drift between config loaders and documentation
+
+**Learning:** Environment variables defined in configuration loaders (like Pydantic's `Settings`) frequently drift from the documentation (e.g., `README.md`). New variables are added to the code but authors forget to document them in the configuration tables, leading to a frustrating onboarding experience.
+
+**Action:** Implement a drift prevention check that reads the actual configuration keys (e.g., via `Settings.model_fields`) and asserts their explicit presence in the documentation. Add this check to the CI pipeline to prevent future regressions.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string, required for Redis integration |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development without Redis |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every env var in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    from h4ckath0n.config import Settings
+
+    readme_text = README.read_text()
+
+    missing: list[str] = []
+    # Use model_fields on the class to avoid deprecation warnings
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            env_vars = ["OPENAI_API_KEY", "H4CKATH0N_OPENAI_API_KEY"]
+        else:
+            env_vars = [f"H4CKATH0N_{field_name.upper()}"]
+
+        found = any(env_var in readme_text for env_var in env_vars)
+        if not found:
+            missing.append(env_vars[0])
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  `{env_var}`")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(
+        f"✅ All {len(Settings.model_fields)} environment variables "
+        "from Settings are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added missing environment variables from `Settings` to the `README.md` configuration table and created a drift prevention check.
🎯 Why: Environment variables often drift between the `config.py` definitions and user documentation, leading to configuration confusion and difficult onboarding.
🧪 Verification: Run `uv run scripts/check_env_vars.py` locally to verify that all variables in `Settings` are documented in `README.md`.
🔒 Drift Prevention: Added `scripts/check_env_vars.py` which dynamically reads `Settings.model_fields` and asserts their presence in `README.md`. Wired this script into the `.github/workflows/ci.yml` quality gates to block future regressions.
🗺️ Evidence: `src/h4ckath0n/config.py` was used as the source of truth to populate the configuration section in `README.md`.

---
*PR created automatically by Jules for task [6421333181699183883](https://jules.google.com/task/6421333181699183883) started by @ToolchainLab*