### PR TITLE
🧭 Atlas: Replace static config table with generated table from Pydantic Settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: |
+          uv run --locked scripts/generate_config_docs.py
+          git diff --exit-code README.md || {
+            echo "::error::Generated configuration docs are out of date. Run 'uv run python scripts/generate_config_docs.py' and commit the changes."
+            exit 1
+          }
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production. Defaults to `localhost` in development |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production. Defaults to `http://localhost:8000` in development |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY` or `H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development instead of enqueuing to Redis |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Backend for file storage |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory path for local file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email delivery backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to store emails when using `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
+<!-- CONFIG_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_config.py
+++ b/scripts/check_doc_config.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every config variable is documented."""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings():
+    from h4ckath0n.config import Settings
+
+    return Settings.model_fields.keys()
+
+
+def check_settings_in_readme(settings):
+    readme_text = README.read_text()
+    missing = []
+    for setting in settings:
+        env_var = f"H4CKATH0N_{setting.upper()}"
+        if setting == "openai_api_key":
+            if not re.search(r"`OPENAI_API_KEY`", readme_text) and not re.search(
+                r"`H4CKATH0N_OPENAI_API_KEY`", readme_text
+            ):
+                missing.append(env_var)
+            continue
+
+        if not re.search(rf"`{env_var}`", readme_text):
+            missing.append(env_var)
+
+    return missing
+
+
+if __name__ == "__main__":
+    settings = get_settings()
+    missing = check_settings_in_readme(settings)
+    if missing:
+        print("❌ The following config variables are NOT documented in README.md:\n")
+        for m in missing:
+            print(f"  {m}")
+        sys.exit(1)
+    print("✅ All config variables are documented in README.md.")
+    sys.exit(0)

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script: generate configuration docs from Settings."""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def generate_markdown_table() -> str:
+    from pydantic_core import PydanticUndefined
+
+    from h4ckath0n.config import Settings
+
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for name, field in Settings.model_fields.items():
+        if name == "openai_api_key":
+            env_var = "`OPENAI_API_KEY` or `H4CKATH0N_OPENAI_API_KEY`"
+        else:
+            env_var = f"`H4CKATH0N_{name.upper()}`"
+
+        default_val = field.default
+        if default_val is None or default_val == "":
+            default_str = "empty"
+        elif default_val is PydanticUndefined:
+            default_factory = getattr(field, "default_factory", None)
+            default_str = f"`{default_factory()}`" if default_factory is not None else "required"
+        else:
+            # Format booleans as lowercase string `true` / `false` or list as `[]` etc.
+            if isinstance(default_val, bool):
+                default_str = f"`{str(default_val).lower()}`"
+            else:
+                default_str = f"`{default_val}`"
+
+        description = field.description or ""
+
+        lines.append(f"| {env_var} | {default_str} | {description} |")
+
+    return "\n".join(lines)
+
+
+def update_readme(table_content: str) -> bool:
+    content = README.read_text()
+
+    start_marker = "<!-- CONFIG_START -->"
+    end_marker = "<!-- CONFIG_END -->"
+
+    pattern = re.compile(rf"{re.escape(start_marker)}.*?{re.escape(end_marker)}", re.DOTALL)
+
+    if not pattern.search(content):
+        print("❌ Could not find configuration markers in README.md.", file=sys.stderr)
+        sys.exit(1)
+
+    new_block = f"{start_marker}\n{table_content}\n{end_marker}"
+    new_content = pattern.sub(new_block, content)
+
+    if content == new_content:
+        return False
+
+    README.write_text(new_content)
+    return True
+
+
+if __name__ == "__main__":
+    table = generate_markdown_table()
+    changed = update_readme(table)
+    if changed:
+        print("✅ README.md configuration table updated.")
+    else:
+        print("✅ README.md configuration table is already up to date.")

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 UserVerification = Literal["required", "preferred", "discouraged"]
@@ -24,54 +25,102 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: UserVerification = "preferred"
-    attestation: AttestationConveyance = "none"
+    rp_id: str = Field(
+        default="",
+        description=(
+            "WebAuthn relying party ID, required in production. "
+            "Defaults to `localhost` in development"
+        ),
+    )
+    origin: str = Field(
+        default="",
+        description=(
+            "WebAuthn origin, required in production. "
+            "Defaults to `http://localhost:8000` in development"
+        ),
+    )
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: UserVerification = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: AttestationConveyance = Field(
+        default="none", description="WebAuthn attestation preference"
+    )
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline in development instead of enqueuing to Redis"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: StorageBackend = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: StorageBackend = Field(
+        default="local", description="Backend for file storage"
+    )
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory path for local file storage"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum file upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: EmailBackend = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: EmailBackend = Field(
+        default="file", description="Email delivery backend (`file` or `smtp`)"
+    )
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for outgoing emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox",
+        description="Directory to store emails when using `file` backend",
+    )
+    smtp_host: str = Field(default="", description="SMTP server hostname")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP connection")
+    smtp_ssl: bool = Field(default=False, description="Use SSL/TLS for SMTP connection")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 **What**: Replaces the hand-written, drift-prone Configuration table in `README.md` with an automatically generated markdown table populated directly from the Pydantic `Settings` model fields.

🎯 **Why**: The existing static table missed numerous configuration variables (like Redis, Email, Storage, and Demo settings). By generating this documentation directly from `src/h4ckath0n/config.py`, we reduce "time-to-understanding" for new contributors and completely eliminate documentation drift for environment variables.

🧪 **Verification**: 
Run locally:
```bash
uv run python scripts/generate_config_docs.py
```

🔒 **Drift Prevention**: Added a dedicated check in `.github/workflows/ci.yml` that runs the generator script and fails the build with an error if `README.md` changes were not committed alongside `config.py` updates.

🗺️ **Evidence**:
- `src/h4ckath0n/config.py` (authoritative source of settings)
- `scripts/generate_config_docs.py` (new generator logic)
- `.github/workflows/ci.yml` (automated enforcement check)

---
*PR created automatically by Jules for task [6733582803488101097](https://jules.google.com/task/6733582803488101097) started by @ToolchainLab*