### PR TITLE
🧭 Atlas: Enforce environment variable documentation parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2023-10-25 - Environment variable documentation drift
+
+**Learning:** Environment variables frequently drift from their documented state as new settings are added to configuration models (like Pydantic's `Settings`). This leads to incomplete documentation where required or optional configurations are not discoverable.
+**Action:** Always use a drift prevention script that dynamically parses the configuration source of truth (e.g., `Settings.model_fields`), applies the relevant prefix, and enforces that the specific variable string enclosed in backticks exists in the README or appropriate documentation file.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for storing uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web frontend for emails/links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory where file-based emails are saved |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable read-only demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every env var is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    vars_list = []
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            vars_list.append("OPENAI_API_KEY")
+            vars_list.append("H4CKATH0N_OPENAI_API_KEY")
+        else:
+            vars_list.append(f"H4CKATH0N_{field_name.upper()}")
+
+    return vars_list
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    readme_text = README.read_text()
+
+    missing = []
+    for var in env_vars:
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### 💡 What
Added a new CI drift prevention check (`scripts/check_env_vars.py`) that strictly enforces documentation parity for all environment variables defined in the application's configuration (`src/h4ckath0n/config.py`). Also added all missing configurations (Redis, Storage, Email, Demo) to the `README.md`.

### 🎯 Why
Environment variables often drift from the documentation, making it difficult for users to discover configuration flags or onboarding parameters. This ensures the README is the reliable source of truth. 

### 🔬 Verification
- `uv run scripts/check_env_vars.py` executed successfully.
- `uv run --locked ruff format .`, `uv run --locked ruff check .`, `uv run --locked mypy src`, and `uv run pytest` pass cleanly.

### 🔒 Drift Prevention
Added `scripts/check_env_vars.py` to `.github/workflows/ci.yml`. If someone adds a variable to `src/h4ckath0n/config.py` without documenting it in `README.md`, CI will fail. The script properly matches exact identifiers inside backticks to prevent substring false-positives and correctly handles exceptions like `OPENAI_API_KEY`.

### 🗺️ Evidence
- `src/h4ckath0n/config.py` (`Settings.model_fields`)
- `.github/workflows/ci.yml`

---
*PR created automatically by Jules for task [236690472241854379](https://jules.google.com/task/236690472241854379) started by @ToolchainLab*