### PR TITLE
⚡ Bolt: Optimize single record retrieval to avoid Result object hydration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-24 - Avoid ORM Hydration for Single Record Retrieval
+**Learning:** When retrieving a single model instance using a select statement, using `db.execute(select(Model)).scalars().first()` forces SQLAlchemy to allocate and hydrate intermediate `Result` and `ScalarResult` objects, adding overhead.
+**Action:** Always prefer `db.scalar(select(Model))` or `session.scalar(select(Model))` over `db.execute(...).scalars().first()` when only a single scalar value or instance is needed to avoid unnecessary object allocation and hydration overhead.

--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -211,13 +211,14 @@ async def finish_authentication(
     flow = await _get_valid_flow(db, flow_id, "authenticate")
 
     raw_id = credential_json.get("rawId") or credential_json.get("id", "")
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.credential_id == raw_id,
-            WebAuthnCredential.revoked_at.is_(None),
+    if (
+        stored := await db.scalar(
+            select(WebAuthnCredential).filter(
+                WebAuthnCredential.credential_id == raw_id,
+                WebAuthnCredential.revoked_at.is_(None),
+            )
         )
-    )
-    if (stored := result.scalars().first()) is None:
+    ) is None:
         raise ValueError("Unknown or revoked credential")
 
     challenge_bytes = base64url_to_bytes(flow.challenge)
@@ -358,13 +359,14 @@ async def rename_passkey(
     Raises :class:`PasskeyNotFoundError` if not found / not owned and
     :class:`PasskeyRevokedError` if the credential is revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
+    if (
+        cred := await db.scalar(
+            select(WebAuthnCredential).filter(
+                WebAuthnCredential.id == key_id,
+                WebAuthnCredential.user_id == user.id,
+            )
         )
-    )
-    if (cred := result.scalars().first()) is None:
+    ) is None:
         raise PasskeyNotFoundError
     if cred.revoked_at is not None:
         raise PasskeyRevokedError
@@ -395,13 +397,14 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
+        if (
+            cred := await db.scalar(
+                select(WebAuthnCredential).filter(
+                    WebAuthnCredential.id == key_id,
+                    WebAuthnCredential.user_id == user.id,
+                )
             )
-        )
-        if (cred := result.scalars().first()) is None:
+        ) is None:
             raise PasskeyNotFoundError
         if cred.revoked_at is not None:
             raise PasskeyAlreadyRevokedError

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,7 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    if await db.scalar(select(User).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(
@@ -75,8 +74,7 @@ async def register_user(
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    if (user := await db.scalar(select(User).filter(User.email == email))) is None:
         return None
     if not user.password_hash:
         return None
@@ -159,13 +157,14 @@ async def confirm_password_reset(db: AsyncSession, raw_token: str, new_password:
     """Confirm a password reset and return the user."""
     hash_password, _verify = _require_password_extra()
     hashed = _hash_token(raw_token)
-    prt_result = await db.execute(
-        select(PasswordResetToken).filter(
-            PasswordResetToken.token_hash == hashed,
-            PasswordResetToken.used.is_(False),
+    if (
+        prt := await db.scalar(
+            select(PasswordResetToken).filter(
+                PasswordResetToken.token_hash == hashed,
+                PasswordResetToken.used.is_(False),
+            )
         )
-    )
-    if (prt := prt_result.scalars().first()) is None:
+    ) is None:
         raise ValueError("Invalid or already-used reset token")
     if prt.expires_at.replace(tzinfo=UTC) < datetime.now(UTC):
         raise ValueError("Reset token expired")

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -169,7 +169,7 @@ def _resolve_user(session: Session, args: argparse.Namespace) -> User | None:
     else:
         stmt = select(User).where(User.email == email)
 
-    return session.execute(stmt).scalars().first()
+    return session.scalar(stmt)
 
 
 def _user_or_exit(session: Session, args: argparse.Namespace) -> tuple[User | None, int | None]:


### PR DESCRIPTION
💡 What: Replaced occurrences of `db.execute(select(...)).scalars().first()` with `db.scalar(select(...))` across the codebase.
🎯 Why: To avoid the overhead of intermediate full `Result` and `ScalarResult` object allocation and hydration when retrieving a single model instance.
📊 Impact: Reduces memory allocation and speeds up database read operations, slightly improving overall response times, especially in hot paths like authentication flows.
🔬 Measurement: Can be verified by running the test suite to ensure all functionality remains correct and checking profiling tools for a reduction in object allocations during database queries.

---
*PR created automatically by Jules for task [2327330884732725259](https://jules.google.com/task/2327330884732725259) started by @ToolchainLab*