### PR TITLE
⚡ Bolt: Use db.get() for passkey primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,9 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    cred = await db.get(WebAuthnCredential, key_id)
+    if cred is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +371,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        cred = await db.get(WebAuthnCredential, key_id)
+        if cred is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What: Replaced SQLAlchemy `execute(select(...).filter(...)).scalars().first()` with `await db.get(...)` for primary key lookups in `src/h4ckath0n/auth/passkeys/service.py` (`rename_passkey` and `revoke_passkey`). Re-implemented the `user_id` check in Python to maintain authorization constraints.

🎯 Why: Using `db.get()` is a known optimization for primary key lookups. It checks the SQLAlchemy identity map first, bypassing a database query and parsing overhead if the object is already loaded, which is beneficial in high-frequency hot paths like authentication flows. The previous implementation bypassed this identity map lookup.

📊 Impact: Reduces database queries and parsing overhead for operations that fetch an already-loaded credential by its primary key. Improves efficiency for passkey rename and revoke operations.

🔬 Measurement: Verify tests run properly (all `pytest` checks and Playwright `test:e2e` pass) without regressions or broken authentication flows. Memory and timing profiling on `rename_passkey` and `revoke_passkey` operations would show reduced DB overhead when identity map caching kicks in.

---
*PR created automatically by Jules for task [10282970856856421856](https://jules.google.com/task/10282970856856421856) started by @ToolchainLab*