### PR TITLE
🧭 Atlas: Enforce docs parity for configuration env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc environment variables
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2025-06-05 - Environment Variable Docs Drift Check
+**Learning:** The configuration table in README.md easily falls out of sync with `Settings` in `src/h4ckath0n/config.py` (e.g., Redis, email, storage settings were missing). Manual documentation updates are prone to omissions as the app's configuration grows.
+**Action:** Created `scripts/check_doc_env_vars.py` and added it to the CI pipeline to enforce that every environment variable defined in Pydantic's `Settings.model_fields` is strictly matched within backticks in `README.md`. Handle exceptions like `OPENAI_API_KEY` explicitly.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development without a worker |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default ARQ queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | `local` or `s3` storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory path |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend app |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | `file` or `smtp` email backend |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+
+def check_env_vars_in_readme() -> list[str]:
+    """Return environment variables that are not mentioned in README.md."""
+    vars_to_check = []
+    prefix = Settings.model_config.get("env_prefix", "H4CKATH0N_")
+
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            vars_to_check.append("OPENAI_API_KEY")
+            vars_to_check.append(f"{prefix}OPENAI_API_KEY".upper())
+        else:
+            vars_to_check.append(f"{prefix}{field_name}".upper())
+
+    readme_text = README.read_text()
+    missing: list[str] = []
+
+    for var in vars_to_check:
+        combined = rf"`{re.escape(var)}`"
+        if not re.search(combined, readme_text):
+            missing.append(var)
+
+    return missing
+
+
+def main() -> int:
+    missing = check_env_vars_in_readme()
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these environment variables to README.md.")
+        return 1
+
+    print("✅ All environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added missing environment variables to `README.md` and created a CI drift-prevention check (`scripts/check_doc_env_vars.py`) that fails if any field in `Settings` is undocumented.
🎯 Why: Configuration drift causes major onboarding friction. The Pydantic model had grown (Redis, email, storage, etc.) while the README table remained stagnant.
🧪 Verification: Locally run `uv run scripts/check_doc_env_vars.py` and `uv run pytest`.
🔒 Drift Prevention: Added `scripts/check_doc_env_vars.py` to the GitHub Actions `backend` CI job to prevent future regressions.
🗺️ Evidence: `src/h4ckath0n/config.py` (`Settings.model_fields`).

---
*PR created automatically by Jules for task [1180429680604212520](https://jules.google.com/task/1180429680604212520) started by @ToolchainLab*