### PR TITLE
∷ Vector: centralize display_name validation logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2025-02-24 - Centralize Field Validation with BeforeValidator
+**Learning:** Duplicated `@field_validator` methods for strings that require normalization (like stripping whitespace and checking for emptiness) can cause bugs or drift across multiple schemas.
+**Action:** Use Pydantic V2's `Annotated` with `BeforeValidator` to extract these normalizations into pure, shared helpers. Always check `if isinstance(v, str):` in `BeforeValidator` since it receives raw inputs.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -5,27 +5,19 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, ValidDisplayName
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: ValidDisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,12 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
+
+
+def _clean_required_display_name(v: Any) -> Any:
+    if isinstance(v, str):
+        v = v.strip()
+        if not v:
+            raise ValueError("Display name must not be empty")
+    return v
+
+
+ValidDisplayName = Annotated[str, BeforeValidator(_clean_required_display_name)]
 
 
 def _validate_display_name(v: str | None) -> str | None:
@@ -31,19 +42,11 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: ValidDisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
         max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 **What**: Extracted the duplicated `_clean_display_name` `@field_validator` in `RegisterRequest` and `PasskeyRegisterStartRequest` into a shared, pure `ValidDisplayName` `Annotated` type leveraging Pydantic V2's `BeforeValidator`.
- 🎯 **Why**: Centralizes duplicate string normalization logic (stripping whitespace and checking for emptiness) ensuring the business rule is applied consistently, reducing boilerplate, and guarding against drift.
- 🧠 **Design**: Pydantic's `BeforeValidator` allows the validation logic to be bundled cleanly within an `Annotated` type alias. This pure functional approach isolates the side-effects of normalization and validation away from the model definitions, making the definitions smaller and declarative. An `isinstance(v, str)` guard was added to the pure helper function since `BeforeValidator` receives un-coerced inputs, maintaining complete safety.
- λ **FP Angle**: Moves away from class-bound mutation methods (e.g., `@field_validator`) to a composable and reusable transformation pipeline (via a pure helper function and `Annotated` type composition).
- ✅ **Verification**: Checked modifications via `git diff`. Executed the complete backend testing suite and quality gates (`uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest`) with all tests passing.
- 🧪 **Edge cases**: Ensured raw non-string inputs are safely handled during extraction by checking their instance type before modifying, while properly capturing edge cases for empty values.
- ⚠️ **Risk**: Very low; no API boundaries were altered, only the internal model composition mechanisms used for validation.

---
*PR created automatically by Jules for task [1824934011315603581](https://jules.google.com/task/1824934011315603581) started by @ToolchainLab*