### PR TITLE
🎨 Palette: Add accessible loading states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Bind loading state to aria-busy in interactive elements]
+ **Learning:** React components (especially buttons and spinners) require explicit `aria-busy` attributes bound to their loading states and `aria-hidden="true"` on internal decorative spinner icons to ensure proper screen reader announcement of the transient UI state.
+ **Action:** When utilizing or implementing interactive elements that reflect async operations, consistently apply `aria-busy={isLoading}` on the host element and `aria-hidden="true"` to decorative loading indicators.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
@@ -49,6 +49,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={isLoading || disabled}
+        aria-busy={isLoading}
         className={cn(
           "inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
           variants[variant],
@@ -57,7 +58,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         {...props}
       >
-        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {isLoading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
         {children}
       </button>
     );

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ForgotPassword.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ForgotPassword.tsx
@@ -13,7 +13,6 @@ import {
 import { Alert } from "../components/Alert";
 import { publicFetch } from "../auth/api";
 import type { components } from "../api/openapi";
-import { Loader2 } from "lucide-react";
 
 type PasswordResetRequestBody =
   components["schemas"]["PasswordResetRequestSchema"];
@@ -100,12 +99,10 @@ export function ForgotPassword() {
               <Button
                 type="submit"
                 disabled={isLoading || !email.trim()}
+                isLoading={isLoading}
                 className="w-full"
                 data-testid="forgot-submit"
               >
-                {isLoading && (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                )}
                 Send Reset Link
               </Button>
             </form>

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Login.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Login.tsx
@@ -13,7 +13,7 @@ import {
   CardFooter,
 } from "../components/Card";
 import { Alert } from "../components/Alert";
-import { Fingerprint, Loader2 } from "lucide-react";
+import { Fingerprint } from "lucide-react";
 
 export function Login() {
   const [email, setEmail] = useState("");
@@ -75,15 +75,12 @@ export function Login() {
           <Button
             onClick={handlePasskeyLogin}
             disabled={isLoading}
+            isLoading={passkeyLoading}
             className="w-full h-12 text-base font-semibold"
             size="lg"
             data-testid="login-submit"
           >
-            {passkeyLoading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Fingerprint className="mr-2 h-5 w-5" />
-            )}
+            {!passkeyLoading && <Fingerprint className="mr-2 h-5 w-5" />}
             Sign in with Passkey
           </Button>
 
@@ -140,12 +137,10 @@ export function Login() {
               type="submit"
               variant="secondary"
               disabled={isLoading || !email.trim() || !password}
+              isLoading={passwordLoading}
               className="w-full"
               data-testid="login-password-btn"
             >
-              {passwordLoading && (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              )}
               Sign In
             </Button>
           </form>

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.tsx
@@ -13,7 +13,7 @@ import {
   CardFooter,
 } from "../components/Card";
 import { Alert } from "../components/Alert";
-import { Fingerprint, Loader2 } from "lucide-react";
+import { Fingerprint } from "lucide-react";
 
 const DISPLAY_NAME_MAX_LENGTH = 200;
 
@@ -98,15 +98,12 @@ export function Register() {
             <Button
               onClick={handlePasskeyRegister}
               disabled={isLoading || !displayName.trim()}
+              isLoading={passkeyLoading}
               className="w-full h-12 text-base font-semibold"
               size="lg"
               data-testid="register-submit"
             >
-              {passkeyLoading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Fingerprint className="mr-2 h-5 w-5" />
-              )}
+              {!passkeyLoading && <Fingerprint className="mr-2 h-5 w-5" />}
               Register with Passkey
             </Button>
           </div>
@@ -153,12 +150,10 @@ export function Register() {
                 !email.trim() ||
                 !password
               }
+              isLoading={passwordLoading}
               className="w-full"
               data-testid="register-password-btn"
             >
-              {passwordLoading && (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              )}
               Sign Up
             </Button>
           </form>

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ResetPassword.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/ResetPassword.tsx
@@ -13,7 +13,6 @@ import {
 import { Alert } from "../components/Alert";
 import { publicFetch } from "../auth/api";
 import type { components } from "../api/openapi";
-import { Loader2 } from "lucide-react";
 
 type PasswordResetConfirmBody =
   components["schemas"]["PasswordResetConfirmSchema"];
@@ -134,12 +133,10 @@ export function ResetPassword() {
               <Button
                 type="submit"
                 disabled={isLoading || !newPassword}
+                isLoading={isLoading}
                 className="w-full"
                 data-testid="reset-submit"
               >
-                {isLoading && (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                )}
                 Reset Password
               </Button>
             </form>

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -332,20 +332,17 @@ export function Settings() {
           <Button
             onClick={handleAddPasskey}
             disabled={addLoading}
+            isLoading={addLoading}
             data-testid="add-passkey-btn"
           >
-            {addLoading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Plus className="mr-2 h-4 w-4" />
-            )}
+            {!addLoading && <Plus className="mr-2 h-4 w-4" />}
             Add Passkey
           </Button>
         </CardHeader>
         <CardContent>
           {isLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            <div className="flex justify-center py-8" aria-busy="true">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
             </div>
           ) : passkeys && passkeys.length > 0 ? (
             <div className="space-y-4">


### PR DESCRIPTION
💡 What: Added `aria-busy` to the Button component and `aria-hidden` to loading spinners, while centralizing loading state handling across auth pages.
🎯 Why: Ensures screen readers properly announce loading contexts and ignore decorative loading icons.
📸 Before/After: Visuals unchanged.
♿ Accessibility: Explicit ARIA roles map the loading visual feedback for AT.

---
*PR created automatically by Jules for task [379722617535880039](https://jules.google.com/task/379722617535880039) started by @ToolchainLab*