### PR TITLE
🧭 Atlas: Implement environment variables drift check and fix README parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Configuration environment variables are highly prone to drift
+**Learning:** Hardcoded environment variable lists in READMEs routinely drift out of sync with actual configuration models (like Pydantic `BaseSettings`), leaving users unaware of valid config options.
+**Action:** Implement drift-prevention checks that dynamically parse the application's configuration schema (e.g., `Settings.model_fields`) and verify that every accepted environment variable is explicitly documented.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (e.g., `local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory path |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend app |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based emails |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host for email |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that all environment variables are documented."""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+README = REPO_ROOT / "README.md"
+
+# Fields that we do not require in user docs
+FRAMEWORK_FIELDS = frozenset()
+
+
+def check_env_vars_in_readme() -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+
+    for field_name in Settings.model_fields:
+        if field_name in FRAMEWORK_FIELDS:
+            continue
+
+        env_var = "H4CKATH0N_" + field_name.upper()
+
+        # Look for the exact backticked env var
+        if f"`{env_var}`" not in readme_text:
+            if env_var == "H4CKATH0N_OPENAI_API_KEY" and "`OPENAI_API_KEY`" in readme_text:
+                pass
+            else:
+                missing.append(env_var)
+
+    return missing
+
+
+def main() -> int:
+    missing = check_env_vars_in_readme()
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  {env_var}")
+        print("\nAdd these variables to the Configuration section in README.md.")
+        return 1
+
+    print(
+        f"✅ All {len(Settings.model_fields)} environment variables are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: The exact doc improvement
This PR introduces a drift-prevention check to ensure that all environment variables defined in the application's configuration schema (`Settings`) are explicitly documented in the Configuration table of `README.md`. It also updates `README.md` to add 17 previously missing environment variables (such as Redis and Email configurations).

🎯 Why: The user pain or drift risk it resolves
Hardcoded environment variable lists in READMEs routinely drift out of sync with actual configuration models (like Pydantic `BaseSettings`), leaving users unaware of valid config options. This automation prevents that gap, ensuring that new configuration properties cannot be added to the codebase without corresponding documentation.

🧪 Verification: Commands to validate locally, including the drift check
```bash
uv run scripts/check_doc_env_vars.py
```

🔒 Drift Prevention: What mechanism now prevents regressions
The `scripts/check_doc_env_vars.py` script has been added to `.github/workflows/ci.yml`. It dynamically parses `h4ckath0n.config.Settings.model_fields` and fails the build if any accepted environment variable is missing from `README.md`.

🗺️ Evidence: A short list of repo files that were treated as the source of truth
- `src/h4ckath0n/config.py` (`Settings` class)

---
*PR created automatically by Jules for task [4698682977515506826](https://jules.google.com/task/4698682977515506826) started by @ToolchainLab*