### PR TITLE
🎨 Palette: Add skip to content and mobile ARIA labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-04 - Fix ambiguous ARIA label matching in responsive UI
+**Learning:** Adding explicit `aria-label`s to UI elements like theme toggles or menu buttons that exist in both desktop and mobile views (even if hidden by CSS classes like `md:hidden`) will cause React Testing Library's `getByRole` to throw ambiguous match errors because the testing library queries the DOM regardless of visual visibility.
+**Action:** When adding `aria-label`s to responsive elements, always update related tests to use `getAllByRole(...)[0]!` or query specifically for visibility, and ensure `expect(button).toBeDefined()` is used in strict TypeScript environments prior to interactions.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,15 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
+    expect(button).toBeDefined();
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +76,15 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
+    expect(button).toBeDefined();
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0]!,
       ).toBeInTheDocument();
     });
 
@@ -91,8 +93,8 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+        screen.queryAllByRole("button", { name: /Theme: system/ }).length,
+      ).toBe(0);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -95,6 +95,12 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-surface flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-surface focus:text-primary"
+      >
+        Skip to main content
+      </a>
       <nav className="border-b border-border bg-surface/80 backdrop-blur-md sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
@@ -192,6 +198,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +214,7 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -266,7 +278,11 @@ export function Layout() {
         )}
       </nav>
 
-      <main className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8 focus:outline-none"
+      >
         <Outlet />
       </main>
 


### PR DESCRIPTION
💡 What: Added a keyboard-navigable "Skip to main content" link and inserted explicit `aria-label` properties on icon-only mobile navigation buttons.
🎯 Why: Enhances overall accessibility by giving screen reader and keyboard users a mechanism to bypass repetitive navigation links, and provides accessible names to previously unlabelled mobile-only icons.
📸 Before/After: Verified visually via screenshots/video to ensure the hidden skip link behaves properly on focus.
♿ Accessibility: Improves WCAG compliance for bypass blocks and non-text interactive elements, while updating the test suite to robustly handle identical accessible names across responsive views.

---
*PR created automatically by Jules for task [6397635448094801715](https://jules.google.com/task/6397635448094801715) started by @ToolchainLab*