### PR TITLE
∸ Vector: Centralize display name validation using Annotated type

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,19 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, DisplayNameStr
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayNameStr = Field(
         ...,
         description="Human-facing display name for the new account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
-    """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
+def _clean_display_name(v: str) -> str:
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
+
+
+DisplayNameStr = Annotated[str, AfterValidator(_clean_display_name)]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +32,11 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayNameStr = Field(
         ...,
         description="Human-facing display name for the account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- **💡 What:** Replaced duplicated `@field_validator("display_name")` methods in `auth/schemas.py` and `auth/passkeys/schemas.py` with a centralized Pydantic V2 `Annotated` type (`DisplayNameStr`) wrapping a pure function. Removed the unused `_validate_display_name` helper.
- **🎯 Why:** Code duplication across the schemas violated the single source of truth principle. Centralizing it reduces the chance of future drift and simplifies the Pydantic models.
- **🧠 Design:** Instead of mutating class state with scattered `@field_validator` hooks, the logic is extracted into a declarative type alias (`DisplayNameStr = Annotated[str, AfterValidator(_clean_display_name)]`) which seamlessly merges with existing `Field(max_length=...)` constraints without collision.
- **λ FP Angle:** This transformation favors composing pure transformation/validation steps into types (`Annotated` pipeline) rather than relying on class-bound method side-effects, enhancing semantic precision.
- **✅ Verification:** Passed `uv run --locked ruff check .` (fixed minor unused imports), passed `uv run pytest`, and fully passed the playwright frontend E2E suite (`npm run test:e2e`).
- **🧪 Edge cases:** Explicitly retained the exact custom `ValueError("Display name must not be empty")` string ensuring existing edge-case tests matching this exact output will not break (as opposed to default Pydantic `StringConstraints` errors).
- **⚠️ Risk:** Extremely low risk. The validation behavior remains functionally identical. The only change is how Pydantic wires the validation hook during model initialization.

---
*PR created automatically by Jules for task [7822663409295828598](https://jules.google.com/task/7822663409295828598) started by @ToolchainLab*