### PR TITLE
⚡ Bolt: Optimize first user emptiness check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-22 - Avoid Table Scans for Emptiness Checks
+**Learning:** Using `await db.execute(select(func.count()).select_from(Model))` to check if a table is empty causes an O(N) full table scan in Postgres due to MVCC.
+**Action:** Always use `await db.scalar(select(Model.id).limit(1))` and check for `None` to perform an O(1) emptiness check, stopping the scan after the first matching row is found.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -40,9 +40,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Use select(Model.id).limit(1) for emptiness check to avoid O(N) full table scan
+        first_user_id = await db.scalar(select(User.id).limit(1))
+        if first_user_id is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What:
Replaced the `func.count()` query used to check if the `User` table is empty with `await db.scalar(select(User.id).limit(1))` during user registration.

🎯 Why:
In relational databases like PostgreSQL, running `COUNT(*)` without a WHERE clause requires a full table or full index scan due to MVCC visibility checks. This is an O(N) operation. When checking if a table is empty, we only need a single witness. Using `.limit(1)` allows the database to stop scanning as soon as the first row is found, converting it into an O(1) operation.

📊 Impact:
Transforms an O(N) table scan into an O(1) existence check for every user registration when `first_user_is_admin` is enabled. Reduces database load and memory allocation, particularly as the `User` table grows over time.

🔬 Measurement:
1. Registering the first user will check the table.
2. Subsequent registrations will execute `select(User.id).limit(1)`. Since there are already users, it instantly returns the ID of the first user it scans and proceeds, rather than scanning all existing users to compute a full count.
3. Verified via `uv run pytest` and frontend E2E tests (`npm run test:e2e`).

---
*PR created automatically by Jules for task [15457476496592760937](https://jules.google.com/task/15457476496592760937) started by @ToolchainLab*