### PR TITLE
🧭 Atlas: Enforce configuration documentation parity in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config variables
+        run: uv run --locked scripts/check_doc_config.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-07-01 - Prevent configuration drift in docs
+**Learning:** The `README.md` configuration section easily drifts from `src/h4ckath0n/config.py` because there was no programmatic check to enforce parity for environment variables.
+**Action:** Added a `scripts/check_doc_config.py` script that iterates over `Settings.model_fields` and verifies that every config key is documented as `H4CKATH0N_<KEY>` in `README.md`. Also added this check to `ci.yml`.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (local) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max file upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Frontend app base URL |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connection |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connection |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_config.py
+++ b/scripts/check_doc_config.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify every config var in Settings is in README.md."""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_settings_keys() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    return list(Settings.model_fields.keys())
+
+
+def main() -> int:
+    keys = get_settings_keys()
+    readme_text = README.read_text()
+
+    missing = []
+    for key in keys:
+        env_var = f"H4CKATH0N_{key.upper()}"
+        if env_var not in readme_text:
+            if key == "openai_api_key" and "OPENAI_API_KEY" in readme_text:
+                continue
+            missing.append(env_var)
+
+    if missing:
+        print("❌ The following config variables are NOT documented in README.md:\n")
+        for m in missing:
+            print(f"  `{m}`")
+        print("\nPlease add them to the Configuration section in README.md.")
+        return 1
+
+    print(f"✅ All {len(keys)} config variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- 💡 What: Add missing configuration variables to README.md and introduce a script to enforce parity.
- 🎯 Why: To ensure the documentation is always accurate and to prevent missing configurations from causing confusion.
- 🧪 Verification: Run `uv run scripts/check_doc_config.py` locally.
- 🔒 Drift Prevention: Added a check in `.github/workflows/ci.yml` that runs `scripts/check_doc_config.py`.
- 🗺️ Evidence: `src/h4ckath0n/config.py` and `README.md`.

---
*PR created automatically by Jules for task [11308953592584436338](https://jules.google.com/task/11308953592584436338) started by @ToolchainLab*