### PR TITLE
∴ Vector: Centralize display name validation using AfterValidator

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2025-06-04 - Centralized display name validation using AfterValidator
+**Learning:** Found duplicated `@field_validator` methods for `display_name` validation (`_clean_display_name`) across `RegisterRequest` and `PasskeyRegisterStartRequest`. Pydantic V2 encourages composing reusable validation rules via `typing.Annotated` and `pydantic.functional_validators.AfterValidator` rather than repetitive `@field_validator` classes to adhere to FP principles (reusability and pure transformations).
+**Action:** Use `typing.Annotated` with `AfterValidator` to centralize validation logic. E.g., `DisplayName = Annotated[str, Field(max_length=DISPLAY_NAME_MAX_LENGTH), AfterValidator(_clean_display_name)]` and replace all `display_name: str` usages.

--- a/packages/create-h4ckath0n/templates/fullstack/api/openapi.json
+++ b/packages/create-h4ckath0n/templates/fullstack/api/openapi.json
@@ -659,7 +659,7 @@
       "PasskeyRegisterStartRequest": {
         "properties": {
           "display_name": {
-            "description": "Human-facing display name for the new account.",
+            "description": "Human-facing display name.",
             "maxLength": 200,
             "title": "Display Name",
             "type": "string"
@@ -853,7 +853,7 @@
             "title": "Device Public Key Jwk"
           },
           "display_name": {
-            "description": "Human-facing display name for the account.",
+            "description": "Human-facing display name.",
             "maxLength": 200,
             "title": "Display Name",
             "type": "string"

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/api/openapi.ts
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/api/openapi.ts
@@ -910,7 +910,7 @@ export interface components {
         PasskeyRegisterStartRequest: {
             /**
              * Display Name
-             * @description Human-facing display name for the new account.
+             * @description Human-facing display name.
              */
             display_name: string;
         };
@@ -1016,7 +1016,7 @@ export interface components {
             } | null;
             /**
              * Display Name
-             * @description Human-facing display name for the account.
+             * @description Human-facing display name.
              */
             display_name: string;
             /**

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,15 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
-        ...,
-        description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
-    )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    display_name: DisplayName
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,28 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
+def _validate_display_name(v: str) -> str:
     """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
+
+
+DisplayName = Annotated[
+    str,
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH, description="Human-facing display name."),
+    AfterValidator(_validate_display_name),
+]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +37,7 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
-        ...,
-        description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
-    )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    display_name: DisplayName
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 **What**
Centralized the duplicated `display_name` validation logic (`_clean_display_name` `@field_validator`) into a reusable `DisplayName` type using `typing.Annotated` and Pydantic V2's `AfterValidator`. Applied this new type across `RegisterRequest` and `PasskeyRegisterStartRequest`.

🎯 **Why**
To adhere to functional programming principles, eliminate duplicate validation code, and enforce consistent display name behavior (trimming, emptiness check, and length constraint) across multiple schemas.

🧠 **Design**
By replacing scattered, imperative `@field_validator` definitions with a declarative `Annotated` wrapper, the rule is defined once as a pure transformation function (`_validate_display_name`) and easily composable elsewhere.

λ **FP Angle**
This change moves away from mutating/class-level state (imperative field validators) toward explicit, centralized, pure transformation logic encapsulated within a single reusable data type.

✅ **Verification**
* Executed `uv run --locked ruff format .` and `uv run --locked ruff check .`
* Verified type soundness with `uv run --locked mypy src`
* Passed all unit tests via `uv run pytest`
* Passed all E2E Playwright tests via `npm run test:e2e` in the web frontend template.

🧪 **Edge cases**
The centralized validation continues to correctly catch whitespace-only strings and enforces the strict non-empty condition alongside the existing `DISPLAY_NAME_MAX_LENGTH` limit.

⚠️ **Risk**
Minimal. The validation behavior remains semantically identical to the original implementation. The tests confirm complete parity in how endpoints handle missing, empty, or whitespace-only inputs.

---
*PR created automatically by Jules for task [14601425147552308936](https://jules.google.com/task/14601425147552308936) started by @ToolchainLab*