### PR TITLE
∯ Vector: Centralize required display name validation logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2025-05-16 - Centralize Required Display Name Validation
+**Learning:** Extracting Pydantic validation logic for required fields must not overwrite optional field validation helpers, and standalone helpers must be called inside `@classmethod` wrappers to avoid mypy errors.
+**Action:** Centralize duplicated string validation logic by extracting `clean_required_display_name` into `h4ckath0n.auth.schemas` and importing it into `h4ckath0n.auth.passkeys.schemas`.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import (
+    DISPLAY_NAME_MAX_LENGTH,
+    DeviceBindingMixin,
+    clean_required_display_name,
+)
 
 # -- Registration --
 
@@ -22,10 +26,7 @@ class PasskeyRegisterStartRequest(BaseModel):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return clean_required_display_name(v)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -20,6 +20,14 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def clean_required_display_name(v: str) -> str:
+    """Trim whitespace; raise ValueError if empty."""
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -40,10 +48,7 @@ class RegisterRequest(DeviceBindingMixin):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return clean_required_display_name(v)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What:
Extracted a new pure helper function `clean_required_display_name(v: str) -> str` into `src/h4ckath0n/auth/schemas.py`. Refactored `RegisterRequest` and `PasskeyRegisterStartRequest` to use this new helper inside their `@field_validator("display_name")` methods instead of duplicating the strip-and-check-empty logic.

🎯 Why:
The exact same string validation logic (stripping whitespace and raising a `ValueError` if the string was empty) was duplicated across two different schema files. This violated the principle of having a single source of truth for semantic validation and risked drift if the rules for a valid display name changed in the future.

🧠 Design:
The `_validate_display_name` helper in `src/h4ckath0n/auth/schemas.py` is designed for *optional* display names (it safely returns `None` for empty strings). Rather than modifying it and breaking optional field semantics, I extracted a new dedicated helper, `clean_required_display_name`, specifically for required fields. To comply with Pydantic v2 and mypy constraints, the helper is called from within the existing `@classmethod` validators rather than replacing them entirely.

λ FP Angle:
The change moves local, mutation-heavy ad-hoc logic into a centralized pure transformation pipeline. Instead of inline branching (`v = v.strip(); if not v:`), the schemas now map their inputs through a declarative, composable string-cleaning function.

✅ Verification:
- Ran the backend CI quality gate: `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest`. All 200 tests passed, and static analysis is clean.

🧪 Edge cases:
- Handled empty strings and whitespace-only strings consistently across both endpoints.
- Avoided mutating the semantics of the existing `_validate_display_name` helper.

⚠️ Risk:
Low risk. The behavior of the validation remains functionally identical to the previous inline logic, just structurally cleaner.

---
*PR created automatically by Jules for task [316231085031090362](https://jules.google.com/task/316231085031090362) started by @ToolchainLab*