### PR TITLE
🎨 Palette: [a11y] Add aria-busy and aria-hidden to Button loading state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - [Add aria-busy to loading Button]
+**Learning:** In React UI components with loading states, always bind the loading prop (e.g., isLoading) to the aria-busy attribute on the interactive element and apply aria-hidden="true" to any inner decorative spinner icons. This ensures screen readers properly announce the loading context.
+**Action:** Consistently apply this pattern when adding or modifying loading states across interactive components.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
@@ -49,6 +49,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={isLoading || disabled}
+        aria-busy={isLoading}
         className={cn(
           "inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
           variants[variant],
@@ -57,7 +58,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         {...props}
       >
-        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {isLoading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
         {children}
       </button>
     );


### PR DESCRIPTION
💡 What: Added `aria-busy={isLoading}` to the `<button>` element and `aria-hidden="true"` to the decorative `<Loader2>` spinner in `Button.tsx`.
🎯 Why: Ensures screen readers properly announce the loading context to visually impaired users without reading out confusing decorative graphic elements.
📸 Before/After: Visuals remain unchanged, screen reader behavior improved.
♿ Accessibility: Directly improves keyboard and screen reader accessibility for async operations.

---
*PR created automatically by Jules for task [11551792610583354941](https://jules.google.com/task/11551792610583354941) started by @ToolchainLab*