### PR TITLE
🗺️ Atlas: Add doc config drift check and fix missing envs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc envs
+        run: uv run --locked scripts/check_doc_envs.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs synchronously in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | From address for outbound emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email storage |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_envs.py
+++ b/scripts/check_doc_envs.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every configuration setting in the app is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_envs.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_config_vars() -> list[str]:
+    """Return the expected environment variable names from Settings."""
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    fields = Settings.model_fields
+    vars_list = []
+    for name in fields:
+        env_name = f"H4CKATH0N_{name.upper()}"
+        vars_list.append(env_name)
+    return sorted(vars_list)
+
+
+def check_envs_in_readme(vars_list: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing = []
+    for var in vars_list:
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    vars_list = get_config_vars()
+    missing = check_envs_in_readme(vars_list)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration section in README.md.")
+        return 1
+
+    print(f"✅ All {len(vars_list)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added missing environment variables to the Configuration section of README.md and introduced a script to verify documentation parity.
🎯 Why: The configuration table had drifted from the real application state defined in `src/h4ckath0n/config.py`, making it difficult for users to discover and configure all available settings.
🧪 Verification: Verified locally by running `uv run scripts/check_doc_envs.py`.
🔒 Drift Prevention: Added `scripts/check_doc_envs.py` and a new CI job step in `backend` to enforce that all `Settings` variables are mentioned in `README.md`.
🗺️ Evidence: Looked at `src/h4ckath0n/config.py` as the source of truth for all configurations.

---
*PR created automatically by Jules for task [953875074261512635](https://jules.google.com/task/953875074261512635) started by @ToolchainLab*