### PR TITLE
∴ Vector: Centralize display name validation into a shared Pydantic Annotated type

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,4 @@
+## 2025-02-20 - Centralizing Validation with Pydantic V2 `Annotated`
+
+**Learning:** When using Pydantic V2, validation logic (like trimming or string sanitization) duplicated across multiple schemas can be elegantly centralized using `typing.Annotated` in combination with `pydantic.functional_validators.AfterValidator` or `StringConstraints`. In this repo, multiple models duplicated a `@field_validator("display_name")` method to strip whitespace and check for emptiness.
+**Action:** Always prefer creating a custom `Annotated` type (e.g., `ValidDisplayName = Annotated[str, Field(max_length=200), AfterValidator(_clean_display_name)]`) to serve as a single source of truth for validation rules over repeating `@field_validator` hooks on individual fields. This keeps data models cleaner, reduces boilerplate, and enforces consistent semantics.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, ValidDisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: ValidDisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,28 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
+def _clean_display_name(v: str) -> str:
     """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
+
+
+ValidDisplayName = Annotated[
+    str,
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH),
+    AfterValidator(_clean_display_name),
+]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +37,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: ValidDisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):

--- a/vector.plan
+++ b/vector.plan
@@ -1,0 +1,6 @@
+1. Remove `_validate_display_name` and the duplicate `@field_validator("display_name")` methods in `src/h4ckath0n/auth/schemas.py` and `src/h4ckath0n/auth/passkeys/schemas.py`.
+2. Introduce a reusable `ValidDisplayName` type in `src/h4ckath0n/auth/schemas.py` using `typing.Annotated` and `pydantic.functional_validators.AfterValidator` as recommended in `.jules/vector.md` memory for V2 models.
+3. Update `RegisterRequest` in `src/h4ckath0n/auth/schemas.py` and `PasskeyRegisterStartRequest` in `src/h4ckath0n/auth/passkeys/schemas.py` to use `ValidDisplayName`.
+4. Run tests to ensure everything still passes (`uv run pytest tests/`).
+5. Run linting and formatting.
+6. Commit the changes and open PR as Vector.


### PR DESCRIPTION
💡 What:
Replaced duplicated `@field_validator("display_name")` methods in `RegisterRequest` and `PasskeyRegisterStartRequest` with a shared Pydantic V2 `Annotated` type (`ValidDisplayName`).

🎯 Why:
The display name trimming and emptiness check was completely duplicated across `h4ckath0n.auth.schemas` and `h4ckath0n.auth.passkeys.schemas`. An unused function `_validate_display_name` also existed, polluting the namespace. This change removes duplication and enforces consistent validation semantics in a single place.

🧠 Design:
Used `typing.Annotated` combined with `pydantic.functional_validators.AfterValidator` to compose the max-length constraint and custom cleaning logic into a single explicit type. The models now simply use this type definition (`display_name: ValidDisplayName`) which is much cleaner than redefining class methods.

λ FP Angle:
By encapsulating the validation logic into a discrete, composable type (`ValidDisplayName`), we've turned scattered imperative mutation/validation steps (the `@field_validator` class methods) into a clear data-in/data-out pipeline. We established a single, pure source of truth for normalizing display names, which strongly aligns with the FP goal of centralizing semantics.

✅ Verification:
- Explicitly checked file contents to ensure clean replacement.
- Ran backend formatting (`uv run --locked ruff format .`), linting (`uv run --locked ruff check .`), type-checking (`uv run --locked mypy src`), and testing (`uv run pytest`), which all passed successfully.
- Ran the frontend E2E Playwright tests (`npm run test:e2e`) to guarantee no regressions in authentication flows.

🧪 Edge cases:
Empty strings and whitespace-only strings ("   ") are correctly stripped and rejected by the single `_clean_display_name` helper. Exceeding the maximum length limit (200 characters) is caught safely by Pydantic's `Field` before custom validation runs.

⚠️ Risk:
Extremely low risk. The validation behavior remains identical. The Pydantic V2 order of operations safely guarantees length limits are verified as they were previously.

---
*PR created automatically by Jules for task [1118234453696603859](https://jules.google.com/task/1118234453696603859) started by @ToolchainLab*