### PR TITLE
∷ Vector: Centralize display name validation logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,4 @@
+
+## 2024-07-03 - Pydantic Field Validation with Helpers
+**Learning:** When using a helper function in a Pydantic V2 `@field_validator`, assigning it directly (e.g. `_clean_field = field_validator('field')(classmethod(helper))`) can cause mypy type-checking errors.
+**Action:** Always wrap reusable helper functions inside a `@classmethod` decorated method in the model (e.g. `def _clean_field(cls, v): return helper(v)`).

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import (
+    DISPLAY_NAME_MAX_LENGTH,
+    DeviceBindingMixin,
+    require_display_name,
+)
 
 # -- Registration --
 
@@ -22,10 +26,7 @@ class PasskeyRegisterStartRequest(BaseModel):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return require_display_name(v)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -10,6 +10,14 @@ from pydantic import BaseModel, EmailStr, Field, field_validator
 DISPLAY_NAME_MAX_LENGTH = 200
 
 
+def require_display_name(v: str) -> str:
+    """Trim whitespace; raise ValueError on empty."""
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
 def _validate_display_name(v: str | None) -> str | None:
     """Trim whitespace; reject empty-after-trim values."""
     if v is None:
@@ -40,10 +48,7 @@ class RegisterRequest(DeviceBindingMixin):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return require_display_name(v)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extract a shared `require_display_name` helper in `auth/schemas.py` and reuse it across password and passkey registration schemas.
- 🎯 Why: Removes duplicated whitespace stripping and empty-checking validation logic, establishing a single source of truth for display name normalization.
- 🧠 Design: A small pure helper function enforces the invariant (must not be empty after trimming) and is cleanly wrapped by Pydantic `@classmethod` validators as required by Pydantic V2.
- λ FP Angle: Centralized normalizer logic.
- ✅ Verification: Ran `ruff check` and `pytest`.
- 🧪 Edge cases: Tested empty or whitespace-only display names.
- ⚠️ Risk: Extremely low risk since the exact same logic was previously duplicated inline.

---
*PR created automatically by Jules for task [8701892252764170784](https://jules.google.com/task/8701892252764170784) started by @ToolchainLab*