### PR TITLE
🎨 Palette: Add aria-busy and aria-hidden for Button loading state

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
@@ -49,6 +49,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={isLoading || disabled}
+        aria-busy={isLoading}
         className={cn(
           "inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
           variants[variant],
@@ -57,7 +58,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         {...props}
       >
-        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {isLoading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
         {children}
       </button>
     );


### PR DESCRIPTION
💡 **What**: Added `aria-busy={isLoading}` to the `<button>` element and `aria-hidden="true"` to the inner `Loader2` spinner component in `Button.tsx`.

🎯 **Why**: When a button is in a loading state, screen readers need to be explicitly informed that the element is busy processing an action. Without `aria-busy`, the loading state is purely visual. Additionally, the spinner icon itself is decorative and redundant when `aria-busy` is present, so hiding it prevents screen readers from unnecessarily announcing "loader" or similar strings.

📸 **Before/After**: 
*   **Before**: `<button disabled> <svg class="animate-spin" /> Submit </button>` (Visually loading, but semantically just disabled. Screen readers might announce the SVG).
*   **After**: `<button disabled aria-busy="true"> <svg class="animate-spin" aria-hidden="true" /> Submit </button>` (Semantically busy, SVG properly hidden from AT).

♿ **Accessibility**: Greatly improves the screen reader experience by accurately conveying the transient "processing" state without cluttering the announcement stream with decorative icon labels.

---
*PR created automatically by Jules for task [7694115118032075998](https://jules.google.com/task/7694115118032075998) started by @ToolchainLab*