### PR TITLE
∴ Vector: Centralize display name validation using Pydantic Annotated

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -5,27 +5,18 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,22 +2,28 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
-def _validate_display_name(v: str | None) -> str | None:
+def _clean_display_name(v: Any) -> Any:
     """Trim whitespace; reject empty-after-trim values."""
-    if v is None:
-        return None
-    v = v.strip()
-    if v == "":
-        return None
+    if isinstance(v, str):
+        v = v.strip()
+        if not v:
+            raise ValueError("Display name must not be empty")
     return v
+
+
+DisplayName = Annotated[
+    str,
+    BeforeValidator(_clean_display_name),
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH),
+]
 
 
 class DeviceBindingMixin(BaseModel):
@@ -31,19 +37,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 **What**: Extracted `display_name` string validation (trimming and empty-check) from inline `@field_validator` instances across multiple schema files into a centralized `DisplayName` type using Pydantic V2's `Annotated` and `BeforeValidator`.
🎯 **Why**: To DRY up Pydantic validation schemas. The `display_name` trimming logic was duplicated between `RegisterRequest` and `PasskeyRegisterStartRequest`. An unused `_validate_display_name` existed but silently swallowed empty values (returned `None`) whereas the endpoint actually demands raising a `ValueError`.
🧠 **Design**: Replaced the local functions with a single `DisplayName = Annotated[str, BeforeValidator(_clean_display_name), Field(max_length=DISPLAY_NAME_MAX_LENGTH)]`. This enforces trimming and validation prior to standard field length checks.
λ **FP Angle**: Centralizes shared normalization and parsing semantics, moving repeated local transformations into a clear, single source-of-truth helper type.
✅ **Verification**: Run `uv run pytest` which successfully verified all edge cases (too long, empty, whitespace-only). Checked formatting and typing via `ruff` and `mypy`.
🧪 **Edge cases**: Ensured that the `BeforeValidator` correctly checks `isinstance(v, str)` before mutating to prevent type errors on invalid input, and safely passes `max_length` logic downstream.
⚠️ **Risk**: Low. Preserves the exact same endpoint validation behavior while cleaning up schema definitions.

---
*PR created automatically by Jules for task [1650430805996325558](https://jules.google.com/task/1650430805996325558) started by @ToolchainLab*