### PR TITLE
🧭 Atlas: Replace hand-written env var lists with generated list from config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check config docs
+        run: uv run --locked scripts/generate_config_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Config docs drift prevention
+**Learning:** Hardcoding config variables in a README markdown table leads to drift as the `Settings` class grows. For this repo, parsing `Settings.model_fields` and using `pydantic.Field` descriptions allows full generation of the config documentation.
+**Action:** Use a script to extract env variables and default settings from `Settings.model_fields` in `src/h4ckath0n/config.py`. Enclose the README config section with HTML comments (`<!-- CONFIG_DOCS_START -->` and `<!-- CONFIG_DOCS_END -->`) and write the parsed content in between, then run this check in CI.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_DOCS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -174,7 +175,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of queueing |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local` or `s3`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode constraints (e.g. read-only capabilities) |
+<!-- CONFIG_DOCS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: generate config env vars in README.md."""
+
+import re
+import sys
+from pathlib import Path
+
+# Add src to sys.path to allow importing h4ckath0n
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from h4ckath0n.config import Settings  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def generate_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for field_name, field_info in Settings.model_fields.items():
+        var_name = f"`H4CKATH0N_{field_name.upper()}`"
+        if field_name == "openai_api_key":
+            var_name = "`OPENAI_API_KEY`"
+
+        default_val = field_info.default
+        if default_val == "":
+            default_val_str = "empty"
+        elif isinstance(default_val, bool):
+            default_val_str = f"`{str(default_val).lower()}`"
+        elif isinstance(default_val, list) and not default_val:
+            default_val_str = "`[]`"
+        elif field_name == "rp_id":
+            default_val_str = "`localhost` in development"
+        elif field_name == "origin":
+            default_val_str = "`http://localhost:8000` in development"
+        else:
+            default_val_str = f"`{default_val}`"
+
+        desc = field_info.description or ""
+        lines.append(f"| {var_name} | {default_val_str} | {desc} |")
+
+        if field_name == "openai_api_key":
+            lines.append(
+                "| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate API key for the LLM wrapper |"
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    readme_text = README.read_text(encoding="utf-8")
+
+    start_marker = "<!-- CONFIG_DOCS_START -->\n"
+    end_marker = "<!-- CONFIG_DOCS_END -->"
+
+    pattern = re.compile(rf"{re.escape(start_marker)}.*?{re.escape(end_marker)}", re.DOTALL)
+    if not pattern.search(readme_text):
+        print("❌ Could not find CONFIG_DOCS markers in README.md")
+        return 1
+
+    new_table = generate_table()
+    replacement = f"{start_marker}{new_table}{end_marker}"
+    new_readme = pattern.sub(replacement, readme_text)
+
+    if readme_text == new_readme:
+        print("✅ README.md config documentation is up to date.")
+        return 0
+
+    if check_only:
+        print(
+            "❌ README.md config documentation is out of date. "
+            "Run `uv run scripts/generate_config_docs.py` to update."
+        )
+        return 1
+
+    README.write_text(new_readme, encoding="utf-8")
+    print("✅ Updated README.md config documentation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,54 +19,84 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: str = "preferred"
-    attestation: str = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: str = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: str = Field(default="none", description="WebAuthn attestation preference")
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[], description="JSON list of emails that become admin on password signup"
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline in development instead of queueing"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: str = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: str = Field(default="local", description="Storage backend (`local` or `s3`)")
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: str = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL for email links"
+    )
+    email_backend: str = Field(default="file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file email backend"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP connections")
+    smtp_ssl: bool = Field(default=False, description="Use SSL for SMTP connections")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(
+        default=False, description="Enable demo mode constraints (e.g. read-only capabilities)"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
* 💡 What: Replaces the hand-written configuration table in README.md with an automatically generated table from `h4ckath0n.config.Settings`.
* 🎯 Why: Fixes config drift. The current README misses 17 environment variables (e.g., Redis, Storage, Email config). Generating from Pydantic `Field` prevents this from recurring.
* 🧪 Verification: Run `uv run scripts/generate_config_docs.py --check` locally.
* 🔒 Drift Prevention: Added `generate_config_docs.py` which fails in CI if the README.md table is out-of-date compared to `src/h4ckath0n/config.py`. Added a step in `ci.yml`.
* 🗺️ Evidence: `src/h4ckath0n/config.py` using `pydantic-settings` as the source of truth.

---
*PR created automatically by Jules for task [13922471161259043134](https://jules.google.com/task/13922471161259043134) started by @ToolchainLab*