### PR TITLE
∷ Vector: [consolidate display name validation]

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import (
+    DISPLAY_NAME_MAX_LENGTH,
+    DeviceBindingMixin,
+    validate_required_display_name,
+)
 
 # -- Registration --
 
@@ -22,10 +26,7 @@ class PasskeyRegisterStartRequest(BaseModel):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return validate_required_display_name(v)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -20,6 +20,14 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def validate_required_display_name(v: str) -> str:
+    """Trim whitespace; reject empty-after-trim values for required fields."""
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -40,10 +48,7 @@ class RegisterRequest(DeviceBindingMixin):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return validate_required_display_name(v)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What: Centralized required display name validation into a reusable function `validate_required_display_name`. Left `_validate_display_name` intact to preserve its semantics for optional fields.
🎯 Why: To eliminate duplicated validation logic between `RegisterRequest` and `PasskeyRegisterStartRequest`, while avoiding regression risks from modifying the existing `_validate_display_name`.
🧠 Design: Extracted the strict `_clean_display_name` logic to a module-level pure function to serve as a single source of truth for required display name normalization, keeping it distinct from the optional normalization helper.
λ FP Angle: Improved composability and centralized a pure normalization pipeline without breaking the original helper's contract.
✅ Verification: Ran `ruff format`, `ruff check`, `mypy src`, and `pytest` successfully.
🧪 Edge cases: Maintains the strict edge case checks for required names (rejects whitespace-only display names and trims surrounding whitespace).
⚠️ Risk: Low risk, preserves existing behavior and API.

---
*PR created automatically by Jules for task [4899263786870993864](https://jules.google.com/task/4899263786870993864) started by @ToolchainLab*