### PR TITLE
🧭 Atlas: [Document missing configuration variables and add drift prevention]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked python scripts/check_doc_config.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Configuration Drift Prevention
+
+**Learning:** When ensuring configuration values (like Pydantic `Settings`) are properly documented in README.md, you must also be mindful of environment variable prefixes (`H4CKATH0N_`) and possible exceptions like `OPENAI_API_KEY`.
+**Action:** When adding drift checks for configurations, parse the application's configuration models directly (e.g. `Settings.model_fields.keys()`), reconstruct the expected environment variable name, and grep for it in the documentation.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `True` | Run jobs inline in development instead of enqueuing |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` or other supported options) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory path for storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file size for uploads in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web application for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory path for the file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host for sending emails |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `True` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `False` | Use implicit SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `False` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_config.py
+++ b/scripts/check_doc_config.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every configuration variable is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_config.py
+
+The script imports the h4ckath0n config Settings, enumerates all fields, and checks
+that README.md mentions each one (e.g. `H4CKATH0N_ENV`).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_config_fields() -> list[str]:
+    """Return a list of configuration field names from Settings."""
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    return list(Settings.model_fields.keys())
+
+
+def check_fields_in_readme(fields: list[str]) -> list[str]:
+    """Return field names that are not mentioned in README.md."""
+    readme_text = README.read_text()
+    missing: list[str] = []
+
+    for field_name in fields:
+        env_var = f"H4CKATH0N_{field_name.upper()}"
+
+        # Special case for OpenAI API key which might be documented without prefix
+        if env_var == "H4CKATH0N_OPENAI_API_KEY":
+            if not re.search(r"`OPENAI_API_KEY`", readme_text) and not re.search(
+                r"`H4CKATH0N_OPENAI_API_KEY`", readme_text
+            ):
+                missing.append(env_var)
+            continue
+
+        # Look for the exact env var name enclosed in backticks
+        pattern = rf"`{env_var}`"
+        if not re.search(pattern, readme_text):
+            missing.append(env_var)
+
+    return missing
+
+
+def main() -> int:
+    fields = get_config_fields()
+    missing = check_fields_in_readme(fields)
+
+    if missing:
+        print("❌ The following configuration variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration section in README.md.")
+        return 1
+
+    print(f"✅ All {len(fields)} configuration variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added the 17 missing configuration variables (like Redis, Storage, and Email settings) to the Configuration table in README.md, created a drift-prevention script (`scripts/check_doc_config.py`) that reads the Pydantic `Settings.model_fields` and verifies documentation presence, and wired it into the GitHub Actions CI pipeline.
🎯 Why: Configuration drift can lead to confusion during onboarding or when attempting to configure application features (like background jobs or emails). Enforcing that all Settings fields are documented ensures new developers have a single, reliable source of truth.
🧪 Verification: Run `uv run --locked python scripts/check_doc_config.py` locally and observe it succeeds.
🔒 Drift Prevention: Added `scripts/check_doc_config.py` to `.github/workflows/ci.yml`. It will fail the CI if a new property is added to `Settings` but missing from the `README.md`.
🗺️ Evidence: `src/h4ckath0n/config.py` (`Settings.model_fields`) is used as the source of truth.

---
*PR created automatically by Jules for task [13084359219938622131](https://jules.google.com/task/13084359219938622131) started by @ToolchainLab*