### PR TITLE
🧭 Atlas: Generate configuration docs from Pydantic Settings to prevent drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check config docs
+        run: uv run --locked scripts/check_config_docs.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-06-25 - Settings documentation drift
+**Learning:** README.md manually duplicates the `H4CKATH0N_` environment variables list from `src/h4ckath0n/config.py` but is missing variables like `H4CKATH0N_DEMO_MODE`, `H4CKATH0N_REDIS_URL`, `H4CKATH0N_STORAGE_DIR`, etc.
+**Action:** Use Pydantic V2 `Field(description="...")` inline and build a drift-prevention script that parses `Settings.model_fields` to automatically generate the markdown table and inject it into README.md between marker tags.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY / H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs synchronously in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend ('local' only currently) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | 'file' or 'smtp' |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode constraints (read-only profiles, etc.) |
+<!-- CONFIG_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_config_docs.py
+++ b/scripts/check_config_docs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that config documentation in README matches Settings."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic_core import PydanticUndefined
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings_table() -> str:
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        env_name = f"H4CKATH0N_{name.upper()}"
+        if name == "openai_api_key":
+            env_name = "OPENAI_API_KEY / H4CKATH0N_OPENAI_API_KEY"
+
+        default_val = getattr(field, "default_factory", None)
+        default_val = field.default if default_val is None else default_val()
+
+        if default_val is PydanticUndefined:
+            default_val = "Required"
+
+        if default_val == "":
+            default_str = "empty"
+        elif isinstance(default_val, bool):
+            default_str = f"`{str(default_val).lower()}`"
+        elif isinstance(default_val, list) and len(default_val) == 0:
+            default_str = "`[]`"
+        else:
+            default_str = f"`{default_val}`"
+
+        desc = field.description or ""
+        lines.append(f"| `{env_name}` | {default_str} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true", help="Update the README.md file")
+    args = parser.parse_args()
+
+    table = get_settings_table()
+    readme_text = README.read_text()
+
+    start_marker = "<!-- CONFIG_START -->"
+    end_marker = "<!-- CONFIG_END -->"
+
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print("❌ Markers not found in README.md")
+        return 1
+
+    start_idx = readme_text.index(start_marker) + len(start_marker)
+    end_idx = readme_text.index(end_marker)
+
+    new_readme = readme_text[:start_idx] + "\n" + table + "\n" + readme_text[end_idx:]
+
+    if args.update:
+        README.write_text(new_readme)
+        print("✅ README.md updated with config documentation.")
+        return 0
+    else:
+        if new_readme != readme_text:
+            print("❌ Configuration documentation in README.md is out of date.")
+            print("Run `uv run scripts/check_config_docs.py --update` to fix.")
+            return 1
+        print("✅ Configuration documentation in README.md is up to date.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 UserVerification = Literal["required", "preferred", "discouraged"]
@@ -24,54 +25,90 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: UserVerification = "preferred"
-    attestation: AttestationConveyance = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: UserVerification = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: AttestationConveyance = Field(
+        default="none", description="WebAuthn attestation preference"
+    )
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs synchronously in development"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: StorageBackend = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: StorageBackend = Field(
+        default="local", description="Storage backend ('local' only currently)"
+    )
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local file storage"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum allowed file upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: EmailBackend = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173",
+        description="Base URL of the frontend application for email links",
+    )
+    email_backend: EmailBackend = Field(default="file", description="'file' or 'smtp'")
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file-based email outbox"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP username")
+    smtp_password: str = Field(default="", description="SMTP password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP")
+    smtp_ssl: bool = Field(default=False, description="Use implicit SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(
+        default=False, description="Enable demo mode constraints (read-only profiles, etc.)"
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: 
Added a drift-prevention check (`scripts/check_config_docs.py`) to generate the environment variables documentation in `README.md` directly from the `Settings` Pydantic model by leveraging `Field(description="...")`.

🎯 Why:
The `README.md` configuration table was hand-maintained and had already drifted from the codebase. Many new configuration keys (like Redis and Storage configurations) were missing from the docs. By moving the documentation into the single source of truth (the Pydantic model) and enforcing parity via a CI script, we eliminate future drift and ambiguity.

🔎 Verification:
Run locally: `uv run scripts/check_config_docs.py` to check for parity, or `uv run scripts/check_config_docs.py --update` to regenerate the markdown table in `README.md`.

🔒 Drift Prevention:
A new CI step in `.github/workflows/ci.yml` runs the check script to fail the build if the README table diverges from the `Settings` class definitions.

🗺️ Evidence:
The source of truth utilized is the `Settings` model in `src/h4ckath0n/config.py`.

---
*PR created automatically by Jules for task [14523892032991844688](https://jules.google.com/task/14523892032991844688) started by @ToolchainLab*