### PR TITLE
⚡ Bolt: Optimize first-user emptiness check to O(1)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-06-15 - Optimize Emptiness Checks using limit(1) instead of count()
+
+**Learning:** When checking if a database table is empty (e.g., verifying if the first user is registering), using `await db.execute(select(func.count()).select_from(Model))` triggers an O(N) full table or index scan, which becomes a severe bottleneck as the table grows.
+**Action:** Use `await db.scalar(select(Model.id).limit(1))` and check for `None`. This converts the check into an O(1) operation by returning the first row immediately if one exists, significantly reducing database load.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -40,9 +40,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Optimize check to see if first user using O(1) limit(1) instead of O(N) count()
+        first_user_id = await db.scalar(select(User.id).limit(1))
+        if first_user_id is None:
             return True
     return False
 


### PR DESCRIPTION
**💡 What**: Replaced `select(func.count()).select_from(User)` with `select(User.id).limit(1)` in the `_is_bootstrap_admin` check during user registration.

**🎯 Why**: The original approach forces SQLAlchemy and the database to execute a full table or index scan to count all rows just to determine if the table is empty. As the user table grows, this O(N) operation becomes a severe and unnecessary performance bottleneck on a hot path (user registration).

**📊 Impact**: Turns an O(N) full table scan into an O(1) database operation. The query now stops and returns immediately upon finding the very first user row.

**🔬 Measurement**: To verify, the registration path can be profiled, or the raw SQL queries executed by SQLAlchemy can be logged. The new `SELECT id FROM user LIMIT 1` will visibly execute much faster on large datasets compared to `SELECT count(*) FROM user`. All tests passed locally.

---
*PR created automatically by Jules for task [8597480115317961059](https://jules.google.com/task/8597480115317961059) started by @ToolchainLab*