### PR TITLE
∴ Vector: Extract reusable DisplayNameField Pydantic type to remove duplicated validation

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayNameField
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayNameField = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,20 +2,27 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated, Any
+
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
-    """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
-    v = v.strip()
-    if v == "":
-        return None
+def _strict_clean_display_name(v: Any) -> Any:
+    if isinstance(v, str):
+        v = v.strip()
+        if not v:
+            raise ValueError("Display name must not be empty")
     return v
+
+
+DisplayNameField = Annotated[
+    str,
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH),
+    BeforeValidator(_strict_clean_display_name),
+]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -29,19 +36,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayNameField = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted the duplicated `_clean_display_name` validation logic from `RegisterRequest` and `PasskeyRegisterStartRequest` into a centralized, reusable `DisplayNameField` using Pydantic V2's `Annotated` type and `BeforeValidator`.
- 🎯 Why: To reduce duplication, create a single source of truth for display name normalization/validation, and ensure that validation correctly handles edge cases (like trimming whitespace before checking `max_length`).
- 🧠 Design: By using `Annotated[str, Field(max_length=...), BeforeValidator(...)]`, we create a pure transformation pipeline that strips whitespace and raises `ValueError` if empty *before* standard Pydantic constraints apply, seamlessly merging field constraints. The `isinstance` check safely handles accidental non-string inputs. 
- λ FP Angle: Replaces repeated imperative class methods (`@field_validator`) with a declarative, composable type definition (`DisplayNameField`) that can be safely imported and used across schemas.
- ✅ Verification: Ran `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest` ensuring no behavior regressions. 
- 🧪 Edge cases: Fixed a latent edge-case bug where `max_length` validation was occurring before trimming due to Pydantic v2's default `mode='after'` on `@field_validator`. `BeforeValidator` properly resolves this.
- ⚠️ Risk: Very low. This preserves exactly the intended behavior but enforces it earlier in the Pydantic lifecycle and safely handles non-string type inputs by passing them to Pydantic's core engine instead of raising `AttributeError`.

---
*PR created automatically by Jules for task [14757809344843046890](https://jules.google.com/task/14757809344843046890) started by @ToolchainLab*