### PR TITLE
🎨 Palette: Add ARIA labels to mobile layout buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-07 - Adding ARIA attributes can break test queries
+**Learning:** When adding `aria-label` to identical components hidden contextually (e.g., desktop/mobile toggles), `getByRole` tests will fail by finding multiple matches.
+**Action:** Update affected tests to expect multiple matches and use `getAllByRole()[0]`, and explicitly assert definition using `expect(element).toBeDefined()` before firing events to satisfy strict TypeScript/Vite environments.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,15 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
+    expect(button).toBeDefined();
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +76,15 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
+    expect(button).toBeDefined();
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0]!,
       ).toBeInTheDocument();
     });
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -192,6 +192,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +208,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-expanded={isMobileMenuOpen}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />


### PR DESCRIPTION
💡 What: Added `aria-label` to the mobile theme toggle and `aria-label` + `aria-expanded` to the mobile menu hamburger button. Updated layout tests to support multiple matching buttons with identical context.

🎯 Why: Icon-only buttons lacking accessible labels result in ambiguous states for screen reader users. The mobile navigation toggle was missing state indicators (`aria-expanded`) and descriptive actions.

📸 Before/After: Visuals are unchanged (verified locally), but DOM accessibility tree now exposes "Theme: [state]" and "Open menu"/"Close menu".

♿ Accessibility:
- Added accessible name computation for both mobile navigation interactive elements.
- Maintained consistent aria-label naming conventions with the desktop counterpart for the theme toggle.
- Refactored Vitest test suite (`Layout.test.tsx`) using strict-mode compliant index-based querying (`getAllByRole()[0]!`) and explict expectations to handle new identical matching buttons safely.

---
*PR created automatically by Jules for task [3617939285577865001](https://jules.google.com/task/3617939285577865001) started by @ToolchainLab*