### PR TITLE
🎨 Palette: Add skip link and ARIA labels to Layout

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-02 - Desktop/Mobile Component Duplication and Accessible Naming
+**Learning:** When adding ARIA labels to UI components that have identical counterparts hidden in responsive modes (e.g., desktop vs mobile theme toggles in `Layout.tsx`), tests using `getByRole` will begin to fail because there are now multiple elements matching the same accessible name query.
+**Action:** When adding accessible names to duplicated responsive components, update corresponding unit tests to use `getAllByRole(...)[0]` to handle the duplicate matches correctly without relying on fragile element ordering logic or over-complicating the mock DOM.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0],
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0],
       ).toBeInTheDocument();
     });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,12 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-4 focus:bg-surface focus:text-primary"
+      >
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -192,6 +198,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +214,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +279,11 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 outline-none"
+      >
         <Outlet />
       </main>
 


### PR DESCRIPTION
### 💡 What
Added a "Skip to main content" link to the `Layout.tsx` component and explicitly defined `aria-label` attributes for the icon-only mobile menu and theme toggle buttons. Test selectors were updated to handle duplicate responsive buttons.

### 🎯 Why
To improve the user experience for users relying on keyboard navigation and screen readers. A skip-link prevents keyboard-only users from having to tab through the entire navigation bar repeatedly, while explicit ARIA labels ensure the purpose of icon-only mobile controls is clearly communicated to assistive technologies.

### 📸 Before/After
Before: Keyboard users were forced to tab through every nav element. Mobile buttons were identified only by their SVG icons.
After: Keyboard users can bypass navigation via a visible-on-focus link. Assistive tech correctly announces "Open menu", "Close menu", and "Theme: system/dark/light". 
*(Verified visually with Playwright screenshots & video).*

### ♿ Accessibility
- Added `href="#main-content"` skip link (hidden until focused with `sr-only focus:not-sr-only`).
- Targeted `<main id="main-content" tabIndex={-1}>`.
- Added `aria-label` to the mobile Theme toggle.
- Added `aria-label` and `aria-expanded` to the mobile Menu toggle.

---
*PR created automatically by Jules for task [4787527443199439716](https://jules.google.com/task/4787527443199439716) started by @ToolchainLab*