### PR TITLE
∴ Vector: Centralize display_name validation with composable Annotated type

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,19 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, DisplayNameString
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayNameString = Field(
         ...,
         description="Human-facing display name for the new account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
-    """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
+def _clean_display_name(v: str) -> str:
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
+
+
+DisplayNameString = Annotated[str, AfterValidator(_clean_display_name)]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +32,11 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayNameString = Field(
         ...,
         description="Human-facing display name for the account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What: Extracted duplicated `display_name` validation logic into a centralized `DisplayNameString` type using Pydantic V2's `Annotated` and `AfterValidator`.

🎯 Why: The exact same trimming and empty-check logic (`_clean_display_name`) was duplicated via `@field_validator` in two different schemas (`RegisterRequest` in `auth/schemas.py` and `PasskeyRegisterStartRequest` in `auth/passkeys/schemas.py`). Centralizing this into a single type definition removes duplication and provides a single source of truth for display name semantics.

🧠 Design: I used `Annotated[str, AfterValidator(_clean_display_name)]` because the codebase uses custom `ValueError` messages ("Display name must not be empty"). Using `StringConstraints(min_length=1, strip_whitespace=True)` would have replaced the custom error message with Pydantic's default, potentially breaking API contracts or tests that rely on that specific message string. This design perfectly aligns with the project's preference for composable, pure transformations while adhering to Pydantic V2 idioms.

λ FP Angle: This replaces ad-hoc local mutation (class methods reaching into data streams) with a composable, reusable type definition. The validation is now declarative and bound directly to the field's type signature rather than floating as an implementation detail on the model.

✅ Verification: 
- Ran backend CI suite: `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest` (Passed)
- Ran frontend E2E suite: `cd packages/create-h4ckath0n/templates/fullstack/web/ && npm ci && npx playwright install --with-deps chromium && npm run test:e2e` (Passed)
- Verified with code review tool.

🧪 Edge cases: Preserves identical handling for `display_name="   "` (raises value error), `display_name=" valid "` (strips to `"valid"`), and `display_name=""` (raises value error).

⚠️ Risk: Very low. This is a behavior-preserving, compile-time refactor. The API contract, validation rules, and error messages remain exactly the same.

---
*PR created automatically by Jules for task [11295219682728345258](https://jules.google.com/task/11295219682728345258) started by @ToolchainLab*