### PR TITLE
⚡ Bolt: Optimize first user check to O(1)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-22 - O(N) Count vs O(1) Limit Query in SQLAlchemy
+
+**Learning:** When checking if a table is completely empty (such as verifying if the very first user is registering), using `await db.execute(select(func.count()).select_from(Model))` triggers a sequential full-table or index scan, making it an O(N) operation.
+**Action:** Replace `func.count()` with a `limit(1)` lookup, e.g. `await db.scalar(select(Model.id).limit(1))`. If this returns `None`, the table is empty. This short-circuits the query immediately upon finding the first row, converting an O(N) scan into an O(1) existence check.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -40,9 +40,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Check for existence with O(1) limit(1) instead of O(N) count()
+        first_id = await db.scalar(select(User.id).limit(1))
+        if first_id is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: Replaced `func.count()` with `limit(1)` in `_is_bootstrap_admin` when checking if the `User` table is empty.

🎯 Why: To decide if a new user should be a bootstrap admin, the backend was executing `SELECT COUNT(*) FROM users`. This forces the database to scan all rows (or index entries), making it an O(N) operation.

📊 Impact: Converts an O(N) full table/index scan into an O(1) existence check that stops exactly after locating the very first row, significantly improving performance as the user table grows.

🔬 Measurement: Verify via backend and frontend E2E test suites ensuring the first user still successfully registers as an admin.

---
*PR created automatically by Jules for task [13795665696701019491](https://jules.google.com/task/13795665696701019491) started by @ToolchainLab*