### PR TITLE
🧭 Atlas: Add env var drift check and document missing variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-06-02 - Pydantic settings env var drift check
+**Learning:** Pydantic `Settings` environment variables can easily drift from the documentation table in README.md. Substring matching the README may fail if variable names overlap.
+**Action:** Always write a drift script using `Settings.model_fields` and strictly verify exact variable names using backticks (e.g. \`VARIABLE_NAME\`). Handle environment prefixes explicitly.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | 50 MB |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | `"file"` or `"smtp"` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | |
+| `H4CKATH0N_SMTP_HOST` | empty | |
+| `H4CKATH0N_SMTP_PORT` | `587` | |
+| `H4CKATH0N_SMTP_USERNAME` | empty | |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | |
+| `H4CKATH0N_SMTP_SSL` | `false` | |
+| `H4CKATH0N_DEMO_MODE` | `false` | |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that env vars in Settings are documented in the README."""
+
+import sys
+from pathlib import Path
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_expected_env_vars() -> list[str]:
+    """Return all environment variables defined in Settings."""
+    vars = []
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            vars.extend(["OPENAI_API_KEY", "H4CKATH0N_OPENAI_API_KEY"])
+        else:
+            vars.append(f"H4CKATH0N_{field_name.upper()}")
+    return sorted(vars)
+
+
+def check_env_vars_in_readme(expected_vars: list[str]) -> list[str]:
+    """Return env vars that are not mentioned in README.md wrapped in backticks."""
+    readme_text = README.read_text()
+    missing = []
+    for var in expected_vars:
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    expected_vars = get_expected_env_vars()
+    missing = check_env_vars_in_readme(expected_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(expected_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: 
- Creates a drift-prevention script `scripts/check_env_vars.py` that verifies every Pydantic `Settings` environment variable is documented in the README table.
- Corrects `README.md` by adding 17 missing environment variables (e.g., Redis, email, storage, demo config) with their exact fallback behaviors.
- Wires the verification script into the `.github/workflows/ci.yml` matrix.
- Appends a critical learning log in `.jules/atlas.md` about avoiding substring matching with Pydantic variables.

🎯 Why: 
Environment variables were drifting between the authoritative `Settings` schema in the codebase and the documentation table, reducing "time-to-understanding" and leaving developers guessing about storage, background jobs, and email configurations. 

🔬 Verification:
- Run `uv run --locked scripts/check_env_vars.py` to pass the drift check locally.
- Run `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest` to pass backend quality gates.
- Run `cd packages/create-h4ckath0n/templates/fullstack/web && npm run test:e2e` to verify frontend tests.

🔒 Drift Prevention: 
The newly added script `scripts/check_env_vars.py` parses `Settings.model_fields` and strictly matches the backticked `` `VARIABLE_NAME` `` in `README.md`. This runs in the `backend` CI job on every PR and push.

🗺️ Evidence: 
- Authoritative source: `src/h4ckath0n/config.py` (specifically `Settings.model_fields`)

---
*PR created automatically by Jules for task [2273686950388703538](https://jules.google.com/task/2273686950388703538) started by @ToolchainLab*