### PR TITLE
⚡ Bolt: Replace .scalars().first() with .scalar() and .get() to reduce ORM overhead

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -211,13 +211,15 @@ async def finish_authentication(
     flow = await _get_valid_flow(db, flow_id, "authenticate")
 
     raw_id = credential_json.get("rawId") or credential_json.get("id", "")
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.credential_id == raw_id,
-            WebAuthnCredential.revoked_at.is_(None),
+    # ⚡ Bolt: Prefer scalar() over execute().scalars().first() to avoid Result hydration
+    if (
+        stored := await db.scalar(
+            select(WebAuthnCredential).filter(
+                WebAuthnCredential.credential_id == raw_id,
+                WebAuthnCredential.revoked_at.is_(None),
+            )
         )
-    )
-    if (stored := result.scalars().first()) is None:
+    ) is None:
         raise ValueError("Unknown or revoked credential")
 
     challenge_bytes = base64url_to_bytes(flow.challenge)
@@ -358,13 +360,15 @@ async def rename_passkey(
     Raises :class:`PasskeyNotFoundError` if not found / not owned and
     :class:`PasskeyRevokedError` if the credential is revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
+    # ⚡ Bolt: Prefer scalar() over execute().scalars().first() to avoid Result hydration
+    if (
+        cred := await db.scalar(
+            select(WebAuthnCredential).filter(
+                WebAuthnCredential.id == key_id,
+                WebAuthnCredential.user_id == user.id,
+            )
         )
-    )
-    if (cred := result.scalars().first()) is None:
+    ) is None:
         raise PasskeyNotFoundError
     if cred.revoked_at is not None:
         raise PasskeyRevokedError
@@ -395,13 +399,15 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
+        # ⚡ Bolt: Prefer scalar() over execute().scalars().first() to avoid Result hydration
+        if (
+            cred := await db.scalar(
+                select(WebAuthnCredential).filter(
+                    WebAuthnCredential.id == key_id,
+                    WebAuthnCredential.user_id == user.id,
+                )
             )
-        )
-        if (cred := result.scalars().first()) is None:
+        ) is None:
             raise PasskeyNotFoundError
         if cred.revoked_at is not None:
             raise PasskeyAlreadyRevokedError

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Select only .id to avoid hydrating the full User model and prefer scalar()
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(
@@ -75,8 +75,8 @@ async def register_user(
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Prefer scalar() over execute().scalars().first() to avoid Result hydration
+    if (user := await db.scalar(select(User).filter(User.email == email))) is None:
         return None
     if not user.password_hash:
         return None
@@ -159,13 +159,15 @@ async def confirm_password_reset(db: AsyncSession, raw_token: str, new_password:
     """Confirm a password reset and return the user."""
     hash_password, _verify = _require_password_extra()
     hashed = _hash_token(raw_token)
-    prt_result = await db.execute(
-        select(PasswordResetToken).filter(
-            PasswordResetToken.token_hash == hashed,
-            PasswordResetToken.used.is_(False),
+    # ⚡ Bolt: Prefer scalar() over execute().scalars().first() to avoid Result hydration
+    if (
+        prt := await db.scalar(
+            select(PasswordResetToken).filter(
+                PasswordResetToken.token_hash == hashed,
+                PasswordResetToken.used.is_(False),
+            )
         )
-    )
-    if (prt := prt_result.scalars().first()) is None:
+    ) is None:
         raise ValueError("Invalid or already-used reset token")
     if prt.expires_at.replace(tzinfo=UTC) < datetime.now(UTC):
         raise ValueError("Reset token expired")

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -165,11 +165,11 @@ def _resolve_user(session: Session, args: argparse.Namespace) -> User | None:
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        # ⚡ Bolt: Use db.get() for primary key lookup
+        return session.get(User, user_id)
     else:
-        stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        # ⚡ Bolt: Prefer scalar() over execute().scalars().first() to avoid Result hydration
+        return session.scalar(select(User).where(User.email == email))
 
 
 def _user_or_exit(session: Session, args: argparse.Namespace) -> tuple[User | None, int | None]:


### PR DESCRIPTION
- **💡 What**: Replaced usages of `db.execute(select(Model)).scalars().first()` with `db.scalar(select(Model))`, `db.scalar(select(Model.id))`, and `session.get(Model, pk)` across the codebase.
- **🎯 Why**: Using `db.execute(...).scalars().first()` creates unnecessary full `Result` objects and, in the case of primary key lookups, bypasses the session's identity map. `db.scalar()` provides a more direct, lower-overhead extraction path, while `db.get()` leverages the identity map for cache hits. When checking existence, only selecting `.id` avoids hydrating the full ORM model completely.
- **📊 Impact**: Reduces database latency, intermediate memory allocations, and parsing overhead during high-frequency paths like authentication, resulting in faster request handling.
- **🔬 Measurement**: Run identical loads with profiling on authentication paths and observe reduced time spent in SQLAlchemy ORM mapping and parsing.

---
*PR created automatically by Jules for task [12652706876008339863](https://jules.google.com/task/12652706876008339863) started by @ToolchainLab*