### PR TITLE
🧭 Atlas: Document missing environment variables and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_docs_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-06-06 - Pydantic Settings drift check technique
+**Learning:** Documenting Pydantic Settings environment variables is a common source of drift. Dynamically parsing `Settings.model_fields` and strictly matching the full variable name (prefixed with `H4CKATH0N_` and enclosed in backticks) reliably catches undocumented configs and avoids false-positive substring matches.
+**Action:** Create a script that iterates over `Settings.model_fields` and asserts that each corresponding environment variable is enclosed in backticks within the configuration documentation. Integrate this script into CI.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend: `local` or `s3` |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory path |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max file upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend: `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable implicit SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_docs_env_vars.py
+++ b/scripts/check_docs_env_vars.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that all environment variables are documented in README.md.
+
+Usage (from repo root):
+    uv run scripts/check_docs_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    settings_fields = Settings.model_fields
+
+    readme_text = README.read_text(encoding="utf-8")
+
+    missing: list[str] = []
+
+    for field_name in settings_fields:
+        if field_name == "openai_api_key":
+            if (
+                "`OPENAI_API_KEY`" not in readme_text
+                and "`H4CKATH0N_OPENAI_API_KEY`" not in readme_text
+            ):
+                missing.append("OPENAI_API_KEY")
+        else:
+            env_var = "H4CKATH0N_" + field_name.upper()
+            if f"`{env_var}`" not in readme_text:
+                missing.append(env_var)
+
+    if missing:
+        print("❌ The following environment variables are missing from README.md:\n")
+        for m in missing:
+            print(f"  {m}")
+        print("\nPlease add them to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(settings_fields)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What:
Documented 17 missing environment variables in the README.md Configuration table based on `h4ckath0n.config.Settings`. Added `scripts/check_docs_env_vars.py` to prevent future drift by checking that all Pydantic settings are correctly documented, and wired it into the CI pipeline.

🎯 Why:
To ensure the README remains the source of truth for configuration and matches the actual code. Relying on manually updating documentation frequently leads to missing configurations and degraded developer experience.

🧪 Verification:
Run `uv run scripts/check_docs_env_vars.py` locally. It should pass successfully.

🔒 Drift Prevention:
A new CI job (`Check doc env vars`) runs the custom validation script to catch undocumented environment variables before PRs are merged.

🗺️ Evidence:
The variables are sourced directly from `src/h4ckath0n/config.py`.

---
*PR created automatically by Jules for task [6755381056883701402](https://jules.google.com/task/6755381056883701402) started by @ToolchainLab*