### PR TITLE
⚡ Bolt: Optimize primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,9 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    cred = await db.get(WebAuthnCredential, key_id)
+    if cred is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +371,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        cred = await db.get(WebAuthnCredential, key_id)
+        if cred is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -148,10 +148,10 @@ def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-un
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
-    else:
-        stmt = select(User).where(User.email == email)
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        return session.get(User, user_id)
 
+    stmt = select(User).where(User.email == email)
     return session.execute(stmt).scalars().first()
 
 


### PR DESCRIPTION
💡 What: Replaced explicit `session.execute(select(Model).where(Model.id == pk))` queries with `session.get(Model, pk)` and `await db.get(Model, pk)` for primary key lookups in `src/h4ckath0n/auth/passkeys/service.py` (`rename_passkey`, `revoke_passkey`) and `src/h4ckath0n/cli.py` (`_get_user`).

🎯 Why: Using `db.get()` bypasses the SQLAlchemy Identity Map overhead when the object is already loaded, avoiding unnecessary database queries and hydration time on hot paths. 

📊 Impact: Reduces database latency and memory allocation overhead during common entity lookups by leveraging the Identity Map, preventing an unconditional network roundtrip and parsing penalty.

🔬 Measurement: Verify by monitoring database query logs. The overall number of `SELECT` queries for `WebAuthnCredential` and `User` by their primary key IDs during these flows should visibly drop. No regressions in unit or E2E tests, which all passed successfully.

---
*PR created automatically by Jules for task [47121179421138948](https://jules.google.com/task/47121179421138948) started by @ToolchainLab*