### PR TITLE
∴ Vector: Centralize duplicated display_name validation logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2026-06-10 - Centralize Pydantic Validation Logic via Annotated
+**Learning:** When refactoring duplicated `@field_validator` logic in Pydantic V2 into reusable types, using `typing.Annotated` with `pydantic.functional_validators.AfterValidator` preserves custom `ValueError` messages compared to `StringConstraints`, avoiding test failures that depend on exact exception text.
+**Action:** Extract reusable `AfterValidator` annotations instead of repeating `@field_validator` methods, especially when maintaining specific error messages is important.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayNameType
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayNameType = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
+
+
+def _clean_display_name(v: str) -> str:
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
+DisplayNameType = Annotated[
+    str, Field(max_length=DISPLAY_NAME_MAX_LENGTH), AfterValidator(_clean_display_name)
+]
 
 
 def _validate_display_name(v: str | None) -> str | None:
@@ -29,19 +44,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayNameType = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What: Extracted duplicated `display_name` validation logic (whitespace trimming and empty check) into a centralized `DisplayNameType` using `typing.Annotated` and `AfterValidator`.
🎯 Why: To remove duplicated `@field_validator` methods across `RegisterRequest` and `PasskeyRegisterStartRequest`, adhering to DRY principles.
🧠 Design: Using `AfterValidator` rather than `StringConstraints` preserves the custom `ValueError("Display name must not be empty")` string which tests might depend on. The `DISPLAY_NAME_MAX_LENGTH` is also cleanly captured in the alias.
λ FP Angle: Transforms scattered mutation (imperative validators mapped to specific schema classes) into a single explicit, composable type definition.
✅ Verification: `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest` passed successfully. Frontend E2E tests (`npm run test:e2e`) also passed.
🧪 Edge cases: `_clean_display_name` safely handles edge cases like strings that only contain spaces (e.g. `"   "`), converting them to an empty string and explicitly raising a validation error.
⚠️ Risk: Low risk. This is a pure refactor of validation logic; API schemas and the final runtime validation remain identical.

---
*PR created automatically by Jules for task [3193508232451950102](https://jules.google.com/task/3193508232451950102) started by @ToolchainLab*