### PR TITLE
⚡ Bolt: Optimize single model instance retrievals

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+## 2024-07-03 - Avoid full Result object hydration for single model lookups
+**Learning:** Using `db.execute(select(...)).scalars().first()` instantiates a full intermediate Result object, parsing columns that are ultimately discarded by `first()`. This introduces unnecessary memory overhead for scalar lookups.
+**Action:** Always prefer `db.scalar(select(...))` or `session.scalar(select(...))` for single model instance retrieval to bypass the intermediate Result object hydration step entirely.

--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -211,13 +211,14 @@ async def finish_authentication(
     flow = await _get_valid_flow(db, flow_id, "authenticate")
 
     raw_id = credential_json.get("rawId") or credential_json.get("id", "")
-    result = await db.execute(
+    # ⚡ Bolt: Use db.scalar() to avoid intermediate Result object hydration
+    stored = await db.scalar(
         select(WebAuthnCredential).filter(
             WebAuthnCredential.credential_id == raw_id,
             WebAuthnCredential.revoked_at.is_(None),
         )
     )
-    if (stored := result.scalars().first()) is None:
+    if stored is None:
         raise ValueError("Unknown or revoked credential")
 
     challenge_bytes = base64url_to_bytes(flow.challenge)
@@ -358,13 +359,14 @@ async def rename_passkey(
     Raises :class:`PasskeyNotFoundError` if not found / not owned and
     :class:`PasskeyRevokedError` if the credential is revoked.
     """
-    result = await db.execute(
+    # ⚡ Bolt: Use db.scalar() to avoid intermediate Result object hydration
+    cred = await db.scalar(
         select(WebAuthnCredential).filter(
             WebAuthnCredential.id == key_id,
             WebAuthnCredential.user_id == user.id,
         )
     )
-    if (cred := result.scalars().first()) is None:
+    if cred is None:
         raise PasskeyNotFoundError
     if cred.revoked_at is not None:
         raise PasskeyRevokedError
@@ -395,13 +397,14 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
+        # ⚡ Bolt: Use db.scalar() to avoid intermediate Result object hydration
+        cred = await db.scalar(
             select(WebAuthnCredential).filter(
                 WebAuthnCredential.id == key_id,
                 WebAuthnCredential.user_id == user.id,
             )
         )
-        if (cred := result.scalars().first()) is None:
+        if cred is None:
             raise PasskeyNotFoundError
         if cred.revoked_at is not None:
             raise PasskeyAlreadyRevokedError

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,9 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Use db.scalar() to avoid intermediate Result object hydration
+    user_exists = await db.scalar(select(User).filter(User.email == email))
+    if user_exists:
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(
@@ -75,8 +76,9 @@ async def register_user(
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> User | None:
     _hash, verify_password = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if (user := result.scalars().first()) is None:
+    # ⚡ Bolt: Use db.scalar() to avoid intermediate Result object hydration
+    user = await db.scalar(select(User).filter(User.email == email))
+    if user is None:
         return None
     if not user.password_hash:
         return None
@@ -159,13 +161,14 @@ async def confirm_password_reset(db: AsyncSession, raw_token: str, new_password:
     """Confirm a password reset and return the user."""
     hash_password, _verify = _require_password_extra()
     hashed = _hash_token(raw_token)
-    prt_result = await db.execute(
+    # ⚡ Bolt: Use db.scalar() to avoid intermediate Result object hydration
+    prt = await db.scalar(
         select(PasswordResetToken).filter(
             PasswordResetToken.token_hash == hashed,
             PasswordResetToken.used.is_(False),
         )
     )
-    if (prt := prt_result.scalars().first()) is None:
+    if prt is None:
         raise ValueError("Invalid or already-used reset token")
     if prt.expires_at.replace(tzinfo=UTC) < datetime.now(UTC):
         raise ValueError("Reset token expired")

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -169,7 +169,8 @@ def _resolve_user(session: Session, args: argparse.Namespace) -> User | None:
     else:
         stmt = select(User).where(User.email == email)
 
-    return session.execute(stmt).scalars().first()
+    # ⚡ Bolt: Use session.scalar() to avoid intermediate Result object hydration
+    return session.scalar(stmt)
 
 
 def _user_or_exit(session: Session, args: argparse.Namespace) -> tuple[User | None, int | None]:


### PR DESCRIPTION
**💡 What:**
Replaced `db.execute(...).scalars().first()` with `db.scalar(...)` for retrieving single entities via primary key and email in `h4ckath0n/auth/service.py`, `h4ckath0n/auth/passkeys/service.py` and `h4ckath0n/cli/_common.py`.

**🎯 Why:**
The `scalars().first()` idiom forces SQLAlchemy to build and instantiate an entire `ScalarResult` object and iterate through the first row when evaluating the execution. `db.scalar(...)` skips this intermediate object instantiation directly, providing a micro-optimization for highly trafficked scalar lookups (such as auth token/user evaluations).

**📊 Impact:**
Negligible but non-zero memory allocation saving during repeated user and credential validation executions.

**🔬 Measurement:**
Can be verified by tracing the execution stack in SQLAlchemy for `db.scalar` versus `db.execute(...).scalars().first()`, showing fewer internal object initializations. Passed the CI unit tests checking API integrations.

---
*PR created automatically by Jules for task [3408738835336580372](https://jules.google.com/task/3408738835336580372) started by @ToolchainLab*