### PR TITLE
🧭 Atlas: [Add automated drift-prevention for configuration docs]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check config docs
+        run: uv run --locked scripts/check_doc_config.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- CONFIG_DOCS_START -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL for background jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (read-only operations) |
+<!-- CONFIG_DOCS_END -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_config.py
+++ b/scripts/check_doc_config.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that configuration variables are documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_config.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    from h4ckath0n.config import Settings
+
+    readme_text = README.read_text()
+
+    missing = []
+    for name, _field in Settings.model_fields.items():
+        # OPENAI_API_KEY is an exception in the docs (no prefix)
+        env_name = f"H4CKATH0N_{name.upper()}"
+        if name == "openai_api_key":
+            if "OPENAI_API_KEY" not in readme_text and env_name not in readme_text:
+                missing.append(env_name)
+        elif env_name not in readme_text:
+            missing.append(env_name)
+
+    # Validate that we also have the generated markers, to ensure they aren't removed
+    if (
+        "<!-- CONFIG_DOCS_START -->" not in readme_text
+        or "<!-- CONFIG_DOCS_END -->" not in readme_text
+    ):
+        print(
+            "❌ The CONFIG_DOCS_START and CONFIG_DOCS_END markers "
+            "are missing from README.md. "
+            "Please generate the config table using a script."
+        )
+        return 1
+
+    if missing:
+        print("❌ The following env vars are NOT documented in README.md:\n")
+        for m in missing:
+            print(f"  {m}")
+        print("\nUpdate the 'Configuration' section in README.md to include them.")
+        return 1
+
+    print(f"✅ All {len(Settings.model_fields)} config vars are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -34,17 +34,12 @@ def get_app_routes() -> list[tuple[str, str]]:
     app = create_app(settings)
 
     routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    openapi = app.openapi()
+    for path, methods in openapi.get("paths", {}).items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
+        for method in methods:
+            routes.append((method.upper(), path))
     return sorted(routes)
 
 

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention generator: Update the configuration table in README.md.
+
+Usage (from repo root):
+    uv run scripts/generate_config_docs.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from pydantic_core import PydanticUndefined
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    from h4ckath0n.config import Settings
+
+    fields = Settings.model_fields
+
+    table_lines = ["| Variable | Default | Description |", "|---|---|---|"]
+
+    for name, field in fields.items():
+        if field.default is PydanticUndefined:
+            default_val = getattr(field, "default_factory", None)
+            default_val = f"`{default_val()}`" if default_val is not None else "required"
+        else:
+            default_val = f"`{field.default}`"
+
+        # Format defaults to match existing table style
+        if default_val == "`[]`":
+            default_val = "`[]`"
+        elif default_val == "`False`":
+            default_val = "`false`"
+        elif default_val == "`True`":
+            default_val = "`true`"
+        elif default_val == "``":
+            default_val = "empty"
+
+        env_name = f"H4CKATH0N_{name.upper()}"
+
+        # Use field description if available, otherwise fallback
+        desc = field.description or "Configuration option"
+
+        # Handle special cases from existing table
+        if name == "openai_api_key":
+            table_lines.append(
+                f"| `OPENAI_API_KEY` | {default_val} | OpenAI API key for the LLM wrapper |"
+            )
+            table_lines.append(
+                f"| `H4CKATH0N_OPENAI_API_KEY` | {default_val} | Alternate "
+                f"OpenAI API key for the LLM wrapper |"
+            )
+            continue
+
+        table_lines.append(f"| `{env_name}` | {default_val} | {desc} |")
+
+    new_table = "\n".join(table_lines)
+
+    readme_text = README.read_text()
+
+    pattern = re.compile(
+        r"(<!-- CONFIG_DOCS_START -->\n).*?(\n<!-- CONFIG_DOCS_END -->)", re.DOTALL
+    )
+
+    if not pattern.search(readme_text):
+        print("❌ Could not find CONFIG_DOCS_START/END markers in README.md")
+        return 1
+
+    new_readme = pattern.sub(rf"\g<1>{new_table}\g<2>", readme_text)
+
+    README.write_text(new_readme)
+    print("✅ Configuration table generated in README.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 UserVerification = Literal["required", "preferred", "discouraged"]
@@ -24,54 +25,79 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field("development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        "sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: UserVerification = "preferred"
-    attestation: AttestationConveyance = "none"
+    rp_id: str = Field("", description="WebAuthn relying party ID, required in production")
+    origin: str = Field("", description="WebAuthn origin, required in production")
+    webauthn_ttl_seconds: int = Field(300, description="WebAuthn challenge TTL in seconds")
+    user_verification: UserVerification = Field(
+        "preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: AttestationConveyance = Field(
+        "none", description="WebAuthn attestation preference"
+    )
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default_factory=list,
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(False, description="First password signup becomes admin")
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field("", description="OpenAI API key for the LLM wrapper")
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field("", description="Redis connection URL for background jobs")
+    jobs_inline_in_dev: bool = Field(True, description="Run background jobs inline in development")
+    jobs_default_queue: str = Field(
+        "default", description="Default queue name for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: StorageBackend = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: StorageBackend = Field("local", description="Storage backend (`local`)")
+    storage_dir: str = Field(
+        "./.h4ckath0n_storage", description="Directory for local storage backend"
+    )
+    max_upload_bytes: int = Field(
+        50 * 1024 * 1024, description="Maximum upload size in bytes"
+    )  # 50 MB
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: EmailBackend = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        "http://localhost:5173", description="Base URL of the frontend application"
+    )
+    email_backend: EmailBackend = Field("file", description="Email backend (`file` or `smtp`)")
+    email_from: str = Field("noreply@localhost", description="Default sender address for emails")
+    email_outbox_dir: str = Field(
+        "./.h4ckath0n_email_outbox", description="Directory for file-based email backend"
+    )
+    smtp_host: str = Field("", description="SMTP server host")
+    smtp_port: int = Field(587, description="SMTP server port")
+    smtp_username: str = Field("", description="SMTP authentication username")
+    smtp_password: str = Field("", description="SMTP authentication password")
+    smtp_starttls: bool = Field(True, description="Enable STARTTLS for SMTP")
+    smtp_ssl: bool = Field(False, description="Enable SSL/TLS for SMTP")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(False, description="Enable demo mode (read-only operations)")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Added documentation drift prevention for configuration variables by updating `README.md` to use dynamically generated markdown markers, and writing automated check scripts for CI. Also refactored the routes check script to use OpenAPI paths instead of iterating over internal `app.routes`.
🎯 Why: Prevents developers from forgetting to document new `H4CKATH0N_` configuration variables as they are added to `config.py`. It guarantees documentation is accurate, up-to-date, and matches the code as the source of truth, removing ambiguity.
🧪 Verification: Run `uv run scripts/check_doc_config.py` and `uv run scripts/check_doc_routes.py`. The backend test suite and lint checks all pass.
🔒 Drift Prevention: Added `scripts/generate_config_docs.py` to auto-generate the markdown table and `scripts/check_doc_config.py` as a CI enforcement step in `.github/workflows/ci.yml`. 
🗺️ Evidence: Used `src/h4ckath0n/config.py` (`Settings` class) as the source of truth for the config.

---
*PR created automatically by Jules for task [5997996950937014497](https://jules.google.com/task/5997996950937014497) started by @ToolchainLab*