### PR TITLE
∴ Vector: Centralize display name validation using Pydantic Annotated

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-06-05 - Centralize Pydantic Validation
+**Learning:** Pydantic duplicated validation logic like `@field_validator` can be cleanly refactored into reusable explicit type definitions using `typing.Annotated` with `AfterValidator`.
+**Action:** Always favor `Annotated` with `AfterValidator` to centralize validation logic rather than scattering duplicated `field_validator` methods across schemas.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, ValidDisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: ValidDisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
@@ -18,6 +21,20 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def _clean_display_name(v: str) -> str:
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
+ValidDisplayName = Annotated[
+    str,
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH),
+    AfterValidator(_clean_display_name),
+]
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict | None = Field(
         None,
@@ -29,19 +46,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: ValidDisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What: Centralized display name validation logic by creating a reusable `ValidDisplayName` type using Pydantic V2's `typing.Annotated` and `AfterValidator`. Applied this type to `RegisterRequest` and `PasskeyRegisterStartRequest` to remove duplicated `@field_validator` methods.
🎯 Why: To remove duplicated validation logic scattered across schemas and ensure a single source of truth for display name normalization and constraints.
🧠 Design: Used `Annotated` with `AfterValidator` rather than duplicating methods or relying on custom base models. The original `_validate_display_name` function was deliberately preserved as it serves a different purpose (handling `str | None`) and might be used for patch endpoints.
λ FP Angle: Transforms validation from scattered imperative classmethods into an explicit, reusable, composable type definition.
✅ Verification: Ran full backend CI checks (`uv run --locked ruff format .`, `uv run --locked ruff check .`, `uv run --locked mypy src`, `uv run pytest`) and frontend E2E tests (`npm run test:e2e`).
🧪 Edge cases: The new validator correctly strips whitespace and raises `ValueError` on empty strings, matching the exact behavior of the replaced methods. Preserved the `max_length` check by nesting `Field(max_length=DISPLAY_NAME_MAX_LENGTH)` inside the annotation.
⚠️ Risk: Low risk. The validation behavior remains identical and is executed in the same order (length check then custom validation) per Pydantic V2 semantics.

---
*PR created automatically by Jules for task [4210211318525325103](https://jules.google.com/task/4210211318525325103) started by @ToolchainLab*