### PR TITLE
🧭 Atlas: Add env var drift prevention and document missing configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked python scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-06-04 - Environment Variable Doc Drift
+**Learning:** Using Pydantic Settings model_fields and dynamically prepending the env_prefix is a reliable verification technique to catch undocumented environment variables in the repo.
+**Action:** Ensure that any doc claim about available environment variables is verified against the actual configuration loader.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string, required if using Redis |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | `local` or other supported storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | `file` or `smtp` email backend |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py
+
+The script imports the h4ckath0n app settings, enumerates all fields, and checks that
+README.md mentions each one enclosed in backticks.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    env_vars = []
+    prefix = Settings.model_config.get("env_prefix", "")
+    for field_name in Settings.model_fields:
+        if field_name.lower() == "openai_api_key":
+            env_vars.append("OPENAI_API_KEY")
+            env_vars.append(f"{prefix.upper()}OPENAI_API_KEY")
+        else:
+            env_vars.append(f"{prefix.upper()}{field_name.upper()}")
+    return list(set(env_vars))
+
+
+def check_env_vars_in_readme(env_vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for var in env_vars:
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return sorted(missing)
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration section in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What:
Documented 17 missing environment variables (like `H4CKATH0N_REDIS_URL`, `H4CKATH0N_SMTP_*`, etc.) in the `README.md` Configuration section, and added an automated drift check script to ensure all fields from Pydantic `Settings` remain documented. 

🎯 Why: 
Users were encountering undocumented environment variables (e.g., SMTP or Redis configuration) that are fully supported by the application config loader but missing from the public docs. This led to a mismatch between actual app capabilities and onboarding instructions. 

🧪 Verification: 
- Ran `uv run python scripts/check_doc_env_vars.py` locally and confirmed it passes.
- Ran the full `uv run pytest` suite.

🔒 Drift Prevention: 
- Created `scripts/check_doc_env_vars.py` which dynamically reads `Settings.model_fields` and asserts that every variable (with its proper prefix) appears explicitly in the README. 
- Integrated the check into the standard `.github/workflows/ci.yml` pipeline alongside route documentation checks.

🗺️ Evidence: 
- `src/h4ckath0n/config.py` - Source of truth for config variables.

---
*PR created automatically by Jules for task [3416416472366504077](https://jules.google.com/task/3416416472366504077) started by @ToolchainLab*