### PR TITLE
∬ Vector: Extract display_name validation to reusable type

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -5,27 +5,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayNameStr
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
-        ...,
-        description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
+    display_name: DisplayNameStr = Field(
+        ..., description="Human-facing display name for the new account."
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,12 +2,30 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
+
+
+def _clean_display_name(v: Any) -> Any:
+    if isinstance(v, str):
+        v = v.strip()
+        if not v:
+            raise ValueError("Display name must not be empty")
+    return v
+
+
+DisplayNameStr = Annotated[
+    str,
+    Field(
+        description="Human-facing display name.",
+        max_length=DISPLAY_NAME_MAX_LENGTH,
+    ),
+    BeforeValidator(_clean_display_name),
+]
 
 
 def _validate_display_name(v: str | None) -> str | None:
@@ -31,19 +49,9 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
-        ...,
-        description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
+    display_name: DisplayNameStr = Field(
+        ..., description="Human-facing display name for the account."
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What: Extracted the duplicated `_clean_display_name` validation logic and `Field` configuration into a shared `DisplayNameStr` Annotated type in `src/h4ckath0n/auth/schemas.py`, and reused it in `src/h4ckath0n/auth/passkeys/schemas.py`.

🎯 Why: The exact same whitespace trimming and empty-string rejection logic for `display_name` was duplicated across multiple Pydantic models. Centralizing this removes the duplication and ensures consistent behavior.

🧠 Design: Uses Pydantic V2's `Annotated` with `BeforeValidator` to apply the normalization before the length constraints. This is the smallest correct cleanup that fully centralizes the semantics.

λ FP Angle: Moves scattered, locally-mutating validation logic (stripping and checking) into a single, pure transformation type that can be composed seamlessly into any schema.

✅ Verification: Ran `uv run --locked ruff format .`, `uv run --locked ruff check .`, `uv run --locked mypy src`, and `uv run pytest`. All checks passed.

🧪 Edge cases: The custom `ValueError("Display name must not be empty")` behavior is precisely maintained, and Pydantic's underlying string constraints remain intact.

⚠️ Risk: Extremely low. The field semantics and validation error messages are identical to before.

---
*PR created automatically by Jules for task [8510078689150838263](https://jules.google.com/task/8510078689150838263) started by @ToolchainLab*