### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix user enumeration timing attack in login endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-14 - Timing Attack on User Login
+**Vulnerability:** User enumeration timing attack possible on the password login endpoint. Returning early if a user isn't found or lacks a password means an attacker can time responses and discover if an email exists in the system.
+**Learning:** Argon2id hash verification is relatively slow. We must ensure the work done is constant, even for absent users.
+**Prevention:** If the user is missing, compute a dummy verify on a pre-computed valid hash structure, so the response time matches the "user found, wrong password" case.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -75,10 +75,20 @@ async def register_user(
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    # 🛡️ Sentinel: Mitigate timing attacks for user enumeration.
+    # Verify against a dummy hash when the user is not found or has no password
+    # to ensure the response time is roughly constant.
+    dummy_hash = (
+        "$argon2id$v=19$m=65536,t=3,p=4$U+wGhgJAqp6Yp/WPakhuUg"
+        "$NkEKDfRE/ZNQNP8BI33j73zmAWkQn2mXQGkT5MumNTM"
+    )
+
+    if user is None or not user.password_hash:
+        verify_password(password, dummy_hash)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: The `authenticate_user` function returns early when a user email is not found in the database. Since Argon2 password hashing takes a significant amount of time, an attacker can use the timing difference between an early return and a full verification to enumerate valid user emails (User Enumeration via Timing Attack).

🎯 **Impact**: Attackers can compile a list of valid user accounts by brute-forcing the login endpoint with different emails and measuring the response time. This compromises user privacy and is the first step towards targeted attacks such as credential stuffing or phishing.

🔧 **Fix**: Modified `authenticate_user` to perform a dummy password verification using a pre-computed valid Argon2id hash structure whenever a user is not found or has no password set. This ensures that the computational cost (and thus response time) is roughly constant whether the user exists or not.

✅ **Verification**: 
1. `test_timing` verified the timing difference.
2. The CI checks (Ruff, mypy, pytest) passed completely.
3. The Playwright E2E test suite for the frontend ran successfully, confirming no regressions in the authentication flow.

---
*PR created automatically by Jules for task [5297025297639353798](https://jules.google.com/task/5297025297639353798) started by @ToolchainLab*