### PR TITLE
🧭 Atlas: Document all environment variables and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked python scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,11 +1,6 @@
-# Atlas Journal: Critical Learnings
-
-## 2026-02-28 - API route substring matching is unreliable for drift checks
-
-**Learning:** Checking whether a path string appears *anywhere* in a README causes false negatives
-when one route's path is a substring of another (e.g. `/auth/passkeys/{key_id}` inside
-`/auth/passkeys/{key_id}/revoke`). The drift check must match `METHOD /path` as a combined token,
-ideally inside backtick delimiters, to avoid this trap.
-
-**Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
-that mirror the actual markdown formatting.
+## 2024-06-07 - Documenting Environment Variables
+**Learning:** Env vars drift heavily between Pydantic config and docs. In this repo, configuration settings are driven by `pydantic-settings` in `src/h4ckath0n/config.py`. They use a prefix (`H4CKATH0N_`), except for some fields like `OPENAI_API_KEY` which are exempt or have aliases. The README has a hard-coded table of environment variables that is missing many new fields (like email and storage backend settings).
+**Action:** Replace the manually maintained env vars table in README.md with an automated list/table generated from Pydantic config, or add a drift-prevention script for env vars.
+## 2024-06-07 - Documenting Environment Variables
+**Learning:** Env vars drift heavily between Pydantic config and docs. In this repo, configuration settings are driven by `pydantic-settings` in `src/h4ckath0n/config.py`. They use a prefix (`H4CKATH0N_`), except for some fields like `OPENAI_API_KEY` which are exempt or have aliases. The README has a hard-coded table of environment variables that is missing many new fields (like email and storage backend settings).
+**Action:** Replace the manually maintained env vars table in README.md with an automated list/table generated from Pydantic config, or add a drift-prevention script for env vars.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend: `local` or `s3` |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50 MB default) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend app |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend: `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in the FastAPI app is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    fields = Settings.model_fields
+    vars = []
+    for field_name in fields:
+        if field_name == "openai_api_key":
+            vars.append("OPENAI_API_KEY")
+            vars.append("H4CKATH0N_OPENAI_API_KEY")
+        else:
+            vars.append(f"H4CKATH0N_{field_name.upper()}")
+    return sorted(list(set(vars)))
+
+
+def check_env_vars_in_readme(vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for var in vars:
+        # Looking for `VAR_NAME`
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    vars = get_env_vars()
+    missing = check_env_vars_in_readme(vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these environment variables to README.md.")
+        return 1
+
+    print(f"✅ All {len(vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 **What**: Added all missing configuration environment variables to the `README.md` Configuration table. Created a drift-prevention script `scripts/check_doc_env_vars.py` and hooked it into `.github/workflows/ci.yml`.

🎯 **Why**: Environment variables heavily drifted between the central configuration source (`src/h4ckath0n/config.py`) and what is stated in the `README.md` docs. Specifically, fields like email and storage backend settings were missing from the user docs.

🧪 **Verification**: The drift check can be run locally via `uv run python scripts/check_doc_env_vars.py`.

🔒 **Drift Prevention**: The `check_doc_env_vars.py` Python script loads all available configurations from `pydantic-settings`, derives their standard names, and checks if they are enclosed in backticks in the `README.md` document. It is executed automatically during the GitHub CI `backend` job sequence.

🗺️ **Evidence**: The repo configuration source of truth in `src/h4ckath0n/config.py`.

---
*PR created automatically by Jules for task [8143029120079213784](https://jules.google.com/task/8143029120079213784) started by @ToolchainLab*