### PR TITLE
∴ Vector: Centralize scope parsing and serialization logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-06-18 - Centralize scope parsing and serialization logic
+**Learning:** Logic for splitting, stripping, and deduplicating comma-separated string fields like scopes was duplicated across multiple architectural layers (router, dependencies, cli) using slightly different list and set comprehensions. Python string-splitting combined with SQLAlchemy text columns creates edge cases around empty strings that must be handled uniformly.
+**Action:** Extract list-parsing logic into pure helper pipelines that accept a raw string and return a deterministic, deduplicated, ordered list to serve as the single source of truth before any domain or database logic acts on it.

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -17,6 +17,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import User
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
 _bearer = HTTPBearer(
@@ -86,7 +87,7 @@ def require_scopes(*scopes: str) -> Any:
     needed: set[str] = set(filter(None, map(str.strip, scopes)))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
-        user_scopes = filter(None, map(str.strip, user.scopes.split(",")))
+        user_scopes = parse_scopes(user.scopes)
         if missing := needed.difference(user_scopes):
             missing_scopes = ", ".join(missing)
             raise HTTPException(

--- a/src/h4ckath0n/auth/scopes.py
+++ b/src/h4ckath0n/auth/scopes.py
@@ -1,0 +1,16 @@
+"""Helpers for parsing and serializing user scopes."""
+
+from __future__ import annotations
+
+
+def parse_scopes(raw: str) -> list[str]:
+    """Parse a comma-separated scopes string into a deduplicated, ordered list."""
+    if not raw:
+        return []
+    parts = filter(None, map(str.strip, raw.split(",")))
+    return list(dict.fromkeys(parts))
+
+
+def serialize_scopes(scopes: list[str]) -> str:
+    """Serialize a list of scopes into a comma-separated string."""
+    return ",".join(parse_scopes(",".join(scopes)))

--- a/src/h4ckath0n/auth/session_router.py
+++ b/src/h4ckath0n/auth/session_router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from h4ckath0n.auth.dependencies import get_auth_context, require_user
 from h4ckath0n.auth.models import User
 from h4ckath0n.auth.schemas import SessionResponse
+from h4ckath0n.auth.scopes import parse_scopes
 from h4ckath0n.realtime.auth import AuthContext
 
 session_router = APIRouter(prefix="/auth", tags=["auth"])
@@ -22,7 +23,7 @@ async def get_session(
     user: User = require_user(),
     ctx: AuthContext = Depends(get_auth_context),
 ) -> SessionResponse:
-    scopes = [s for s in user.scopes.split(",") if s]
+    scopes = parse_scopes(user.scopes)
     return SessionResponse(
         user_id=user.id,
         device_id=ctx.device_id,

--- a/src/h4ckath0n/cli.py
+++ b/src/h4ckath0n/cli.py
@@ -15,6 +15,7 @@ from typing import Any
 from alembic import command as alembic_command
 from alembic.config import Config
 
+from h4ckath0n.auth.scopes import parse_scopes, serialize_scopes
 from h4ckath0n.db.migrations.runtime import (
     PackagedMigrationsError,
     create_sync_engine,
@@ -126,9 +127,7 @@ def _make_sync_engine(url: str):  # type: ignore[no-untyped-def]
 
 def _normalize_scopes(raw: str) -> str:
     """Normalize a comma-separated scopes string."""
-    parts = filter(None, map(str.strip, raw.split(",")))
-    # de-duplicate preserving order
-    return ",".join(dict.fromkeys(parts))
+    return serialize_scopes(parse_scopes(raw))
 
 
 def _resolve_user(session: Any, args: argparse.Namespace):  # type: ignore[no-untyped-def]
@@ -451,10 +450,10 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = set(s for s in user.scopes.split(",") if s.strip())
+            existing = parse_scopes(user.scopes)
             for scope in args.scope:
-                existing.add(scope.strip())
-            user.scopes = _normalize_scopes(",".join(existing))
+                existing.append(scope.strip())
+            user.scopes = serialize_scopes(existing)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -480,10 +479,10 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
                 _err("user not found")
                 return EXIT_NOT_FOUND
 
-            existing = [s for s in user.scopes.split(",") if s.strip()]
+            existing = parse_scopes(user.scopes)
             to_remove = {s.strip() for s in args.scope}
             remaining = [s for s in existing if s not in to_remove]
-            user.scopes = _normalize_scopes(",".join(remaining))
+            user.scopes = serialize_scopes(remaining)
             session.commit()
             session.refresh(user)
             _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/auth/test_scopes.py
+++ b/tests/auth/test_scopes.py
@@ -1,0 +1,21 @@
+"""Tests for auth scope parsing and serialization."""
+
+from h4ckath0n.auth.scopes import parse_scopes, serialize_scopes
+
+
+def test_parse_scopes_empty():
+    assert parse_scopes("") == []
+    assert parse_scopes("   ") == []
+
+
+def test_parse_scopes_deduplicates_and_orders():
+    assert parse_scopes("admin, demo, admin, test, demo") == ["admin", "demo", "test"]
+
+
+def test_parse_scopes_strips_whitespace():
+    assert parse_scopes("  admin  ,   demo  ") == ["admin", "demo"]
+
+
+def test_serialize_scopes():
+    assert serialize_scopes(["admin", "demo", "admin"]) == "admin,demo"
+    assert serialize_scopes([]) == ""


### PR DESCRIPTION
💡 What: Extracted `parse_scopes` and `serialize_scopes` into a new `h4ckath0n.auth.scopes` module and replaced duplicated comma-separated string parsing across the CLI, dependencies, and session router.
🎯 Why: The logic to split, strip, filter, and deduplicate scopes was duplicated in 4 different files using slightly different list/set comprehension logic. This centralizes the semantics into a single source of truth.
🧠 Design: `parse_scopes` explicitly defines the deduplicated, order-preserving behavior and returns a clean list. The CLI and router now operate on this list before optionally re-serializing.
λ FP Angle: Replaces scattered mutation and ad-hoc string splitting with a pure, reusable transformation pipeline (`parse_scopes` -> operate on list -> `serialize_scopes`).
✅ Verification: Ran full pytest suite, mypy, ruff, and Playwright E2E tests. Added explicit tests for `parse_scopes`.
🧪 Edge cases: Handles empty strings, extra whitespace, and duplicated items identically across all entry points.
⚠️ Risk: Low risk, preserves existing behavior.

---
*PR created automatically by Jules for task [6388406886813227462](https://jules.google.com/task/6388406886813227462) started by @ToolchainLab*