### PR TITLE
∷ Vector: Centralize display name validation using Annotated Pydantic types

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,4 @@
+
+## 2025-02-12 - Centralized validation with Pydantic Annotated
+**Learning:** Pydantic V2 allows replacing duplicated `@field_validator` logic with reusable `typing.Annotated` types using `AfterValidator`.
+**Action:** Use `Annotated` + `AfterValidator` to centralize and compose validation rules, rather than repeating `@field_validator` decorators across models.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,19 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,24 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import BaseModel, EmailStr, Field
+from pydantic.functional_validators import AfterValidator
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
-    """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
+def _clean_display_name_fn(v: str) -> str:
+    """Trim whitespace and reject empty display names."""
     v = v.strip()
-    if v == "":
-        return None
+    if not v:
+        raise ValueError("Display name must not be empty")
     return v
+
+
+DisplayName = Annotated[str, AfterValidator(_clean_display_name_fn)]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +33,11 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 **What**: Extracted `display_name` validation into a reusable Pydantic `Annotated` type (`DisplayName`) using `AfterValidator`, removing duplicated `@field_validator` logic across `RegisterRequest` and `PasskeyRegisterStartRequest`. Also removed an unused `_validate_display_name` helper.
- 🎯 **Why**: To remove duplicated validation logic and create a single source of truth for display name normalization/validation.
- 🧠 **Design**: Replaces the decorators with a single, clear, composable type definition following Pydantic V2 idioms.
- λ **FP Angle**: Centralizes semantic rules into a pure helper that composes neatly with Pydantic's functional validation pipelines. Reduces repetition and makes intermediate models more explicitly typed.
- ✅ **Verification**: Ran `uv run pytest` successfully. Verified static types via `mypy` and formatting with `ruff`. Also ran frontend Playwright tests (`npm run test:e2e`) to ensure auth regressions didn't occur.
- 🧪 **Edge cases**: Ensured whitespace-only display names still correctly raise `ValueError`, maintaining exact parity with previous behavior.
- ⚠️ **Risk**: Very low risk. It's a syntactic reorganization that uses supported Pydantic V2 features for identical behavioral validation.

---
*PR created automatically by Jules for task [11776490281288006680](https://jules.google.com/task/11776490281288006680) started by @ToolchainLab*