### PR TITLE
🎨 Palette: Add missing ARIA labels to mobile layout controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-12 - Responsive Button ARIA Synchronization
+**Learning:** When icon-only buttons (like a theme toggle) are duplicated for responsive layouts (e.g., hidden/shown via md:hidden or hidden md:flex), failing to add identical aria-label attributes to the mobile versions creates inconsistent accessibility experiences. Furthermore, adding these labels causes existing getByRole tests to fail due to multiple matches, requiring updates to handle arrays of elements.
+**Action:** Always ensure responsive clones of icon-only controls receive identical ARIA states/labels as their desktop counterparts, and proactively update testing-library queries using getAllByRole and non-null assertions to handle the duplicated DOM nodes robustly.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,15 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
+    expect(button).toBeDefined();
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +76,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
-
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
+    expect(button).toBeDefined();
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0]!,
       ).toBeInTheDocument();
     });
 
@@ -91,8 +92,8 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+        screen.queryAllByRole("button", { name: /Theme: system/ }),
+      ).toHaveLength(0);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -192,6 +192,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +208,9 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label="Toggle mobile menu"
+                aria-expanded={isMobileMenuOpen}
+                aria-controls="mobile-menu"
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -216,7 +224,7 @@ export function Layout() {
 
         {/* Mobile Navigation */}
         {isMobileMenuOpen && (
-          <div className="md:hidden border-t border-border bg-surface">
+          <div id="mobile-menu" className="md:hidden border-t border-border bg-surface">
             <div className="px-4 py-4 space-y-2">
               {isAuthenticated ? (
                 <>


### PR DESCRIPTION
💡 What: Added missing `aria-label`, `aria-expanded`, and `aria-controls` attributes to the mobile navigation controls in `Layout.tsx`, and updated related tests to handle multiple matching elements.
🎯 Why: Icon-only buttons on mobile were lacking accessible names and screen reader feedback for their toggled states, creating a confusing experience for assistive technologies.
📸 Before/After: Before: `<button><Sun /></button>`. After: `<button aria-label="Theme: system (dark)"><Sun /></button>`. Mobile menu toggle now has `aria-expanded` and `aria-controls` linked to `id="mobile-menu"`.
♿ Accessibility: Screen reader users can now understand the purpose and current state of the theme and menu toggle buttons on mobile views.

---
*PR created automatically by Jules for task [9986366036619205627](https://jules.google.com/task/9986366036619205627) started by @ToolchainLab*