### PR TITLE
∴ Vector: Centralize display name validation into an Annotated type

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -4,27 +4,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from typing import Annotated, Any
+
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
@@ -18,6 +20,19 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def _validate_display_name_type(v: Any) -> Any:
+    if isinstance(v, str):
+        v = v.strip()
+        if not v:
+            raise ValueError("Display name must not be empty")
+    return v
+
+
+DisplayName = Annotated[
+    str, BeforeValidator(_validate_display_name_type), Field(max_length=DISPLAY_NAME_MAX_LENGTH)
+]
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict | None = Field(
         None,
@@ -29,19 +44,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted duplicated display name validation logic (`@field_validator` checking for empty-after-strip strings) from `RegisterRequest` and `PasskeyRegisterStartRequest` into a shared, centralized `DisplayName` type using Pydantic's `typing.Annotated` and `BeforeValidator`.
- 🎯 Why: To reduce boilerplate code, ensure consistent error messaging, and enforce identical normalization across all schemas that use a display name.
- 🧠 Design: Pydantic V2's `BeforeValidator` within an `Annotated` block is the smallest and safest way to encapsulate field normalization and constraints. By combining it with the `Field(max_length=...)` limitation, it serves as a declarative single source of truth without requiring any changes to the endpoints.
- λ FP Angle: Replaces scattered object-mutation decorators (`@field_validator`) with a declarative, pure, composable type alias. The normalization pipeline is applied transparently when constructing the data structure.
- ✅ Verification: Ran the mandatory backend CI quality gates (format, check, mypy, pytest) and ran the `e2e` suite in `create-h4ckath0n/templates/fullstack/web` successfully.
- 🧪 Edge cases: `BeforeValidator` explicitly checks `if isinstance(v, str):` to prevent stripping non-string types too early in the coercion pipeline. Empty and whitespace-only display names are still caught exactly as before.
- ⚠️ Risk: Very low. It strictly maps the same logic from the removed validators into a single type.

`pytest` coverage remains robust over the changes.

---
*PR created automatically by Jules for task [15523188022348591708](https://jules.google.com/task/15523188022348591708) started by @ToolchainLab*