### PR TITLE
🛡️ Sentinel: [HIGH] Fix User Enumeration via Timing Attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-01 - User Enumeration via Timing Attack
+**Vulnerability:** Login endpoint returned immediately if user didn't exist, enabling timing attacks to enumerate valid emails.
+**Learning:** In `authenticate_user`, early exits bypassed Argon2 password hashing. Argon2's `verify` needs a structurally valid dummy hash string to process correctly without throwing a fast decode error.
+**Prevention:** Always execute the password hashing function with a valid dummy hash when the user is not found to equalize response times.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -73,13 +73,22 @@ async def register_user(
     return user
 
 
+# Dummy hash to mitigate timing attacks (user enumeration)
+_DUMMY_HASH = (
+    "$argon2id$v=19$m=65536,t=3,p=4"
+    "$e1MD55BZM3KIzDMU6kBsyg$ny7dU4lJPaiqIV8Ftmt09SHwz2Cmiisc1F0KCf72CZc"
+)
+
+
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
     result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    user = result.scalars().first()
+
+    if user is None or not user.password_hash:
+        verify_password(password, _DUMMY_HASH)
         return None
-    if not user.password_hash:
-        return None
+
     if not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
- 🚨 **Severity**: HIGH
- 💡 **Vulnerability**: The `authenticate_user` function returned immediately if an email wasn't found in the database, skipping the expensive Argon2 hash verification. This timing discrepancy allowed attackers to enumerate registered email addresses.
- 🎯 **Impact**: Attackers could harvest valid user emails for credential stuffing or phishing by measuring login response times.
- 🔧 **Fix**: Introduced a valid dummy Argon2 hash (`_DUMMY_HASH`). When a user is not found or has no password, the system now verifies the provided password against the dummy hash, equalizing response times.
- ✅ **Verification**: Ran pytest test suite and confirmed tests passed. Cleaned up scratchpad files.

---
*PR created automatically by Jules for task [12307957103293307002](https://jules.google.com/task/12307957103293307002) started by @ToolchainLab*