### PR TITLE
∴ Vector: [Centralize required display_name validation logic]

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import (
+    DISPLAY_NAME_MAX_LENGTH,
+    DeviceBindingMixin,
+    _clean_required_display_name,
+)
 
 # -- Registration --
 
@@ -22,10 +26,7 @@ class PasskeyRegisterStartRequest(BaseModel):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return _clean_required_display_name(v)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -20,6 +20,14 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def _clean_required_display_name(v: str) -> str:
+    """Trim whitespace and ensure the value is not empty."""
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -40,10 +48,7 @@ class RegisterRequest(DeviceBindingMixin):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return _clean_required_display_name(v)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 **What:** Extract required `display_name` validation logic into a shared pure helper function `_clean_required_display_name`.
- 🎯 **Why:** To reduce duplication and centralize normalization semantics for the `display_name` field across different registration schemas (`RegisterRequest` and `PasskeyRegisterStartRequest`).
- 🧠 **Design:** A small pure helper function `_clean_required_display_name` is created in `src/h4ckath0n/auth/schemas.py`. Both `RegisterRequest` and `PasskeyRegisterStartRequest` are updated to call this shared helper in their `_clean_display_name` field validator methods, preserving the exact same behavior but making the logic single-sourced.
- λ **FP Angle:** Reduces scattered mutation-heavy validation logic into a single deterministic transformation pipeline, making behavior easier to reason about.
- ✅ **Verification:** Ran `uv run --locked ruff format . && uv run --locked ruff check . && uv run --locked mypy src && uv run pytest` to ensure behavior is preserved and all quality gates pass.
- 🧪 **Edge cases:** Empty strings and whitespace-only strings are still correctly rejected with `ValueError`, preserving existing invariants.
- ⚠️ **Risk:** Extremely low risk. It's a pure refactoring of duplicate validation code.

---
*PR created automatically by Jules for task [11743858281106917421](https://jules.google.com/task/11743858281106917421) started by @ToolchainLab*