### PR TITLE
🧭 Atlas: Enforce environment variable documentation parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars doc parity
+        run: uv run python scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-05-29 - Config Env Var Drift
+**Learning:** Configuration environment variables drift easily between the pydantic Settings model and the README documentation.
+**Action:** Created a script `scripts/check_env_vars.py` that parses `Settings.model_fields` and verifies each corresponding `H4CKATH0N_VAR` is documented in `README.md` and added it to CI.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default background job queue |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (e.g., `local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` (50MB) | Maximum file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_config_fields() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    fields = []
+    for field in Settings.model_fields:
+        fields.append(field)
+    return fields
+
+
+def check_env_vars_in_readme(fields: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for field in fields:
+        var_name = f"H4CKATH0N_{field.upper()}"
+        if var_name not in readme_text:
+            missing.append(var_name)
+    return missing
+
+
+def main() -> int:
+    fields = get_config_fields()
+    missing = check_env_vars_in_readme(fields)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(fields)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added missing environment variables to the `README.md` Configuration table and added a script `scripts/check_env_vars.py` to enforce documentation parity.
🎯 Why: Configuration environment variables easily drift between the pydantic Settings model and the README documentation, leading to incorrect or incomplete onboarding documentation.
🧪 Verification: Run `uv run python scripts/check_env_vars.py` locally to verify that all environment variables defined in the configuration are documented.
🔒 Drift Prevention: Added `scripts/check_env_vars.py` script that parses `Settings.model_fields` and fails if an environment variable is not documented. Added a step to run this script in the backend CI job in `.github/workflows/ci.yml`.
🗺️ Evidence: `src/h4ckath0n/config.py` was used as the source of truth for the environment variables configuration.

---
*PR created automatically by Jules for task [5798495747270636199](https://jules.google.com/task/5798495747270636199) started by @ToolchainLab*