### PR TITLE
∷ Vector: Centralize display name validation using a reusable Pydantic Annotated type

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,19 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,10 +2,24 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
+
+
+def _clean_display_name(v: str) -> str:
+    """Trim whitespace and reject empty names."""
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
+DisplayName = Annotated[str, AfterValidator(_clean_display_name)]
 
 
 def _validate_display_name(v: str | None) -> str | None:
@@ -29,19 +43,11 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted the `_clean_display_name` validation logic from `RegisterRequest` and `PasskeyRegisterStartRequest` into a single, reusable `DisplayName` type using Pydantic's `typing.Annotated` and `AfterValidator`.
- 🎯 Why: To remove duplicated parsing and validation logic spread across multiple models, enforcing a single source of truth for display name rules.
- 🧠 Design: By defining `DisplayName = Annotated[str, AfterValidator(_clean_display_name)]`, the exact same trimming and emptiness-check behavior is automatically applied wherever `DisplayName` is used as a field type. This is the smallest, safest, most localized cleanup that guarantees correctness without altering external APIs.
- λ FP Angle: Reduces scattered mutation-like state checks (the `@field_validator` methods) by promoting a single, pure transformation/validation pipeline tied directly to the type definition.
- ✅ Verification: Ran `uv run pytest tests/` which completely passed (all integration/auth tests). Executed `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src`, passing seamlessly. Also executed full frontend E2E Playwright tests to ensure nothing in the auth flow inadvertently broke (`npm run test:e2e`).
- 🧪 Edge cases: Re-validated that empty string and whitespace-only display names correctly throw standard validation errors explicitly defined in `_clean_display_name`.
- ⚠️ Risk: Extremely low risk since Pydantic handles Annotated validators gracefully and natively during parsing. Behavior is precisely preserved.

---
*PR created automatically by Jules for task [18218421081715946945](https://jules.google.com/task/18218421081715946945) started by @ToolchainLab*