### PR TITLE
🧭 Atlas: Add environment variable drift prevention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked python scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-06-01 - Config Drift Prevented
+**Learning:** This repo has a `Settings` class in `src/h4ckath0n/config.py` that specifies all config variables using `H4CKATH0N_` prefix but relies on manual README updates, leading to drift. Adding a script `scripts/check_env_vars.py` parsing `Settings.model_fields.keys()` verifies README drift.
+**Action:** Always check Pydantic Settings classes to identify the source of truth for config variables, and add a drift check if it's missing.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (e.g., `local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions / features |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
 

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable from Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    """Return a list of environment variable names expected by Settings."""
+    from h4ckath0n.config import Settings
+
+    env_vars = []
+    for key in Settings.model_fields:
+        if key == "openai_api_key":
+            # The config explicitly documents both for this specific field
+            env_vars.append("OPENAI_API_KEY")
+            env_vars.append("H4CKATH0N_OPENAI_API_KEY")
+        else:
+            env_vars.append(f"H4CKATH0N_{key.upper()}")
+
+    return env_vars
+
+
+def check_env_vars_in_readme(env_vars: list[str]) -> list[str]:
+    """Return environment variables that are not mentioned in README.md."""
+    readme_text = README.read_text(encoding="utf-8")
+    missing: list[str] = []
+
+    for var in env_vars:
+        # Strictly match the variable name enclosed in backticks
+        pattern = rf"`{var}`"
+        if not re.search(pattern, readme_text):
+            missing.append(var)
+
+    return missing
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added `scripts/check_env_vars.py` to dynamically parse the Pydantic `Settings` model and fail CI if any environment variables are missing from `README.md`.
🎯 Why: Environment variables from the `Settings` class often drifted from the documentation, confusing new contributors. This check forces parity.
🧪 Verification: Run `uv run python scripts/check_env_vars.py` locally. The backend CI job now runs this script.
🔒 Drift Prevention: Added the script as a required step in `.github/workflows/ci.yml` (`backend` job).
🗺️ Evidence: Used `src/h4ckath0n/config.py` (specifically `Settings.model_fields`) as the source of truth for the expected configuration variables.

---
*PR created automatically by Jules for task [2897752295247478068](https://jules.google.com/task/2897752295247478068) started by @ToolchainLab*