### PR TITLE
⚡ Bolt: Avoid O(N) scan when checking for first user

### DIFF
--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -40,9 +40,10 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Check if table is empty using limit(1) instead of count() to avoid O(N)
+        # full table scan
+        first_user = await db.scalar(select(User.id).limit(1))
+        if first_user is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: 
Replaced `select(func.count()).select_from(User)` with `select(User.id).limit(1)` in `_is_bootstrap_admin`.

🎯 Why: 
When checking if a user table is empty (such as during the first user registration), using `func.count()` causes the database (especially in MVCC architectures like PostgreSQL) to perform a full scan of the table or index, which is an O(N) operation. We only need to know if *any* row exists.

📊 Impact: 
Converts the check from O(N) to O(1), making it significantly more efficient for large databases while having negligible impact on small ones. Prevents performance degradation as the user base grows.

🔬 Measurement: 
The execution plan of `SELECT id FROM user LIMIT 1` will show an index scan fetching a single row, whereas `SELECT COUNT(*) FROM user` would show an aggregate scan. Backend tests pass confirming functional parity.

---
*PR created automatically by Jules for task [17786133440257801981](https://jules.google.com/task/17786133440257801981) started by @ToolchainLab*