### PR TITLE
🧭 Atlas: Generate config docs from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check config docs
+        run: |
+          uv run --locked scripts/generate_config_docs.py
+          git diff --exit-code README.md || {
+            echo "::error::Generated config docs are out of date. Run 'uv run scripts/generate_config_docs.py' and commit the changes."
+            exit 1
+          }
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-06-26 - Generate config documentation from Pydantic models
+**Learning:** Hard-coded configuration tables in `README.md` drift quickly from the single source of truth in `src/h4ckath0n/config.py` as settings are added or modified.
+**Action:** Use Pydantic V2's `Field(default=..., description="...")` inside the `BaseSettings` class, and run a script to dynamically generate the markdown table and inject it between markers (`<!-- CONFIG_START -->`) in the `README.md`. Add a CI step that regenerates the docs and fails (`git diff --exit-code`) if drift is detected.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +174,25 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY / H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the web frontend for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+<!-- CONFIG_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env -S uv run python
+"""Generates configuration documentation and injects it into README.md."""
+
+import re
+import sys
+from pathlib import Path
+
+from pydantic_core import PydanticUndefined
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def generate_table() -> str:
+    from h4ckath0n.config import Settings
+
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        var_name = f"H4CKATH0N_{name.upper()}"
+        if name == "openai_api_key":
+            var_name = "OPENAI_API_KEY / H4CKATH0N_OPENAI_API_KEY"
+
+        default = field.default
+        if default is PydanticUndefined:
+            default = getattr(field, "default_factory", None)
+            if default is not None:
+                default = "`[]`" if getattr(default, "__name__", "") == "list" else "factory"
+            else:
+                default = "required"
+        elif default == "":
+            default = "empty"
+        elif isinstance(default, list) and len(default) == 0:
+            default = "`[]`"
+        elif isinstance(default, bool):
+            default = f"`{str(default).lower()}`"
+        elif isinstance(default, (int, str)):
+            if default != "empty":
+                default = f"`{default}`"
+
+        desc = field.description or ""
+        lines.append(f"| `{var_name}` | {default} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def main():
+    table = generate_table()
+    readme_text = README.read_text()
+
+    start_marker = "<!-- CONFIG_START -->"
+    end_marker = "<!-- CONFIG_END -->"
+
+    pattern = re.compile(rf"{start_marker}.*?{end_marker}", re.DOTALL)
+
+    if start_marker not in readme_text:
+        print("Markers not found in README.md")
+        return 1
+
+    new_text = pattern.sub(f"{start_marker}\n{table}\n{end_marker}", readme_text)
+    README.write_text(new_text)
+    print("Updated README.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 UserVerification = Literal["required", "preferred", "discouraged"]
@@ -24,54 +25,89 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: UserVerification = "preferred"
-    attestation: AttestationConveyance = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: UserVerification = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: AttestationConveyance = Field(
+        default="none", description="WebAuthn attestation preference"
+    )
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis URL for background jobs")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run background jobs inline in development"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: StorageBackend = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: StorageBackend = Field(
+        default="local", description="Storage backend (`local`)"
+    )
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: EmailBackend = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173", description="Base URL of the web frontend for email links"
+    )
+    email_backend: EmailBackend = Field(
+        default="file", description="Email backend (`file` or `smtp`)"
+    )
+    email_from: str = Field(
+        default="noreply@localhost", description="Sender address for outbound emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox", description="Directory for file email backend"
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP server username")
+    smtp_password: str = Field(default="", description="SMTP server password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP connections")
+    smtp_ssl: bool = Field(default=False, description="Use SSL/TLS for SMTP connections")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode restrictions")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the hard-coded configuration variable table in `README.md` with a generated version parsed dynamically from Pydantic V2 `Field` definitions in `src/h4ckath0n/config.py`.
🎯 Why: The configuration table in the documentation drifts quickly from the actual settings loaded by the codebase as parameters are added, renamed, or default values change. Generating it from the single source of truth ensures the documentation is always accurate.
🧪 Verification: Run `uv run scripts/generate_config_docs.py` to regenerate the docs, and `git diff README.md` to see the changes.
🔒 Drift Prevention: Added explicit `Field(default=..., description="...")` annotations in the Pydantic settings. Added a generator script `scripts/generate_config_docs.py` that parses `Settings.model_fields` and writes a markdown table between `<!-- CONFIG_START -->` and `<!-- CONFIG_END -->` markers in the README. Added a step to `.github/workflows/ci.yml` that runs the script and fails with `git diff --exit-code` if the output is out of date.
🗺️ Evidence: `src/h4ckath0n/config.py` was used as the source of truth for the available environment variables and their defaults.

---
*PR created automatically by Jules for task [14586633311553764145](https://jules.google.com/task/14586633311553764145) started by @ToolchainLab*