### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix user enumeration timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Auth Timing Attack]
+**Vulnerability:** Timing attack possible on `authenticate_user` when user doesn't exist.
+**Learning:** `authenticate_user` returns early if user not found, skipping the expensive argon2 hash verification. This leaks whether an email is registered or not via response timing.
+**Prevention:** Always perform a dummy hash verification when a user is not found to ensure constant-time response and prevent user enumeration.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -75,12 +75,21 @@ async def register_user(
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+
+    # 🛡️ Sentinel: Mitigate timing attacks by always hashing
+    dummy_hash = (
+        "$argon2id$v=19$m=65536,t=3,p=4$SHcUjI9PpyPXZYms0onllw$"
+        "vcMxg0MQeBXfFjuG9usBx09Z+odqi9uspfdztaRGF90"
+    )
+    user = result.scalars().first()
+
+    if user is None or not user.password_hash:
+        verify_password(password, dummy_hash)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
+
     return user
 
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `authenticate_user` function returned early if a user was not found or did not have a password hash, skipping the expensive Argon2id hash verification process. This created a measurable difference in response times, allowing an attacker to determine if a given email address is registered in the system (Username Enumeration via Timing Attack).
🎯 **Impact:** Attackers could harvest valid email addresses from the system by measuring the response time of the login endpoint. These valid emails could then be targeted for phishing attacks, credential stuffing, or targeted password brute-forcing.
🔧 **Fix:** Modified `authenticate_user` to always verify the provided password against a static, pre-computed "dummy" Argon2id hash when a valid user hash is unavailable. This ensures the expensive hashing operation is always performed, equalizing response times.
✅ **Verification:**
- Wrote and executed an ad-hoc local timing script (`test_timing.py`) to confirm that response times are now nearly identical whether the email exists or not.
- Ran all backend Pytest tests successfully (`uv run pytest`).
- Ran frontend Playwright E2E tests successfully (`npm run test:e2e`).

---
*PR created automatically by Jules for task [6638451399660343793](https://jules.google.com/task/6638451399660343793) started by @ToolchainLab*