### PR TITLE
🎨 Palette: Add accessible loading states to Button component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-17 - Bind loading to aria-busy and hide spinner from screen readers
+ **Learning:** In React UI components with loading states, explicitly binding the loading prop (e.g., `isLoading`) to the `aria-busy` attribute on the interactive element and applying `aria-hidden="true"` to any inner decorative spinner icons ensures screen readers properly announce the loading context without reading out decorative elements.
+ **Action:** Apply this pattern to all interactive elements with a loading state, like the `<Button />` component.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
@@ -49,6 +49,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={isLoading || disabled}
+        aria-busy={isLoading}
         className={cn(
           "inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
           variants[variant],
@@ -57,7 +58,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         {...props}
       >
-        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {isLoading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
         {children}
       </button>
     );

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ForgotPassword.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ForgotPassword.tsx
@@ -13,7 +13,7 @@ import {
 import { Alert } from "../components/Alert";
 import { publicFetch } from "../auth/api";
 import type { components } from "../api/openapi";
-import { Loader2 } from "lucide-react";
+
 
 type PasswordResetRequestBody =
   components["schemas"]["PasswordResetRequestSchema"];
@@ -100,12 +100,11 @@ export function ForgotPassword() {
               <Button
                 type="submit"
                 disabled={isLoading || !email.trim()}
+                isLoading={isLoading}
                 className="w-full"
                 data-testid="forgot-submit"
               >
-                {isLoading && (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                )}
+
                 Send Reset Link
               </Button>
             </form>

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Login.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Login.tsx
@@ -13,7 +13,7 @@ import {
   CardFooter,
 } from "../components/Card";
 import { Alert } from "../components/Alert";
-import { Fingerprint, Loader2 } from "lucide-react";
+import { Fingerprint } from "lucide-react";
 
 export function Login() {
   const [email, setEmail] = useState("");
@@ -75,15 +75,12 @@ export function Login() {
           <Button
             onClick={handlePasskeyLogin}
             disabled={isLoading}
+            isLoading={passkeyLoading}
             className="w-full h-12 text-base font-semibold"
             size="lg"
             data-testid="login-submit"
           >
-            {passkeyLoading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Fingerprint className="mr-2 h-5 w-5" />
-            )}
+            {!passkeyLoading && <Fingerprint className="mr-2 h-5 w-5" />}
             Sign in with Passkey
           </Button>
 
@@ -140,12 +137,11 @@ export function Login() {
               type="submit"
               variant="secondary"
               disabled={isLoading || !email.trim() || !password}
+              isLoading={passwordLoading}
               className="w-full"
               data-testid="login-password-btn"
             >
-              {passwordLoading && (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              )}
+
               Sign In
             </Button>
           </form>

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.tsx
@@ -13,7 +13,7 @@ import {
   CardFooter,
 } from "../components/Card";
 import { Alert } from "../components/Alert";
-import { Fingerprint, Loader2 } from "lucide-react";
+import { Fingerprint } from "lucide-react";
 
 const DISPLAY_NAME_MAX_LENGTH = 200;
 
@@ -98,15 +98,12 @@ export function Register() {
             <Button
               onClick={handlePasskeyRegister}
               disabled={isLoading || !displayName.trim()}
+              isLoading={passkeyLoading}
               className="w-full h-12 text-base font-semibold"
               size="lg"
               data-testid="register-submit"
             >
-              {passkeyLoading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Fingerprint className="mr-2 h-5 w-5" />
-              )}
+              {!passkeyLoading && <Fingerprint className="mr-2 h-5 w-5" />}
               Register with Passkey
             </Button>
           </div>
@@ -153,12 +150,11 @@ export function Register() {
                 !email.trim() ||
                 !password
               }
+              isLoading={passwordLoading}
               className="w-full"
               data-testid="register-password-btn"
             >
-              {passwordLoading && (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              )}
+
               Sign Up
             </Button>
           </form>

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ResetPassword.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ResetPassword.tsx
@@ -13,7 +13,7 @@ import {
 import { Alert } from "../components/Alert";
 import { publicFetch } from "../auth/api";
 import type { components } from "../api/openapi";
-import { Loader2 } from "lucide-react";
+
 
 type PasswordResetConfirmBody =
   components["schemas"]["PasswordResetConfirmSchema"];
@@ -134,12 +134,11 @@ export function ResetPassword() {
               <Button
                 type="submit"
                 disabled={isLoading || !newPassword}
+                isLoading={isLoading}
                 className="w-full"
                 data-testid="reset-submit"
               >
-                {isLoading && (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                )}
+
                 Reset Password
               </Button>
             </form>

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -332,13 +332,10 @@ export function Settings() {
           <Button
             onClick={handleAddPasskey}
             disabled={addLoading}
+            isLoading={addLoading}
             data-testid="add-passkey-btn"
           >
-            {addLoading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Plus className="mr-2 h-4 w-4" />
-            )}
+            {!addLoading && <Plus className="mr-2 h-4 w-4" />}
             Add Passkey
           </Button>
         </CardHeader>


### PR DESCRIPTION
💡 What: Bound the `isLoading` prop to the `aria-busy` attribute on the root button and added `aria-hidden="true"` to the inner loading spinner in the `Button` component. Also refactored the Login, Register, ForgotPassword, ResetPassword, and Settings pages to leverage this built-in prop instead of manually rendering their own `Loader2` spinners.

🎯 Why: This ensures screen readers correctly announce when the button is in a loading state without reading out the decorative loading spinner icon. Refactoring the pages to use the built-in prop centralizes this accessibility fix and reduces boilerplate.

📸 Before/After: Visuals remain unchanged, but the DOM now has proper ARIA attributes during loading states.

♿ Accessibility: Improved screen reader support for loading state in buttons, preventing them from reading out decorative elements and correctly announcing the busy state.

---
*PR created automatically by Jules for task [9832800394060074478](https://jules.google.com/task/9832800394060074478) started by @ToolchainLab*