### PR TITLE
🎨 Palette: Add aria-busy and aria-hidden to Button loading state

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
@@ -49,6 +49,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={isLoading || disabled}
+        aria-busy={isLoading}
         className={cn(
           "inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
           variants[variant],
@@ -57,7 +58,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         {...props}
       >
-        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {isLoading && <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />}
         {children}
       </button>
     );


### PR DESCRIPTION
💡 What: Added `aria-busy={isLoading}` to the `<button>` element and `aria-hidden="true"` to the `<Loader2>` icon in `Button.tsx`.
🎯 Why: To ensure screen readers properly announce the loading context of the button, following accessibility guidelines.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: Improved screen reader experience for users with visual impairments by correctly conveying the button's loading state.

---
*PR created automatically by Jules for task [10686786619405414725](https://jules.google.com/task/10686786619405414725) started by @ToolchainLab*