### PR TITLE
🧭 Atlas: Generate config docs from code and check for drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/check_doc_config.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Avoid hardcoded configuration lists in README
+
+**Learning:** Environment variables and configuration options listed in READMEs frequently drift from the actual code definition (like `pydantic.BaseSettings`). In this repo, many properties were completely undocumented (like SMTP settings). Hardcoded lists are practically guaranteed to drift.
+
+**Action:** Centralize config documentation directly on the code models (e.g. `pydantic.Field(description="...")`), generate the markdown table programmatically, and use HTML markers (`<!-- BEGIN CONFIG TABLE -->`) to inject it into the README. Add a check script hooked into CI to fail if the generated table drifts from the README.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN CONFIG TABLE -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | `empty` | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | `empty` | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -174,7 +175,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | `empty` | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of enqueuing |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend ('local' or 's3') |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend ('file' or 'smtp') |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | `empty` | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | `empty` | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | `empty` | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode constraints |
+<!-- END CONFIG TABLE -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_config.py
+++ b/scripts/check_doc_config.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that all configuration variables are documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_config.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from pydantic_core import PydanticUndefined
+
+from h4ckath0n.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def generate_table() -> str:
+    lines = [
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+    for name, field in Settings.model_fields.items():
+        if name == "openai_api_key":
+            lines.append(f"| `OPENAI_API_KEY` | empty | {field.description or ''} |")
+            lines.append(f"| `H4CKATH0N_OPENAI_API_KEY` | empty | {field.description or ''} |")
+            continue
+
+        var_name = f"H4CKATH0N_{name.upper()}"
+        default = field.default if field.default != "" else "empty"
+        if default == PydanticUndefined and field.default_factory is not None:
+            default = field.default_factory()
+
+        if isinstance(default, bool):
+            default = str(default).lower()
+        if isinstance(default, list) and not default:
+            default = "[]"
+
+        desc = field.description or ""
+        lines.append(f"| `{var_name}` | `{default}` | {desc} |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    readme_text = README.read_text()
+
+    start_marker = "<!-- BEGIN CONFIG TABLE -->"
+    end_marker = "<!-- END CONFIG TABLE -->"
+
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print("❌ Could not find configuration table markers in README.md.")
+        print(f"Ensure the config table is wrapped in {start_marker} and {end_marker}")
+        return 1
+
+    start_idx = readme_text.find(start_marker) + len(start_marker)
+    end_idx = readme_text.find(end_marker)
+
+    current_table = readme_text[start_idx:end_idx].strip()
+    expected_table = generate_table().strip()
+
+    if current_table != expected_table:
+        print("❌ Configuration documentation in README.md is out of sync with Settings.")
+        print("\nExpected table:")
+        print(expected_table)
+        print("\nPlease update the README.md to match the generated table.")
+        return 1
+
+    print("✅ Configuration variables in README.md are up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,75 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field("none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(
+        True, description="Run jobs inline in development instead of enqueuing"
+    )
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field("local", description="Storage backend ('local' or 's3')")
+    storage_dir: str = Field("./.h4ckath0n_storage", description="Directory for local storage")
+    max_upload_bytes: int = Field(50 * 1024 * 1024, description="Max upload size in bytes")
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field("file", description="Email backend ('file' or 'smtp')")
+    email_from: str = Field("noreply@localhost", description="Default sender email address")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = Field("", description="SMTP server hostname")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP username")
+    smtp_password: str = Field("", description="SMTP password")
+    smtp_starttls: bool = Field(True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Use implicit SSL for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode constraints")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 **What:** Migrated all configuration settings in `src/h4ckath0n/config.py` to use `pydantic.Field` with explicit descriptions. Added a new script `scripts/check_doc_config.py` that generates a markdown table directly from the code and verifies it exactly matches the contents of the `README.md` (via HTML comment markers).

🎯 **Why:** The `README.md`'s list of environment variables was hardcoded and significantly out of date (missing all email/SMTP, storage, and redis variables). This guarantees that new configuration variables added to the application will automatically fail CI unless they are properly documented, eliminating this class of documentation drift entirely.

🧪 **Verification:** 
- `uv run scripts/check_doc_config.py` checks the drift locally.
- `uv run --locked ruff check .` and `uv run pytest` pass cleanly.

🔒 **Drift Prevention:** A new CI step in `.github/workflows/ci.yml` runs `uv run --locked scripts/check_doc_config.py`, which will block merging if `README.md` gets out of sync with `Settings`.

🗺️ **Evidence:** 
- `src/h4ckath0n/config.py` is the single source of truth for the config variables.
- `README.md` now cleanly imports its definitions directly from it.

---
*PR created automatically by Jules for task [15972058143543738583](https://jules.google.com/task/15972058143543738583) started by @ToolchainLab*