### PR TITLE
🗺️ Atlas: Replace handwritten config docs with generated table from Pydantic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check config docs
+        run: uv run --locked scripts/sync_config_docs.py --check
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2025-06-28 - Generate env var docs from Pydantic config
+**Learning:** Env vars drift heavily when Pydantic config adds/modifies attributes and manual tables are left unchanged (e.g. README configuration table was severely outdated with many missing variables like Redis, jobs, storage, email).
+**Action:** When auditing configuration docs for drift, replace handwritten tables with generated blocks using a script that parses `Settings.model_fields`, accesses `pydantic.Field` descriptors for defaults/descriptions, and runs in CI as a `--check` flag.

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL (e.g. redis://localhost:6379/0) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development without a worker process |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Backend for file uploads (e.g. `local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed file upload size in bytes (default 50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to store emails when using the `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use explicit SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (e.g. injects fake latency, disables destructive actions) |
+<!-- CONFIG_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/sync_config_docs.py
+++ b/scripts/sync_config_docs.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that config settings are accurately documented.
+
+Usage (from repo root):
+    uv run scripts/sync_config_docs.py [--check]
+
+If --check is provided, it exits with 1 if the README is out of sync.
+Otherwise, it updates the README with the generated configuration table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic_core import PydanticUndefined
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- CONFIG_START -->"
+END_MARKER = "<!-- CONFIG_END -->"
+
+
+def generate_table() -> str:
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for name, field in Settings.model_fields.items():
+        if name == "openai_api_key":
+            lines.append("| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |")
+            lines.append(
+                "| `H4CKATH0N_OPENAI_API_KEY` | empty | "
+                "Alternate OpenAI API key for the LLM wrapper |"
+            )
+            continue
+
+        env_name = f"H4CKATH0N_{name.upper()}"
+
+        default = field.default
+        if default is PydanticUndefined:
+            default_factory = getattr(field, "default_factory", None)
+            default = default_factory() if default_factory is not None else "required"
+
+        if default == "":
+            default = "empty"
+        elif default is True:
+            default = "`true`"
+        elif default is False:
+            default = "`false`"
+        elif default == []:
+            default = "`[]`"
+        elif (isinstance(default, str) and default not in ("empty", "required")) or (
+            isinstance(default, int) and not isinstance(default, bool)
+        ):
+            default = f"`{default}`"
+
+        desc = field.description or ""
+
+        lines.append(f"| `{env_name}` | {default} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Check if README is up-to-date")
+    args = parser.parse_args()
+
+    readme_text = README.read_text()
+
+    if START_MARKER not in readme_text or END_MARKER not in readme_text:
+        print("❌ Markers not found in README.md")
+        return 1
+
+    start_idx = readme_text.find(START_MARKER) + len(START_MARKER)
+    end_idx = readme_text.find(END_MARKER)
+
+    current_section = readme_text[start_idx:end_idx].strip()
+    new_section = generate_table().strip()
+
+    if current_section == new_section:
+        print("✅ Configuration documentation is up-to-date.")
+        return 0
+
+    if args.check:
+        print("❌ Configuration documentation in README.md is out of sync!")
+        print("Run `uv run scripts/sync_config_docs.py` to fix it.")
+        return 1
+
+    new_readme = readme_text[:start_idx] + "\n" + new_section + "\n" + readme_text[end_idx:]
+    README.write_text(new_readme)
+    print("✅ Updated configuration documentation in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 UserVerification = Literal["required", "preferred", "discouraged"]
@@ -24,54 +25,97 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: UserVerification = "preferred"
-    attestation: AttestationConveyance = "none"
+    rp_id: str = Field(default="", description="WebAuthn relying party ID, required in production")
+    origin: str = Field(default="", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(default=300, description="WebAuthn challenge TTL in seconds")
+    user_verification: UserVerification = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: AttestationConveyance = Field(
+        default="none", description="WebAuthn attestation preference"
+    )
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(default="", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(
+        default="", description="Redis connection URL (e.g. redis://localhost:6379/0)"
+    )
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run jobs inline in development without a worker process"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: StorageBackend = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: StorageBackend = Field(
+        default="local", description="Backend for file uploads (e.g. `local`)"
+    )
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Directory for local file uploads"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024,
+        description="Maximum allowed file upload size in bytes (default 50MB)",
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: EmailBackend = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173",
+        description="Base URL of the frontend application for email links",
+    )
+    email_backend: EmailBackend = Field(
+        default="file", description="Email backend to use (`file` or `smtp`)"
+    )
+    email_from: str = Field(
+        default="noreply@localhost", description="Default sender address for outbound emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox",
+        description="Directory to store emails when using the `file` backend",
+    )
+    smtp_host: str = Field(default="", description="SMTP server hostname")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP authentication username")
+    smtp_password: str = Field(default="", description="SMTP authentication password")
+    smtp_starttls: bool = Field(default=True, description="Use STARTTLS for SMTP connections")
+    smtp_ssl: bool = Field(default=False, description="Use explicit SSL/TLS for SMTP connections")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(
+        default=False,
+        description="Enable demo mode (e.g. injects fake latency, disables destructive actions)",
+    )
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced the handwritten, outdated environment variable configuration table in `README.md` with an automatically generated block using a Python script (`scripts/sync_config_docs.py`). Upgraded Pydantic Settings model attributes in `src/h4ckath0n/config.py` to leverage `pydantic.Field(description="...")` to serve as the documentation source of truth.
🎯 Why: Env vars in the README were severely outdated, omitting essential vars such as those for Redis, Jobs, Storage, and Email. The drift between the manual docs and codebase leads to painful onboarding experiences where people assume commands or variables that do not actually exist or are unconfigured. Generating this ensures doc correctness moving forward.
🔎 Verification: Use `uv run scripts/sync_config_docs.py` to regenerate the docs, and test the drift check using `uv run scripts/sync_config_docs.py --check`. Formatting, typechecking, linting, and tests all passed with `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest`.
🔒 Drift Prevention: Added `sync_config_docs.py` which reads `Settings.model_fields` and directly updates/checks `README.md` for drift. Wrote a CI job to run it with `--check` so that PRs fail if configuration changes are not reflected in the README. 
🗺️ Evidence: `src/h4ckath0n/config.py` and `.github/workflows/ci.yml`.

---
*PR created automatically by Jules for task [6046733506074302974](https://jules.google.com/task/6046733506074302974) started by @ToolchainLab*