### PR TITLE
∴ Vector: Centralize display_name normalization pipeline

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,19 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, ValidDisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: ValidDisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,24 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
+def _validate_display_name(v: str) -> str:
     """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
+
+
+ValidDisplayName = Annotated[str, AfterValidator(_validate_display_name)]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +33,11 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: ValidDisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted duplicated display name validation logic (trimming whitespace and rejecting empty strings) from multiple Pydantic models into a single `ValidDisplayName` type using `Annotated` and `AfterValidator`.
- 🎯 Why: To remove duplicated parsing/normalization logic across `src/h4ckath0n/auth/schemas.py` and `src/h4ckath0n/auth/passkeys/schemas.py`, ensuring a single source of truth for name formatting rules.
- 🧠 Design: By defining `ValidDisplayName` as a declarative, reusable type, we remove the need for identical `@field_validator` methods scattered across multiple request schemas. The underlying helper function was also tightened to correctly raise `ValueError` on empty values instead of returning `None`, which aligns perfectly with how Pydantic expects `AfterValidator` to function when attached to a required `str` field.
- λ FP Angle: Replaces scattered, object-attached validation methods with a pure helper function (`_validate_display_name`) and an explicit, composable transformation pipeline (`Annotated[str, AfterValidator(...)]`). This is a more functional, declarative way to express data invariants in Python/Pydantic.
- ✅ Verification: Ran the backend test suite (`uv run pytest`), type checker (`uv run --locked mypy src`), and linters (`uv run --locked ruff check .`), as well as the full frontend Playwright E2E suite (`npm run test:e2e`). All checks pass.
- 🧪 Edge cases: The centralized logic preserves handling of leading/trailing whitespace and explicitly tests for emptiness after trimming, raising a clear validation error.
- ⚠️ Risk: Very low. This is a behavior-preserving refactor. Pydantic's native type system guarantees the `AfterValidator` executes at the correct time during model parsing.

---
*PR created automatically by Jules for task [5770783535559166346](https://jules.google.com/task/5770783535559166346) started by @ToolchainLab*