### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -338,13 +338,9 @@ async def rename_passkey(
 
     Raises ValueError if not found / not owned / revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.get() for primary key lookup
+    cred = await db.get(WebAuthnCredential, key_id)
+    if cred is None or cred.user_id != user.id:
         raise ValueError("Credential not found")
     if cred.revoked_at is not None:
         raise ValueError("Cannot rename a revoked passkey")
@@ -375,13 +371,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        cred = await db.get(WebAuthnCredential, key_id)
+        if cred is None or cred.user_id != user.id:
             raise ValueError("Credential not found")
         if cred.revoked_at is not None:
             raise ValueError("Credential already revoked")


### PR DESCRIPTION
💡 What: Replaced the `select(WebAuthnCredential).filter()` queries with `db.get(WebAuthnCredential, key_id)` inside the `rename_passkey` and `revoke_passkey` authentication routines.

🎯 Why: To improve performance when querying credentials by utilizing the SQLAlchemy Identity Map cache, avoiding unnecessary database trips when the requested entity is already loaded into the current session.

📊 Impact: Reduces unneeded database read operations for cached credentials during updates/deletions.

🔬 Measurement: Verified that primary key queries continue to successfully execute with `db.get()`, returning the credential, and secondary constraint (`user_id == user.id`) continues to correctly raise a `ValueError` during IDOR testing scenarios.

---
*PR created automatically by Jules for task [6864476937352779188](https://jules.google.com/task/6864476937352779188) started by @ToolchainLab*