### PR TITLE
∴ Vector: Centralize display name validation into a shared pure helper

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,5 @@
+## 2025-05-29 - Shared Validations in Pydantic
+
+**Learning:** When using Pydantic `field_validator`, duplication of the validation function definition (e.g. `_clean_display_name`) can be eliminated by exposing a single module-level pure helper (e.g. `clean_display_name`) and passing it to `field_validator` via functional application (e.g. `_clean_display_name = field_validator("display_name")(clean_display_name)`).
+
+**Action:** Look out for duplicated `field_validator` classmethods and extract them into shared pure functions to apply across multiple Pydantic schemas.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, clean_display_name
 
 # -- Registration --
 
@@ -18,13 +18,7 @@ class PasskeyRegisterStartRequest(BaseModel):
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
 
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    _clean_display_name = field_validator("display_name")(clean_display_name)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -8,13 +8,11 @@ from pydantic import BaseModel, EmailStr, Field, field_validator
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
+def clean_display_name(v: str) -> str:
     """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
 
 
@@ -35,13 +33,7 @@ class RegisterRequest(DeviceBindingMixin):
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
 
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    _clean_display_name = field_validator("display_name")(clean_display_name)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted duplicated `_clean_display_name` field validators in `RegisterRequest` and `PasskeyRegisterStartRequest` into a single module-level pure helper `clean_display_name`.
- 🎯 Why: To reduce duplicated validation logic and ensure a single source of truth for normalizing and validating display names across different registration endpoints.
- 🧠 Design: Removed the unused and subtly different `_validate_display_name` function, replacing it with the stricter `clean_display_name` logic which correctly raises `ValueError` on empty values. The new function is functionally composed into Pydantic models using `field_validator("...")(clean_display_name)`.
- λ FP Angle: Reduces scattered mutation and duplicated class methods in favor of a single pure transformation that makes behavior deterministic.
- ✅ Verification: Ran `uv sync --all-extras`, `uv run --locked ruff format .`, `uv run --locked ruff check .`, `uv run --locked mypy src`, and `uv run pytest`. Checked `git grep` to ensure the replaced function was unused elsewhere.
- 🧪 Edge cases: Tested handling of empty or whitespace-only display names which now correctly fail validation in both forms of registration requests uniformly.
- ⚠️ Risk: Very low risk as it preserves exact existing validation behavior on `display_name` fields while removing unused code.

---
*PR created automatically by Jules for task [8626761648594540223](https://jules.google.com/task/8626761648594540223) started by @ToolchainLab*