### PR TITLE
∴ Vector: Centralize display name validation into reusable type

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
-    """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
+def clean_display_name(v: str) -> str:
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
+
+
+DisplayName = Annotated[
+    str, Field(max_length=DISPLAY_NAME_MAX_LENGTH), AfterValidator(clean_display_name)
+]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +34,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 **What**:
Extracted duplicated `display_name` validation logic (handling whitespace stripping, empty checks, and max length) from individual Pydantic models into a single `DisplayName` reusable `Annotated` type utilizing Pydantic V2's `AfterValidator`.

🎯 **Why**:
Multiple schema models (`RegisterRequest`, `PasskeyRegisterStartRequest`, etc.) were independently defining the same string-stripping logic and custom `ValueError` generation using `@field_validator("display_name")` methods. This led to code duplication and created a risk of validation drift if the requirements for display names changed.

🧠 **Design**:
Pydantic V2 strongly encourages creating domain-specific types via `typing.Annotated`. By defining `DisplayName` with `Field(max_length=...)` and an `AfterValidator`, we wrap the business logic in an explicit, reusable type. We removed the unused `_validate_display_name` utility and replaced scattered `@field_validator` hooks with direct type annotations.

λ **FP Angle**:
This change shifts from ad hoc validation hooks mutating object creation state toward centralized semantic types. Instead of each model knowing *how* to validate a display name, the validation is inherently bound to the type itself. The single pure function `clean_display_name` receives data, normalizes it, and either returns the clean data or raises a semantic error.

✅ **Verification**:
- `uv run --locked ruff format .`
- `uv run --locked ruff check .`
- `uv run --locked mypy src`
- `uv run pytest` (188 tests passed, explicitly validating passkeys and display name persistence).
- Ran frontend E2E Playwright tests locally (all 27 tests passed successfully).

🧪 **Edge cases**:
- Null/optional display names are handled correctly because the type system explicitly uses `DisplayName | None` when needed, allowing the base validator to only concern itself with `str` inputs safely.
- Custom validation messages ("Display name must not be empty") from the legacy implementation were preserved exactly, avoiding breaking downstream test assertions.

⚠️ **Risk**:
Low risk. Pydantic successfully merges field constraints during class building, ensuring API-level schema documentation is preserved seamlessly. The behavior is functionally identical.

---
*PR created automatically by Jules for task [7859977879802572708](https://jules.google.com/task/7859977879802572708) started by @ToolchainLab*