### PR TITLE
🧭 Atlas: Add drift check for environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-06-09 - Pydantic V2 dynamic model extraction for environment variable parity
+
+**Learning:** Environment variables frequently drift because developers add fields to Pydantic Settings models but forget to document them. `BaseSettings` auto-generates env var names based on an `env_prefix` and field names, meaning hardcoding env vars in drift checks is brittle. Furthermore, multiple settings models (`Settings`, `ObservabilitySettings`) can exist with different prefix logic.
+**Action:** When validating environment variable documentation, dynamically extract fields from Pydantic `model_fields`, prepend the correct app-specific prefix (handling exceptions like `OPENAI_API_KEY`), and match exact variables enclosed in backticks (e.g. `` `H4CKATH0N_ENV` ``) to avoid substring matches.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,28 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in dev mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend type |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory path |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the app frontend |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend type (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when backend is `file` |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host for email backend |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Whether to use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Whether to use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Demo mode flag |
+| `LANGSMITH_TRACING` | `false` | Whether LangSmith tracing is enabled |
+| `LANGSMITH_API_KEY` | empty | API key for LangSmith |
+| `LANGSMITH_PROJECT` | `default` | LangSmith project name |
+| `OTEL_ENABLED` | `false` | Whether OpenTelemetry is enabled |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | empty | OpenTelemetry exporter endpoint |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    # We must insert the src directory into sys.path to import local modules directly
+    sys.path.insert(0, str(REPO_ROOT / "src"))  # noqa: E402
+    from h4ckath0n.config import Settings
+    from h4ckath0n.obs.settings import ObservabilitySettings
+
+    env_vars = []
+
+    # Settings has prefix H4CKATH0N_
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            env_vars.append("OPENAI_API_KEY")
+            env_vars.append("H4CKATH0N_OPENAI_API_KEY")
+        else:
+            env_vars.append(f"H4CKATH0N_{field_name.upper()}")
+
+    # ObservabilitySettings has no prefix
+    for field_name in ObservabilitySettings.model_fields:
+        env_vars.append(field_name.upper())
+
+    return env_vars
+
+
+def check_env_vars_in_readme(env_vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing = []
+    for var in env_vars:
+        # Check for strict match enclosed in backticks
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration section in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added documentation for 22 missing environment variables in `README.md`, sourced from `Settings` and `ObservabilitySettings`. Created a `scripts/check_doc_env_vars.py` script to enforce environment variable parity in CI.
🎯 Why: Environment variables frequently drift because developers add fields to Pydantic Settings models but forget to document them in the README, leading to onboarding friction and configuration ambiguity.
🧪 Verification: Run `uv run scripts/check_doc_env_vars.py` to verify all environment variables from Pydantic config models exist in the README. Run `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest` to verify the backend quality gates.
🔒 Drift Prevention: A new script `scripts/check_doc_env_vars.py` dynamically extracts model fields from `Settings` and `ObservabilitySettings` and is executed in the `backend` job of `.github/workflows/ci.yml`. This breaks the build if a new env var is added without documentation.
🗺️ Evidence: Code modifications target `README.md`, `.github/workflows/ci.yml`, and `scripts/check_doc_env_vars.py`. Configuration models were extracted from `src/h4ckath0n/config.py` and `src/h4ckath0n/obs/settings.py`.

---
*PR created automatically by Jules for task [337780275760612354](https://jules.google.com/task/337780275760612354) started by @ToolchainLab*