### PR TITLE
∷ Vector: Centralize display name validation into a shared reusable type

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,27 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
-    """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
+def _clean_display_name(v: str) -> str:
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
+
+
+DisplayName = Annotated[
+    str,
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH),
+    AfterValidator(_clean_display_name),
+]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +36,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- **💡 What:** Replaced duplicated `@field_validator("display_name")` methods with a single, shared `DisplayName` type defined in `src/h4ckath0n/auth/schemas.py`. 
- **🎯 Why:** The logic to trim whitespace and reject empty string display names was duplicated across multiple request schemas (`RegisterRequest` and `PasskeyRegisterStartRequest`). Centralizing it prevents drift and future copy-paste bugs.
- **🧠 Design:** I used Pydantic V2's `typing.Annotated` alongside `AfterValidator`. The old `_validate_display_name` function was replaced with `_clean_display_name` because we need the validator to raise a `ValueError` for custom error messages, maintaining full test suite compatibility. The new `DisplayName` type also encapsulates the `Field(max_length=...)` constraint.
- **λ FP Angle:** This change moves mutation-heavy class methods (`@classmethod` decorators mutating class state via validators) into a pure, declarative, and composable type definition. The normalization logic is now completely separated from the data model definition, acting as a clear transformation pipeline.
- **✅ Verification:** 
  - Executed `uv run --locked ruff format .` and `uv run --locked ruff check .`
  - Passed `uv run --locked mypy src`
  - Executed and passed the backend test suite via `uv run pytest` (188/188 passed).
  - Executed and passed the frontend test suite using `npm run test:e2e` (27/27 passed).
- **🧪 Edge cases:** 
  - Whitespace-only display names ("   ") continue to properly trigger the `"Display name must not be empty"` `ValueError` (caught and handled as 400 Bad Request/422 by FastAPI).
  - Normal valid names continue to be correctly stripped of trailing/leading whitespace.
  - Length limits (`max_length=200`) remain strictly enforced.
- **⚠️ Risk:** Very low risk. This is a behavior-preserving internal refactor relying on built-in Pydantic features. All existing tests pass without modification.

---
*PR created automatically by Jules for task [2736142375123569723](https://jules.google.com/task/2736142375123569723) started by @ToolchainLab*