### PR TITLE
⚡ Bolt: Replace full Result hydration with scalar() for single queries

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -211,13 +211,14 @@ async def finish_authentication(
     flow = await _get_valid_flow(db, flow_id, "authenticate")
 
     raw_id = credential_json.get("rawId") or credential_json.get("id", "")
-    result = await db.execute(
+    # ⚡ Bolt: Use scalar() instead of full Result hydration
+    stored = await db.scalar(
         select(WebAuthnCredential).filter(
             WebAuthnCredential.credential_id == raw_id,
             WebAuthnCredential.revoked_at.is_(None),
         )
     )
-    if (stored := result.scalars().first()) is None:
+    if stored is None:
         raise ValueError("Unknown or revoked credential")
 
     challenge_bytes = base64url_to_bytes(flow.challenge)
@@ -358,13 +359,14 @@ async def rename_passkey(
     Raises :class:`PasskeyNotFoundError` if not found / not owned and
     :class:`PasskeyRevokedError` if the credential is revoked.
     """
-    result = await db.execute(
+    # ⚡ Bolt: Use scalar() instead of full Result hydration
+    cred = await db.scalar(
         select(WebAuthnCredential).filter(
             WebAuthnCredential.id == key_id,
             WebAuthnCredential.user_id == user.id,
         )
     )
-    if (cred := result.scalars().first()) is None:
+    if cred is None:
         raise PasskeyNotFoundError
     if cred.revoked_at is not None:
         raise PasskeyRevokedError
@@ -395,13 +397,14 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
+        # ⚡ Bolt: Use scalar() instead of full Result hydration
+        cred = await db.scalar(
             select(WebAuthnCredential).filter(
                 WebAuthnCredential.id == key_id,
                 WebAuthnCredential.user_id == user.id,
             )
         )
-        if (cred := result.scalars().first()) is None:
+        if cred is None:
             raise PasskeyNotFoundError
         if cred.revoked_at is not None:
             raise PasskeyAlreadyRevokedError

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Fetch only the ID to avoid instantiating the full User ORM object.
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(
@@ -75,8 +75,8 @@ async def register_user(
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use scalar() instead of full Result hydration
+    if (user := await db.scalar(select(User).filter(User.email == email))) is None:
         return None
     if not user.password_hash:
         return None
@@ -159,13 +159,14 @@ async def confirm_password_reset(db: AsyncSession, raw_token: str, new_password:
     """Confirm a password reset and return the user."""
     hash_password, _verify = _require_password_extra()
     hashed = _hash_token(raw_token)
-    prt_result = await db.execute(
+    # ⚡ Bolt: Use scalar() instead of full Result hydration
+    prt = await db.scalar(
         select(PasswordResetToken).filter(
             PasswordResetToken.token_hash == hashed,
             PasswordResetToken.used.is_(False),
         )
     )
-    if (prt := prt_result.scalars().first()) is None:
+    if prt is None:
         raise ValueError("Invalid or already-used reset token")
     if prt.expires_at.replace(tzinfo=UTC) < datetime.now(UTC):
         raise ValueError("Reset token expired")

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -169,7 +169,8 @@ def _resolve_user(session: Session, args: argparse.Namespace) -> User | None:
     else:
         stmt = select(User).where(User.email == email)
 
-    return session.execute(stmt).scalars().first()
+    # ⚡ Bolt: Use scalar() instead of full Result hydration
+    return session.scalar(stmt)
 
 
 def _user_or_exit(session: Session, args: argparse.Namespace) -> tuple[User | None, int | None]:


### PR DESCRIPTION
* **💡 What:** Replaced `db.execute(stmt).scalars().first()` with `db.scalar(stmt)` and `select(Model)` with `select(Model.id)` for single entity lookups and existence checks.
* **🎯 Why:** Bypasses intermediate `Result` hydration to eliminate unnecessary overhead, and avoids full ORM model object instantiation when only existence (or an ID) is required.
* **📊 Impact:** Reduces memory allocations and slightly improves query latency for frequent, simple lookups.
* **🔬 Measurement:** Verified with `uv run pytest` to ensure safe, regression-free functionality.

---
*PR created automatically by Jules for task [11845295553332207639](https://jules.google.com/task/11845295553332207639) started by @ToolchainLab*