### PR TITLE
⚡ Bolt: Optimize SQLAlchemy single object queries to avoid intermediate Result hydration overhead

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -211,13 +211,14 @@ async def finish_authentication(
     flow = await _get_valid_flow(db, flow_id, "authenticate")
 
     raw_id = credential_json.get("rawId") or credential_json.get("id", "")
-    result = await db.execute(
+    # ⚡ Bolt: Prefer db.scalar(...) over intermediate Result object hydration
+    stored = await db.scalar(
         select(WebAuthnCredential).filter(
             WebAuthnCredential.credential_id == raw_id,
             WebAuthnCredential.revoked_at.is_(None),
         )
     )
-    if (stored := result.scalars().first()) is None:
+    if stored is None:
         raise ValueError("Unknown or revoked credential")
 
     challenge_bytes = base64url_to_bytes(flow.challenge)
@@ -358,13 +359,14 @@ async def rename_passkey(
     Raises :class:`PasskeyNotFoundError` if not found / not owned and
     :class:`PasskeyRevokedError` if the credential is revoked.
     """
-    result = await db.execute(
+    # ⚡ Bolt: Prefer db.scalar(...) over intermediate Result object hydration
+    cred = await db.scalar(
         select(WebAuthnCredential).filter(
             WebAuthnCredential.id == key_id,
             WebAuthnCredential.user_id == user.id,
         )
     )
-    if (cred := result.scalars().first()) is None:
+    if cred is None:
         raise PasskeyNotFoundError
     if cred.revoked_at is not None:
         raise PasskeyRevokedError
@@ -395,13 +397,14 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
+        # ⚡ Bolt: Prefer db.scalar(...) over intermediate Result object hydration
+        cred = await db.scalar(
             select(WebAuthnCredential).filter(
                 WebAuthnCredential.id == key_id,
                 WebAuthnCredential.user_id == user.id,
             )
         )
-        if (cred := result.scalars().first()) is None:
+        if cred is None:
             raise PasskeyNotFoundError
         if cred.revoked_at is not None:
             raise PasskeyAlreadyRevokedError

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Fetch only the ID for existence check and avoid Result overhead
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(
@@ -75,8 +75,8 @@ async def register_user(
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Prefer db.scalar(...) over intermediate Result object hydration
+    if (user := await db.scalar(select(User).filter(User.email == email))) is None:
         return None
     if not user.password_hash:
         return None
@@ -159,13 +159,14 @@ async def confirm_password_reset(db: AsyncSession, raw_token: str, new_password:
     """Confirm a password reset and return the user."""
     hash_password, _verify = _require_password_extra()
     hashed = _hash_token(raw_token)
-    prt_result = await db.execute(
+    # ⚡ Bolt: Prefer db.scalar(...) over intermediate Result object hydration
+    prt = await db.scalar(
         select(PasswordResetToken).filter(
             PasswordResetToken.token_hash == hashed,
             PasswordResetToken.used.is_(False),
         )
     )
-    if (prt := prt_result.scalars().first()) is None:
+    if prt is None:
         raise ValueError("Invalid or already-used reset token")
     if prt.expires_at.replace(tzinfo=UTC) < datetime.now(UTC):
         raise ValueError("Reset token expired")

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -169,7 +169,8 @@ def _resolve_user(session: Session, args: argparse.Namespace) -> User | None:
     else:
         stmt = select(User).where(User.email == email)
 
-    return session.execute(stmt).scalars().first()
+    # ⚡ Bolt: Prefer session.scalar(...) over intermediate Result object hydration
+    return session.scalar(stmt)
 
 
 def _user_or_exit(session: Session, args: argparse.Namespace) -> tuple[User | None, int | None]:


### PR DESCRIPTION
💡 What: Replaced occurrences of `execute(...).scalars().first()` with direct `scalar(...)` executions across authentication endpoints and CLI commands. Also optimized `register_user` to fetch only the ID instead of the full ORM object for existence checks.
🎯 Why: Retrieving a single model instance or an identifier using `.scalars().first()` forces SQLAlchemy to parse and hydrate the full intermediate Result and ORM objects, causing unnecessary overhead for simple single-row or existence checks. Using `scalar(...)` is functionally identical but avoids this overhead.
📊 Impact: Reduces memory allocation and parsing CPU overhead in hot path authentication queries and single-user lookups.
🔬 Measurement: Verify tests run smoothly without regression (`uv run pytest`), and that the updated logic executes natively faster due to fewer intermediate structures generated by SQLAlchemy.

---
*PR created automatically by Jules for task [1272042554809501856](https://jules.google.com/task/1272042554809501856) started by @ToolchainLab*