### PR TITLE
∷ Vector: Centralize display name validation using Pydantic Annotated types

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/api/openapi.json
+++ b/packages/create-h4ckath0n/templates/fullstack/api/openapi.json
@@ -661,6 +661,7 @@
           "display_name": {
             "description": "Human-facing display name for the new account.",
             "maxLength": 200,
+            "minLength": 1,
             "title": "Display Name",
             "type": "string"
           }
@@ -855,6 +856,7 @@
           "display_name": {
             "description": "Human-facing display name for the account.",
             "maxLength": 200,
+            "minLength": 1,
             "title": "Display Name",
             "type": "string"
           },

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,17 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field, StringConstraints
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
-
-def _validate_display_name(v: str | None) -> str | None:
-    """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
-    v = v.strip()
-    if v == "":
-        return None
-    return v
+DisplayName = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=DISPLAY_NAME_MAX_LENGTH),
+]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +26,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What
Replaced duplicated `@field_validator` methods for `display_name` fields across auth schemas with a single, centralized Pydantic `Annotated` type (`DisplayName`) using `StringConstraints`. Also removed dead validation code.

🎯 Why
The exact same string normalization and validation logic (trim whitespace, reject empty, enforce max length) was duplicated across `src/h4ckath0n/auth/schemas.py` and `src/h4ckath0n/auth/passkeys/schemas.py`. Centralizing this prevents drift and makes the models cleaner.

🧠 Design
Pydantic V2's `StringConstraints` perfectly models the exact behavior previously handled by a custom `strip()` and empty check sequence (`strip_whitespace=True`, `min_length=1`, `max_length=DISPLAY_NAME_MAX_LENGTH`). Replacing the validator method with an `Annotated` type allows us to declaratively apply these semantics as a single source of truth across all models that accept a display name.

λ FP Angle
This shifts mutation-heavy custom field validator logic into a declarative, type-driven definition. It centralizes the semantic normalization (trimming) and invariant enforcement (non-empty) into a single reusable type, making the models pure structural definitions instead of holding scattered procedural validation.

✅ Verification
- Validated via `uv run pytest -v` (188 backend tests passed).
- Ran backend formatting, linting, and type checking (`ruff format`, `ruff check`, `mypy`).
- Verified the frontend continues to build and passes all E2E tests (`npm test:e2e`).

🧪 Edge cases
- Display names consisting entirely of whitespace are correctly rejected (handled previously by `strip()` -> empty check; now handled by `strip_whitespace=True` -> `min_length=1`).
- Empty strings are rejected.
- Strings exceeding `DISPLAY_NAME_MAX_LENGTH` are rejected.

⚠️ Risk
Low. The validation semantics are identical to the previous implementation, relying entirely on Pydantic's built-in robust validation core. No database or API boundaries were fundamentally altered.

---
*PR created automatically by Jules for task [10399116561918425535](https://jules.google.com/task/10399116561918425535) started by @ToolchainLab*