### PR TITLE
🎨 Palette: Add accessible loading states to Button component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-21 - Accessible Loading States in Interactive Elements
+**Learning:** When creating reusable UI components like Button that support loading states, simply disabling the button and showing a spinner is insufficient for screen readers.
+**Action:** Always bind the loading prop to aria-busy on the interactive element and add aria-hidden="true" to the spinner icon to ensure the loading context is announced properly while hiding decorative elements.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
@@ -49,6 +49,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={isLoading || disabled}
+        aria-busy={isLoading ? "true" : undefined}
         className={cn(
           "inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
           variants[variant],
@@ -57,7 +58,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         {...props}
       >
-        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {isLoading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
         {children}
       </button>
     );


### PR DESCRIPTION
💡 What: Added `aria-busy={isLoading ? "true" : undefined}` to the `<button>` element and `aria-hidden="true"` to the inner loading spinner (`Loader2`).
🎯 Why: To ensure screen readers properly announce the loading context of the button and to hide the decorative loading spinner from assistive technologies, improving overall accessibility during asynchronous operations.
📸 Before/After: Visual presentation remains identical. DOM structure now includes accessible attributes during the loading state.
♿ Accessibility: Improves experience for screen reader users by properly conveying the interactive element's busy state.

---
*PR created automatically by Jules for task [11975122963640233489](https://jules.google.com/task/11975122963640233489) started by @ToolchainLab*