### PR TITLE
🎨 Palette: Add ARIA labels to mobile icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-03 - Resolving Strict Mode Violations in Playwright Tests for Duplicate UI Elements
+ **Learning:** When adding ARIA labels to duplicate UI elements (like mobile/desktop navigation icons), automated UI tests (both React Testing Library and Playwright) will fail due to strict mode violations where multiple elements match the same accessible query.
+ **Action:** Update React Testing Library tests from `getByRole` to `getAllByRole(...)[0]!` and Playwright scripts from `page.get_by_label(...)` to `page.get_by_label(...).nth(1)` to explicitly target the intended element instance and maintain test stability.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0]!,
       ).toBeInTheDocument();
     });
 
@@ -91,8 +91,8 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+        screen.queryAllByRole("button", { name: /Theme: system/ }).length === 0,
+      ).toBe(true);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -191,6 +191,11 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={toggleTheme}
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
                 className="mr-2"
               >
                 {effectiveTheme === "dark" ? (
@@ -203,6 +208,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label="Toggle mobile menu"
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />


### PR DESCRIPTION
💡 What: Added `aria-label` and `aria-expanded` attributes to the mobile theme toggle and mobile menu toggle buttons in the `Layout` component. Updated `Layout.test.tsx` queries to resolve "multiple elements found" errors caused by the new accessible names.
🎯 Why: Icon-only buttons without accessible names are invisible or confusing to screen reader users. These changes ensure the mobile navigation elements are fully accessible and their states (expanded/collapsed) are correctly announced.
📸 Before/After: Visual appearance remains unchanged. Screen readers will now announce "Theme: system (dark)" and "Toggle mobile menu" instead of just "button".
♿ Accessibility: Improves WCAG compliance by providing accessible names (SC 4.1.2) for icon-only buttons.

---
*PR created automatically by Jules for task [7767902713194152115](https://jules.google.com/task/7767902713194152115) started by @ToolchainLab*