### PR TITLE
🧭 Atlas: Enforce env var documentation parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-05-30 - Environment variables drift silently
+**Learning:** Pydantic `Settings` models can easily fall out of sync with README.md tables because there is no built-in linkage. Without explicit checks, default values and new features introduced in `config.py` are frequently undocumented in configuration guides.
+**Action:** Always implement a dynamic schema-reflection script (e.g., `scripts/check_env_vars.py`) that loops through Pydantic fields, formats them with their environment variable prefix, and `grep`s the README, running this script as a mandatory CI step.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline without a worker in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend: `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host for email sending |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+CONFIG_FILE = REPO_ROOT / "src" / "h4ckath0n" / "config.py"
+
+
+def get_env_vars() -> list[str]:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from h4ckath0n.config import Settings
+
+    # Prefix is H4CKATH0N_
+    prefix = Settings.model_config.get("env_prefix", "")
+
+    vars = []
+    for field_name in Settings.model_fields:
+        vars.append(f"{prefix}{field_name}".upper())
+    return sorted(vars)
+
+
+def check_vars_in_readme(vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing = []
+    for var in vars:
+        # Check if the environment variable is present in a table cell or just in the file
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    vars = get_env_vars()
+    missing = check_vars_in_readme(vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What:
Added 17 undocumented environment variables (e.g., `H4CKATH0N_APP_BASE_URL`, `H4CKATH0N_DEMO_MODE`, email settings, storage settings) to the Configuration table in `README.md` and created a script to prevent future omissions.

🎯 Why:
The Pydantic `Settings` model in `src/h4ckath0n/config.py` is the source of truth for configuration, but developers were adding new features (like SMTP, Redis, Storage) without documenting their corresponding environment variables. This creates friction for new contributors attempting to configure the app.

🔬 Verification:
- Ran `uv run python scripts/check_env_vars.py` locally and verified it passes.
- Ran the full test suite (`uv run pytest`) and linters (`ruff`, `mypy`) to ensure no regressions.

🔒 Drift Prevention:
Created `scripts/check_env_vars.py` and added it to `.github/workflows/ci.yml`. This script dynamically parses `Settings.model_fields` and fails the CI pipeline if any environment variable is missing from `README.md`.

🗺️ Evidence:
- `src/h4ckath0n/config.py` (Source of truth for environment variables via Pydantic `BaseSettings`)
- `.github/workflows/ci.yml` (Where the check is enforced)

---
*PR created automatically by Jules for task [5257583181422277639](https://jules.google.com/task/5257583181422277639) started by @ToolchainLab*