### PR TITLE
🧭 Atlas: Document missing environment variables and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-06-13 - Env var drift
+**Learning:** Pydantic Settings dynamically drift from markdown tables unless enforced.
+**Action:** Use a script checking `Settings.model_fields` to catch undocumented variables in README.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development environment |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (e.g., `local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_env_vars.py
+
+The script imports the h4ckath0n config Settings, enumerates all fields,
+and checks that README.md mentions each corresponding environment variable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    """Return a list of environment variables defined by Settings."""
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    env_vars: list[str] = []
+    # Use Settings.model_fields directly to comply with SIM118
+    for field_name in Settings.model_fields:
+        if field_name == "openai_api_key":
+            # Special case for OpenAI key where we support both
+            env_vars.append("OPENAI_API_KEY")
+            env_vars.append("H4CKATH0N_OPENAI_API_KEY")
+        else:
+            env_vars.append(f"H4CKATH0N_{field_name.upper()}")
+
+    return env_vars
+
+
+def check_vars_in_readme(env_vars: list[str]) -> list[str]:
+    """Return environment variables that are not mentioned in README.md."""
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for var in env_vars:
+        # Require the environment variable to be documented in backticks
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    missing = check_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these environment variables to README.md to ensure parity.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Updated `README.md` to document all environment variables present in `pydantic-settings` and added a script `check_env_vars.py` to enforce this parity in CI.
🎯 Why: Environment variables drift between the documentation and what is actually available in configuration, leading to onboarding friction.
✅ Verification: `uv run --locked scripts/check_env_vars.py` locally and verified through CI step.
🔒 Drift Prevention: Added a CI script that strictly checks `Settings.model_fields` and asserts they are mentioned in `README.md`.
🗺️ Evidence: `src/h4ckath0n/config.py` was used to identify missing documentation.

---
*PR created automatically by Jules for task [10524590389668736428](https://jules.google.com/task/10524590389668736428) started by @ToolchainLab*