### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration via timing attack in login/register

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-29 - Argon2id Dummy Hash Structure
+**Vulnerability:** User enumeration via timing attack in login and registration endpoints.
+**Learning:** When mitigating timing attacks using a dummy hash with `argon2-cffi`, the dummy hash must be a fully valid, structurally correct Argon2id string. If an invalid format is used, `argon2.PasswordHasher.verify` fails fast with a decoding error, completely bypassing the intended processing delay.
+**Prevention:** Always generate an actual valid hash for the dummy value using the exact Argon2 parameters expected by the application instead of using placeholder strings.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -59,6 +59,7 @@ async def register_user(
     hash_password, _verify = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
     if result.scalars().first():
+        hash_password(password)  # Mitigate user enumeration timing attacks
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(
@@ -73,15 +74,22 @@ async def register_user(
     return user
 
 
+# A valid Argon2id hash structure for dummy timing mitigation
+_DUMMY_PASSWORD_HASH = "$argon2id$v=19$m=65536,t=3,p=4$+fq4rkwuma4beDA0yUuZOw$6By0lCZYoxh8C6S2IntXqgguU/q9MVwGT6dAN4JzL6g"
+
+
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+
+    user = result.scalars().first()
+    # Mitigate user enumeration timing attacks by always performing the hash verification
+    actual_hash = user.password_hash if user and user.password_hash else _DUMMY_PASSWORD_HASH
+    is_valid = verify_password(password, actual_hash)
+
+    if not user or not user.password_hash or not is_valid:
         return None
-    if not user.password_hash:
-        return None
-    if not verify_password(password, user.password_hash):
-        return None
+
     return user
 
 

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -75,7 +75,7 @@ async def register_user(
 
 
 # A valid Argon2id hash structure for dummy timing mitigation
-_DUMMY_PASSWORD_HASH = "$argon2id$v=19$m=65536,t=3,p=4$+fq4rkwuma4beDA0yUuZOw$6By0lCZYoxh8C6S2IntXqgguU/q9MVwGT6dAN4JzL6g"
+_DUMMY_PASSWORD_HASH = "$argon2id$v=19$m=65536,t=3,p=4$+fq4rkwuma4beDA0yUuZOw$6By0lCZYoxh8C6S2IntXqgguU/q9MVwGT6dAN4JzL6g"  # noqa: E501
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** User enumeration via timing attack. The login and registration endpoints returned early when an email was unknown (or already known in registration), skipping the computationally expensive Argon2id hash operation.
🎯 **Impact:** An attacker could measure the response times of the endpoints to determine if an email address is registered in the system, potentially leading to targeted phishing or credential stuffing attacks.
🔧 **Fix:** 
- In `register_user`, we compute the hash even if the email already exists before returning the error.
- In `authenticate_user`, we always perform a `verify_password` check. If the user doesn't exist, it verifies against a static, valid dummy Argon2id hash.
✅ **Verification:** Verified that the timing mitigation works correctly and no regressions were introduced by running the test suite (`uv run pytest`). Checked that the dummy hash is a valid Argon2id structure to prevent early verification failure.

---
*PR created automatically by Jules for task [17656542082202845606](https://jules.google.com/task/17656542082202845606) started by @ToolchainLab*