### PR TITLE
∷ Vector: Refactor display name validation into centralized Annotated type

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -5,27 +5,18 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,12 +2,28 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
+
+
+def _normalize_display_name(v: Any) -> Any:
+    """Trim whitespace and reject empty display names before length validation."""
+    if isinstance(v, str):
+        v = v.strip()
+        if not v:
+            raise ValueError("Display name must not be empty")
+    return v
+
+
+DisplayName = Annotated[
+    str,
+    BeforeValidator(_normalize_display_name),
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH),
+]
 
 
 def _validate_display_name(v: str | None) -> str | None:
@@ -31,19 +47,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted the `_clean_display_name` validation logic (stripping whitespace and ensuring non-empty) from `RegisterRequest` and `PasskeyRegisterStartRequest` into a centralized, reusable `DisplayName` Pydantic type using `Annotated` and `BeforeValidator`.
- 🎯 Why: This normalization logic was duplicated across two different schema files, increasing the risk of drift.
- 🧠 Design: Pydantic v2 `Annotated` types are the most idiomatic way to handle reusable field normalization. Using `BeforeValidator` instead of the default `field_validator` ensures that string stripping occurs *before* Pydantic's core `max_length` check is applied, preventing edge cases where a trailing space pushes a valid name over the length limit.
- λ FP Angle: This replaces scattered mutation/validation blocks attached to specific data classes with a single, centralized, pure transformation pipeline that enforces the type invariants.
- ✅ Verification: Executed `uv run --locked ruff format .`, `uv run --locked ruff check .`, `uv run --locked mypy src`, and `uv run pytest`. All tests passed.
- 🧪 Edge cases: Ensures that type checking inside `BeforeValidator` prevents crashes if a non-string type reaches the validator before Pydantic applies core type coercion. Handled the `BeforeValidator` vs `AfterValidator` evaluation order constraint safely.
- ⚠️ Risk: Very low. The behavior is semantically identical except for resolving a minor boundary edge case in the evaluation order.

---
*PR created automatically by Jules for task [6236217450539314226](https://jules.google.com/task/6236217450539314226) started by @ToolchainLab*