### PR TITLE
⚡ Bolt: Convert O(N) table count to O(1) emptiness check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-24 - Avoid O(N) Table Scans for Emptiness Checks
+
+**Learning:** When checking if a table is empty (e.g., verifying if the first user is registering), using `await db.execute(select(func.count()).select_from(Model))` triggers a full table or index scan, which is an O(N) operation.
+**Action:** Use `await db.scalar(select(Model.id).limit(1))` and check for `None` to convert the emptiness check into an O(1) operation.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -40,9 +40,10 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Use limit(1) to avoid an O(N) full table scan when checking
+        # if the table is empty.
+        first_user = await db.scalar(select(User.id).limit(1))
+        if first_user is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: Replaced `func.count()` with `limit(1)` for table emptiness check.
🎯 Why: Using `func.count()` requires a full table or index scan, which becomes slower as the table grows. `limit(1)` is an O(1) operation.
📊 Impact: Changes O(N) to O(1) database operation when determining if a new user should be bootstrapped as an admin.
🔬 Measurement: Can be verified by observing database execution plans. `EXPLAIN` will show a `Limit` operation rather than `Aggregate`.

---
*PR created automatically by Jules for task [7666078687709853862](https://jules.google.com/task/7666078687709853862) started by @ToolchainLab*