### PR TITLE
⚡ Bolt: Optimize scalar db queries in auth service

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -393,15 +393,16 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
     """
     try:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
-        await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
+        await db.scalar(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
+        if (
+            cred := await db.scalar(
+                select(WebAuthnCredential).filter(
+                    WebAuthnCredential.id == key_id,
+                    WebAuthnCredential.user_id == user.id,
+                )
             )
-        )
-        if (cred := result.scalars().first()) is None:
+        ) is None:
             raise PasskeyNotFoundError
         if cred.revoked_at is not None:
             raise PasskeyAlreadyRevokedError

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -41,8 +41,7 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
+        count = await db.scalar(select(func.count()).select_from(User))
         if count == 0:
             return True
     return False
@@ -57,8 +56,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Fetch only the ID to avoid instantiating the full User ORM object
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(
@@ -75,8 +74,8 @@ async def register_user(
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.scalar() to avoid intermediate Result object allocation
+    if (user := await db.scalar(select(User).filter(User.email == email))) is None:
         return None
     if not user.password_hash:
         return None


### PR DESCRIPTION
💡 **What**: Refactored multiple database queries across `src/h4ckath0n/auth/service.py` and `src/h4ckath0n/auth/passkeys/service.py` to use `db.scalar(...)` directly instead of `db.execute(...).scalars().first()`. Additionally, modified a check in `register_user` to select only the `User.id` instead of the entire `User` object.

🎯 **Why**: Using `db.execute(...)` forces SQLAlchemy to allocate an intermediate `Result` object. When fetching single models or identifiers, `db.scalar(...)` is more direct. More importantly, when only checking existence (like checking if an email is registered), querying `select(User.id)` avoids parsing, allocating, and hydrating a full ORM `User` instance, saving memory and processing overhead.

📊 **Impact**: Reduces memory allocation and avoids ORM instantiation overhead in high-frequency auth and passkey paths. This contributes to lower tail latency for login and registration requests.

🔬 **Measurement**: Verify by inspecting memory profiles (e.g., via `memray`) before and after the change on high-concurrency login tests, or by observing fewer SQLAlchemy object instantiations via internal tracing. Code correctness is verified by the existing backend test suite passing.

---
*PR created automatically by Jules for task [9090754322119452225](https://jules.google.com/task/9090754322119452225) started by @ToolchainLab*