### PR TITLE
⚡ Bolt: O(1) table emptiness check for first user

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2024-05-24 - O(1) Table Emptiness Checks
+**Learning:** Checking for table emptiness using func.count() causes an O(N) full table scan.
+**Action:** Always use db.scalar(select(Model.id).limit(1)) and check for None for an O(1) operation.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -40,9 +40,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Use limit(1) to check if table is empty instead of an O(N) count()
+        first_user_id = await db.scalar(select(User.id).limit(1))
+        if first_user_id is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: Replaced `await db.execute(select(func.count()).select_from(User))` with `await db.scalar(select(User.id).limit(1))` in `_is_bootstrap_admin`.
🎯 Why: Using `func.count()` on a table to check for emptiness causes the database to perform an O(N) full index/table scan. By fetching just the first ID with a limit of 1, the check becomes an O(1) operation.
📊 Impact: Reduces first-user-admin lookup time from O(N) to O(1). This protects against performance degradation during registration as the user table grows.
🔬 Measurement: Verified that database lookups correctly handle empty and non-empty table states by passing all existing tests.

---
*PR created automatically by Jules for task [450262460647886713](https://jules.google.com/task/450262460647886713) started by @ToolchainLab*