### PR TITLE
🎨 Palette: Add aria-busy and aria-hidden to Button loading state

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Button.tsx
@@ -49,6 +49,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={isLoading || disabled}
+        aria-busy={isLoading}
         className={cn(
           "inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50",
           variants[variant],
@@ -57,7 +58,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         )}
         {...props}
       >
-        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {isLoading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
         {children}
       </button>
     );


### PR DESCRIPTION
💡 What: Added `aria-busy={isLoading}` to the `Button` component and `aria-hidden="true"` to its loading spinner icon.
🎯 Why: To ensure screen readers properly announce the loading context to users and ignore the purely decorative visual spinner.
📸 Before/After: Visuals are unchanged. Semantic HTML updated.
♿ Accessibility: Improves loading state communication to screen readers in all reusable button instances.

---
*PR created automatically by Jules for task [11017197210624267713](https://jules.google.com/task/11017197210624267713) started by @ToolchainLab*