### PR TITLE
🧭 Atlas: Document all environment variables and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked python scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Config drift prevention using Pydantic Settings
+
+**Learning:** Documentation for environment variables often drifts from the source of truth, especially when new features or optional integrations (like Redis or SMTP) are added. The best way to prevent this in a FastAPI app using `pydantic-settings` is to dynamically parse `Settings.model_fields.keys()` and verify that each key exists in the documentation (usually prefixed with the app's env prefix, e.g. `H4CKATH0N_`). Exceptions to the prefix rule (like `OPENAI_API_KEY`) need to be handled explicitly.
+
+**Action:** When adding config drift checks, import the settings model, iterate through `model_fields.keys()`, convert keys to upper case, and search the documentation for exact matches (e.g., using `re.search(rf"\`{env_var}\`", readme_text)`). Integrate this check into the CI pipeline to enforce parity permanently.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline without a worker in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name for jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes (50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based emails |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable read-only or limited demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every config variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings_keys() -> list[str]:
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    return list(Settings.model_fields.keys())
+
+
+def check_env_vars_in_readme(keys: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for key in keys:
+        if key == "openai_api_key":
+            if not re.search(r"`OPENAI_API_KEY`", readme_text) and not re.search(
+                r"`H4CKATH0N_OPENAI_API_KEY`", readme_text
+            ):
+                missing.append("OPENAI_API_KEY")
+            continue
+
+        env_var = f"H4CKATH0N_{key.upper()}"
+        if not re.search(rf"`{env_var}`", readme_text):
+            missing.append(env_var)
+    return missing
+
+
+def main() -> int:
+    keys = get_settings_keys()
+    missing = check_env_vars_in_readme(keys)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these environment variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(keys)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Documented 17 missing configuration variables in the `README.md` Configuration table and added an automated drift check script.
🎯 Why: Environment variables often drift from their source of truth, causing onboarding friction and misconfiguration in deployment. Documenting them correctly reduces friction, while the drift check ensures no future settings are added without being documented.
🧪 Verification: Run locally with `uv run python scripts/check_env_vars.py` and see tests pass via `uv run pytest`.
🔒 Drift Prevention: Added `scripts/check_env_vars.py` which dynamically extracts `Settings.model_fields` and asserts they are present in `README.md`. This script is now enforced in the CI workflow `backend` job.
🗺️ Evidence: Used `src/h4ckath0n/config.py` (Pydantic `Settings`) as the authoritative source of truth.

---
*PR created automatically by Jules for task [8491624931295648860](https://jules.google.com/task/8491624931295648860) started by @ToolchainLab*