### PR TITLE
🛡️ Sentinel: [security improvement] Normalize email to lowercase for authentication and registration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-02-28 - Case-Sensitive Email Lookups in Authentication
+
+**Vulnerability:** Email addresses during registration, login, and password reset flows were not being normalized to lowercase before database insertion or lookup.
+**Learning:** Due to SQLAlchemy's strict string matching and typical database collation, 'User@Example.com' and 'user@example.com' were treated as distinct identities. This gap could result in duplicate accounts, lockouts for users using different casing to log in, and in some platforms, account impersonation risks.
+**Prevention:** Always normalize identity fields (like emails) to a consistent casing (e.g., `.lower()`) at the boundaries of the system before executing validation checks or database queries.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -55,6 +55,7 @@ async def register_user(
     *,
     display_name: str | None = None,
 ) -> User:
+    email = email.lower()
     hash_password, _verify = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
     if result.scalars().first():
@@ -73,6 +74,7 @@ async def register_user(
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
+    email = email.lower()
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
     if (user := result.scalars().first()) is None:
@@ -139,6 +141,7 @@ async def create_password_reset_token(
     expire_minutes: int = 30,
 ) -> str | None:
     """Create a password reset token. Returns raw token or None if email unknown."""
+    email = email.lower()
     # ⚡ Bolt: Fetch only the ID to avoid instantiating the full User ORM object.
     if (user_id := await db.scalar(select(User.id).filter(User.email == email))) is None:
         return None


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Email addresses during registration, authentication, and password reset flows were matched case-sensitively against the database without prior normalization.
🎯 Impact: This oversight can lead to duplicate account creation (e.g., `User@example.com` and `user@example.com`), user lockout if casing is typed differently during login, and potential account impersonation if validation fails to catch the difference.
🔧 Fix: Call `.lower()` on the `email` argument immediately upon entering `register_user`, `authenticate_user`, and `create_password_reset_token` in `src/h4ckath0n/auth/service.py` to enforce case-insensitive uniqueness and matching.
✅ Verification: Ran `pytest` locally and the playwright E2E web suite to verify that account creation and login flows continue to function nominally with the changes applied.

---
*PR created automatically by Jules for task [11321113270548440943](https://jules.google.com/task/11321113270548440943) started by @ToolchainLab*