### PR TITLE
∴ Vector: Centralize display name validation using Pydantic Annotated types

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -5,27 +5,18 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayNameField
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayNameField = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    EmailStr,
+    Field,
+    StringConstraints,
+)
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
@@ -20,6 +26,22 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def _normalize_display_name(v: Any) -> Any:
+    """Trim whitespace; raise ValueError if empty."""
+    if isinstance(v, str):
+        v = v.strip()
+        if not v:
+            raise ValueError("Display name must not be empty")
+    return v
+
+
+DisplayNameField = Annotated[
+    str,
+    BeforeValidator(_normalize_display_name),
+    StringConstraints(max_length=DISPLAY_NAME_MAX_LENGTH),
+]
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -31,19 +53,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayNameField = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What: Centralized `display_name` validation logic into a reusable `DisplayNameField` using Pydantic V2's `Annotated` and `BeforeValidator`. Applied this to `RegisterRequest` and `PasskeyRegisterStartRequest`.
🎯 Why: The validation logic for `display_name` (stripping whitespace, throwing an error if empty) and max length constraint was exactly duplicated across standard auth and passkey auth schemas.
🧠 Design: Using `Annotated` with `BeforeValidator` allows us to securely execute the text normalization and validation exactly once per field, extracting it out of specific models and maintaining a single source of truth for display name rules.
λ FP Angle: Transforms validation logic from ad-hoc object-bound methods (`@field_validator`) into a pure, generic transformation function (`_normalize_display_name`) paired with a deterministic type definition.
✅ Verification: Ran format, lint, typecheck, and full test suite (`uv run pytest`), ensuring behavior was preserved.
🧪 Edge cases: Tested inputs that consist of only whitespace to ensure the explicit ValueError is successfully preserved over Pydantic default length validation.
⚠️ Risk: Low, this is functionally equivalent. Pydantic's `BeforeValidator` guarantees normalization occurs before string constraints.

---
*PR created automatically by Jules for task [6750339093504346242](https://jules.google.com/task/6750339093504346242) started by @ToolchainLab*