### PR TITLE
🧭 Atlas: Document missing env vars and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked python scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Config field names drift from README if not strictly checked
+
+**Learning:** Pydantic `BaseSettings` configurations often grow new variables (e.g., SMTP configurations, max upload bytes, etc.) that get missed in the documentation. In order to catch drift accurately, environment variables need to be formatted exactly as they appear in the documentation (usually enclosed in backticks) and include the app prefix to avoid false-positive matches within prose.
+
+**Action:** Generate the full environment variables programmatically via `Settings.model_fields`, append the app prefix (and account for exceptions like `OPENAI_API_KEY`), and match against markdown-formatted backticks `` `H4CKATH0N_VAR` `` in `README.md`.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline without a worker in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend: `local` or other implementations |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` (50MB) | Maximum file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend: `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for the `file` email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in the config is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py
+
+The script imports the h4ckath0n app's Settings model and checks that
+README.md mentions each configuration variable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    prefix = Settings.model_config.get("env_prefix", "")
+    env_vars: list[str] = []
+
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            env_vars.append("OPENAI_API_KEY")
+            env_vars.append(f"{prefix}OPENAI_API_KEY".upper())
+        else:
+            env_vars.append(f"{prefix}{field_name}".upper())
+
+    return sorted(list(set(env_vars)))
+
+
+def check_env_vars_in_readme(
+    env_vars: list[str],
+) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for var in env_vars:
+        # Match the env var exactly enclosed in backticks
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added documentation for 17 missing environment variables in `README.md` and introduced an automated drift-prevention script.
🎯 Why: Pydantic `BaseSettings` configurations often grow new variables that get missed in documentation. Providing strict, explicit lists prevents onboarding errors and configuration ambiguity.
🧪 Verification: Run `uv run python scripts/check_doc_env_vars.py` to verify that every config value is documented in the README. 
🔒 Drift Prevention: Added `scripts/check_doc_env_vars.py` which dynamically reads `Settings.model_fields`, computes the exact expected names, and fails if they are missing from `README.md`. Wired this into the backend CI `.github/workflows/ci.yml`.
🗺️ Evidence: `src/h4ckath0n/config.py` was treated as the authoritative source of truth for the available config variables.

---
*PR created automatically by Jules for task [13601050910310135545](https://jules.google.com/task/13601050910310135545) started by @ToolchainLab*