### PR TITLE
∷ Vector: Centralize display name validation using Pydantic BeforeValidator

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -5,27 +5,19 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
@@ -20,6 +20,17 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def _clean_display_name_validator(v: Any) -> Any:
+    if isinstance(v, str):
+        v = v.strip()
+        if not v:
+            raise ValueError("Display name must not be empty")
+    return v
+
+
+DisplayName = Annotated[str, BeforeValidator(_clean_display_name_validator)]
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -31,19 +42,11 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What: Replaced duplicated `@field_validator` methods for `display_name` across auth schemas with a centralized `DisplayName` type alias using Pydantic's `Annotated` and `BeforeValidator`.
🎯 Why: Removes duplicated validation logic, ensuring a single source of truth for display name normalization (whitespace trimming and empty string rejection). This aligns with functional programming principles by creating a composable, declarative type.
🧠 Design: Using `BeforeValidator` guarantees normalization happens before Pydantic's built-in `max_length` constraint is evaluated. The validator explicitly checks for `isinstance(v, str)` to prevent type errors on bad input.
λ FP Angle: Replaces scattered mutative validation methods on class definitions with a single declarative, pure transformation pipeline bound directly to the type system.
✅ Verification: Ran `uv run pytest`, `uv run --locked ruff check`, and `uv run --locked mypy src`. All tests and quality gates passed.
🧪 Edge cases: `BeforeValidator` explicitly handles non-string inputs safely by only stripping/validating strings, letting standard Pydantic logic handle type coercion and rejection.
⚠️ Risk: Low. Behavior is strictly preserved; only the location of the validation logic changed.

---
*PR created automatically by Jules for task [10503673658605619933](https://jules.google.com/task/10503673658605619933) started by @ToolchainLab*