### PR TITLE
🧭 Atlas: Replace hand-written env var lists with generated list from config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env
+        run: uv run --locked scripts/check_doc_env.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode features |
+<!-- CONFIG_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env.py
+++ b/scripts/check_doc_env.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that README.md documents all config settings.
+
+Usage:
+    uv run scripts/check_doc_env.py [--update]
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- CONFIG_START -->"
+END_MARKER = "<!-- CONFIG_END -->"
+
+
+def get_default_str(default: Any) -> str:
+    if default == "":
+        return "empty"
+    if default is False:
+        return "`false`"
+    if default is True:
+        return "`true`"
+    if default == []:
+        return "`[]`"
+    return f"`{default}`"
+
+
+def generate_table() -> str:
+    from h4ckath0n.config import Settings
+
+    lines = []
+    lines.append("| Variable | Default | Description |")
+    lines.append("|---|---|---|")
+
+    for name, field_info in Settings.model_fields.items():
+        env_name = f"H4CKATH0N_{name.upper()}"
+        default_str = get_default_str(field_info.default)
+        desc = field_info.description or ""
+
+        if name == "openai_api_key":
+            lines.append(f"| `OPENAI_API_KEY` | {default_str} | {desc} |")
+            lines.append(
+                f"| `H4CKATH0N_OPENAI_API_KEY` | {default_str} "
+                "| Alternate OpenAI API key for the LLM wrapper |"
+            )
+        else:
+            lines.append(f"| `{env_name}` | {default_str} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    update_mode = "--update" in sys.argv
+
+    table_content = generate_table()
+    expected_block = f"{START_MARKER}\n{table_content}\n{END_MARKER}"
+
+    readme_content = README.read_text()
+
+    start_idx = readme_content.find(START_MARKER)
+    end_idx = readme_content.find(END_MARKER)
+
+    if start_idx == -1 or end_idx == -1:
+        print("❌ Could not find CONFIG_START and CONFIG_END markers in README.md")
+        return 1
+
+    current_block = readme_content[start_idx : end_idx + len(END_MARKER)]
+
+    if current_block == expected_block:
+        print("✅ README.md config table is up to date.")
+        return 0
+
+    if update_mode:
+        new_content = (
+            readme_content[:start_idx]
+            + expected_block
+            + readme_content[end_idx + len(END_MARKER) :]
+        )
+        README.write_text(new_content)
+        print("✅ Updated README.md config table.")
+        return 0
+    else:
+        print("❌ README.md config table is out of sync. Run with --update to fix.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,82 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline during development"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: str = Field(default="file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file email backend"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode features")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the manually updated configuration table in README.md with an automated generated table. Added descriptions to the Pydantic variables using `Field()`.
🎯 Why: The hand-written table drifted from the code and lacked 17 settings like Redis, Emails, etc., creating risk.
🧪 Verification: Run `uv run --locked pytest`, and run `uv run python scripts/check_doc_env.py` to assert the README is up-to-date.
🔒 Drift Prevention: Included a `check_doc_env.py` that generates the table from the config loader and verifies it matches what's in README. Added it to the CI workflow.
🗺️ Evidence: Checked against `src/h4ckath0n/config.py`.

---
*PR created automatically by Jules for task [6628385135795585953](https://jules.google.com/task/6628385135795585953) started by @ToolchainLab*