### PR TITLE
⚡ Bolt: Optimize first-user existence check to avoid O(N) table scan

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-22 - Optimize Existence Checks
+
+**Learning:** When checking if a database table is empty (e.g., verifying if the first user is registering to assign admin privileges), using `await db.execute(select(func.count()).select_from(Model))` scans the entire table or index, which is an O(N) operation.
+**Action:** Always use `await db.scalar(select(Model.id).limit(1))` and check for `None` when performing existence checks. This converts an O(N) full table/index scan into an O(1) operation, significantly reducing database load, especially as tables grow large.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -40,9 +40,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Use limit(1) to check for existence instead of a full O(N) table count scan
+        result = await db.scalar(select(User.id).limit(1))
+        if result is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: Replaced `select(func.count())` with `select(User.id).limit(1)` for checking if the `User` table is empty.
🎯 Why: Counting the entire table is an O(N) operation. Checking for existence with `limit(1)` is an O(1) operation, reducing database load during registration.
📊 Impact: Registration path scales better for large tables, shifting from O(N) to O(1) for the admin check.
🔬 Measurement: Run the backend test suite and frontend E2E tests to verify functionality remains unchanged.

---
*PR created automatically by Jules for task [14076323597326269565](https://jules.google.com/task/14076323597326269565) started by @ToolchainLab*