### PR TITLE
🎨 Palette: Add ARIA labels to mobile Layout buttons

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -48,9 +48,9 @@ describe("Layout theme preference", () => {
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
-      expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
-      ).toBeInTheDocument();
+      const buttons = screen.getAllByRole("button", { name: "Theme: system (dark)" });
+      expect(buttons.length).toBeGreaterThan(0);
+      expect(buttons[0]).toBeInTheDocument();
     });
   });
 
@@ -58,15 +58,17 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
-    fireEvent.click(button);
+    const buttons = screen.getAllByRole("button", { name: "Theme: system (dark)" });
+    const button = buttons[0];
+    expect(button).toBeDefined();
+    fireEvent.click(button!);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
-      expect(
-        screen.getByRole("button", { name: "Theme: light" }),
-      ).toBeInTheDocument();
+      const lightButtons = screen.getAllByRole("button", { name: "Theme: light" });
+      expect(lightButtons.length).toBeGreaterThan(0);
+      expect(lightButtons[0]).toBeInTheDocument();
     });
   });
 
@@ -75,18 +77,20 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const buttons = screen.getAllByRole("button", { name: "Theme: light" });
+    const button = buttons[0];
+    expect(button).toBeDefined();
 
-    fireEvent.click(button);
+    fireEvent.click(button!);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
-      expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
-      ).toBeInTheDocument();
+      const darkButtons = screen.getAllByRole("button", { name: "Theme: dark" });
+      expect(darkButtons.length).toBeGreaterThan(0);
+      expect(darkButtons[0]).toBeInTheDocument();
     });
 
-    fireEvent.click(button);
+    fireEvent.click(button!);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -192,6 +192,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +208,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />


### PR DESCRIPTION
💡 What
I've added explicit `aria-label`s to the mobile theme toggle and mobile menu buttons inside the `Layout.tsx` component. In addition, the mobile menu button now features a dynamic `aria-expanded` property.

🎯 Why
These buttons are icon-only UI elements. Screen readers or assistive technologies previously struggled to convey the function of these buttons because no accessible text was associated with them. The update ensures proper and equivalent semantic interpretation for users relying on keyboard navigation and screen readers across devices. 

📸 Before/After
*(Visuals remain unchanged as modifications were purely semantic HTML properties, but users utilizing screen readers can now navigate the Layout effectively)*

♿ Accessibility
- Appended missing `aria-label` descriptive text corresponding to their functionality (`Theme: system...` etc. mirroring the desktop version, and `Open menu`/`Close menu`) on the icon-only controls.
- Added dynamic `aria-expanded` attribute conveying whether the mobile navigation overlay is active.

---
*PR created automatically by Jules for task [16782272625308650041](https://jules.google.com/task/16782272625308650041) started by @ToolchainLab*