### PR TITLE
🧭 Atlas: Document missing environment variables and add drift prevention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc envs
+        run: uv run --locked scripts/check_doc_envs.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Environment variable documentation drift
+**Learning:** It is easy for the configuration table in README.md to drift from the actual `Settings` model in `src/h4ckath0n/config.py`.
+**Action:** Implement a drift check script that dynamically parses `Settings.model_fields` and verifies that every field (with the appropriate env prefix) is explicitly documented in backticks in the README.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (if using redis extra) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline without a worker in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory path for uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web application for emails |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email sending backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to write emails to when using file backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain destructive actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_envs.py
+++ b/scripts/check_doc_envs.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every env var in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_envs.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings_envs() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    envs = []
+    for k in Settings.model_fields:
+        if k == "openai_api_key":
+            envs.append("OPENAI_API_KEY")
+        else:
+            envs.append(f"H4CKATH0N_{k.upper()}")
+    return sorted(envs)
+
+
+def check_envs_in_readme(envs: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing = []
+    for env in envs:
+        if f"`{env}`" not in readme_text:
+            missing.append(env)
+    return missing
+
+
+def main() -> int:
+    envs = get_settings_envs()
+    missing = check_envs_in_readme(envs)
+
+    if missing:
+        print("❌ The following env vars are NOT documented in README.md:\n")
+        for env in missing:
+            print(f"  {env}")
+        return 1
+
+    print(f"✅ All {len(envs)} env vars are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: The README was missing documentation for 17 environment variables parsed by the `Settings` Pydantic model. This change documents them and implements a dynamic test that enforces environment variable documentation.
🎯 Why: Without enforcing the documentation of configuration variables, it is incredibly easy for new variables to be added via PRs, leaving users to find out about them via source code inspection or errors. This reduces "time-to-understanding" for new developers.
🧪 Verification: Run locally with `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest`. Then test the drift check specifically using `uv run --locked scripts/check_doc_envs.py`.
🔒 Drift Prevention: A new script `scripts/check_doc_envs.py` statically enforces documentation coverage for every property in `Settings`. A corresponding step has been added to `.github/workflows/ci.yml`.
🗺️ Evidence: `src/h4ckath0n/config.py` was treated as the ultimate source of truth.

---
*PR created automatically by Jules for task [3335755718422859825](https://jules.google.com/task/3335755718422859825) started by @ToolchainLab*