### PR TITLE
⚡ Bolt: Optimize primary key lookups for passkey operations

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,8 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +370,8 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 **What:** Replaced `db.execute(select(...).filter(...)).scalars().first()` with `await db.get(WebAuthnCredential, key_id)` in `src/h4ckath0n/auth/passkeys/service.py` (`rename_passkey` and `revoke_passkey`). Re-implemented the `user_id` ownership checks in Python logic to ensure security properties are preserved.

🎯 **Why:** `db.execute(select(...).filter(...))` on primary keys bypasses the SQLAlchemy Session Identity Map and always triggers a fresh database query with full parsing and hydration overhead. `db.get()` efficiently checks the local session cache first, providing faster lookups for primary keys and reducing database roundtrips.

📊 **Impact:** Reduces database query overhead by utilizing the Identity Map for passkey retrieval in rename and revoke operations. This is a targeted optimization for primary key fetches as documented in our performance journal.

🔬 **Measurement:** The test suite (`uv run pytest`) passes entirely, proving no functional regression in passkey management or security (IDOR checks). Backend CI linting (`uv run --locked ruff format .` and `uv run --locked ruff check .`) passes completely.

---
*PR created automatically by Jules for task [7493701102407149785](https://jules.google.com/task/7493701102407149785) started by @ToolchainLab*