### PR TITLE
🧭 Atlas: Document missing env vars & add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked python scripts/check_doc_env.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -173,8 +173,30 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes (default: 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to store local emails |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `LANGSMITH_TRACING` | `false` | Enable LangSmith tracing |
+| `LANGSMITH_API_KEY` | empty | LangSmith API key |
+| `LANGSMITH_PROJECT` | `default` | LangSmith project name |
+| `OTEL_ENABLED` | `false` | Enable OpenTelemetry |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | empty | OpenTelemetry OTLP endpoint URL |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env.py
+++ b/scripts/check_doc_env.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that Pydantic Settings are documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env.py
+
+The script imports the application's configuration models and checks that
+README.md mentions each corresponding environment variable enclosed in backticks.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    from h4ckath0n.config import Settings
+    from h4ckath0n.obs.settings import ObservabilitySettings
+
+    env_vars = []
+
+    settings_prefix = Settings.model_config.get("env_prefix", "")
+    for key in Settings.model_fields:
+        if key == "openai_api_key":
+            env_vars.append("OPENAI_API_KEY")
+            env_vars.append(f"{settings_prefix}OPENAI_API_KEY")
+        else:
+            env_vars.append(f"{settings_prefix}{key.upper()}")
+
+    obs_prefix = ObservabilitySettings.model_config.get("env_prefix", "")
+    for key in ObservabilitySettings.model_fields:
+        env_vars.append(f"{obs_prefix}{key.upper()}")
+
+    return env_vars
+
+
+def main() -> int:
+    readme_text = README.read_text()
+    env_vars = get_env_vars()
+    missing: list[str] = []
+
+    for env_var in env_vars:
+        # Strictly match the variable name enclosed in backticks to avoid
+        # false-positive substring matches.
+        if f"`{env_var}`" not in readme_text:
+            missing.append(env_var)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  {env_var}")
+        print("\nAdd these environment variables to the Configuration section in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
* 💡 What: Documented all missing environment variables in README.md and added a drift-prevention CI check.
* 🎯 Why: Outdated env var documentation is a huge pain for new users trying to configure the app.
* 🧪 Verification: Locally run `uv run --locked python scripts/check_doc_env.py`.
* 🔒 Drift Prevention: `scripts/check_doc_env.py` fails CI if any model field in `Settings` or `ObservabilitySettings` is not documented in README.md.
* 🗺️ Evidence: `src/h4ckath0n/config.py` and `src/h4ckath0n/obs/settings.py` were used as the source of truth.

---
*PR created automatically by Jules for task [11989854991036901771](https://jules.google.com/task/11989854991036901771) started by @ToolchainLab*