### PR TITLE
∴ Vector: Extract shared display name normalizer

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-06-14 - Extract shared display name normalization to reusable AfterValidator
+**Learning:** We have duplicated `@field_validator` logic in both `auth/schemas.py` and `auth/passkeys/schemas.py` that raises custom `ValueError` exceptions for empty display names.
+**Action:** Extract this logic into a centralized `typing.Annotated` type with `AfterValidator`. Based on project conventions, use `AfterValidator` rather than `StringConstraints` to preserve the exact custom `ValueError` exception ("Display name must not be empty") that existing tests might rely upon.

--- a/packages/create-h4ckath0n/templates/fullstack/api/openapi.json
+++ b/packages/create-h4ckath0n/templates/fullstack/api/openapi.json
@@ -659,7 +659,7 @@
       "PasskeyRegisterStartRequest": {
         "properties": {
           "display_name": {
-            "description": "Human-facing display name for the new account.",
+            "description": "Human-facing display name.",
             "maxLength": 200,
             "title": "Display Name",
             "type": "string"
@@ -853,7 +853,7 @@
             "title": "Device Public Key Jwk"
           },
           "display_name": {
-            "description": "Human-facing display name for the account.",
+            "description": "Human-facing display name.",
             "maxLength": 200,
             "title": "Display Name",
             "type": "string"

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/api/openapi.ts
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/api/openapi.ts
@@ -910,7 +910,7 @@ export interface components {
         PasskeyRegisterStartRequest: {
             /**
              * Display Name
-             * @description Human-facing display name for the new account.
+             * @description Human-facing display name.
              */
             display_name: string;
         };
@@ -1016,7 +1016,7 @@ export interface components {
             } | null;
             /**
              * Display Name
-             * @description Human-facing display name for the account.
+             * @description Human-facing display name.
              */
             display_name: string;
             /**

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,15 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
-        ...,
-        description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
-    )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    display_name: DisplayName
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,10 +2,26 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated
+
+from pydantic import AfterValidator, BaseModel, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
+
+
+def _clean_display_name_helper(v: str) -> str:
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
+DisplayName = Annotated[
+    str,
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH, description="Human-facing display name."),
+    AfterValidator(_clean_display_name_helper),
+]
 
 
 def _validate_display_name(v: str | None) -> str | None:
@@ -29,19 +45,7 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
-        ...,
-        description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
-    )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+    display_name: DisplayName
 
 
 class LoginRequest(DeviceBindingMixin):

--- a/vector.md
+++ b/vector.md
@@ -1,3 +1,0 @@
-## 2024-06-14 - Extract shared display name normalization to reusable AfterValidator
-**Learning:** We have duplicated `_clean_display_name` validation logic in both `auth/schemas.py` and `auth/passkeys/schemas.py` that raises custom `ValueError` exceptions for empty display names.
-**Action:** Extract this logic into a centralized `typing.Annotated` type with `AfterValidator`. Based on project conventions, use `AfterValidator` rather than `StringConstraints` to preserve the exact custom `ValueError` exception ("Display name must not be empty") that existing tests might rely upon.

--- a/vector.md
+++ b/vector.md
@@ -1,0 +1,3 @@
+## 2024-06-14 - Extract shared display name normalization to reusable AfterValidator
+**Learning:** We have duplicated `_clean_display_name` validation logic in both `auth/schemas.py` and `auth/passkeys/schemas.py` that raises custom `ValueError` exceptions for empty display names.
+**Action:** Extract this logic into a centralized `typing.Annotated` type with `AfterValidator`. Based on project conventions, use `AfterValidator` rather than `StringConstraints` to preserve the exact custom `ValueError` exception ("Display name must not be empty") that existing tests might rely upon.


### PR DESCRIPTION
- 💡 What: Extracted the duplicated `_clean_display_name` validation logic into a centralized `typing.Annotated` type (`DisplayName`) using `AfterValidator`.
- 🎯 Why: Removes duplicated code across `auth/schemas.py` and `auth/passkeys/schemas.py`, ensuring a single source of truth for display name normalization.
- 🧠 Design: Centralized the normalization and custom ValueError logic into `DisplayName`. Refactored `RegisterRequest.display_name` and `PasskeyRegisterStartRequest.display_name` to use this type instead of inline `@field_validator` methods. Used `AfterValidator` rather than `StringConstraints` to preserve the exact custom `ValueError` exception that tests might rely upon.
- λ FP Angle: Reduces scattered mutation and duplicated validation logic by using an explicit pure transformation pipeline (`_clean_display_name_helper`) that normalizes the value explicitly during Pydantic validation.
- ✅ Verification: Ran formatting, linting (Ruff), typechecking (Mypy), and Pytest, which all passed. Also ran frontend E2E Playwright tests successfully.
- 🧪 Edge cases: Preserves the exact handling of whitespace-only strings turning into empty strings, which then properly raise a validation error.
- ⚠️ Risk: Very low. It strictly maintains the exact same validation behavior and uses standard Pydantic typing features.

---
*PR created automatically by Jules for task [13849866534072966664](https://jules.google.com/task/13849866534072966664) started by @ToolchainLab*