### PR TITLE
∴ Vector: Centralize scope normalization logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Centralize string normalization logic for domain types
+**Learning:** Normalization of domain specific types, such as scopes (trimming, deduplication, filtering empty strings), scattered across ad-hoc loops and sets is an anti-pattern that creates subtle bugs and duplicated logic.
+**Action:** Extract a pure, composable `clean_scopes(Iterable[str]) -> list[Scope]` helper function to serve as a single source of truth for scope parsing rules, and replace inline parsing at call sites.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -22,14 +22,19 @@ ADMIN: Role = "admin"
 Scope = NewType("Scope", str)
 
 
-def parse_scopes(raw: str) -> list[Scope]:
-    """Parse a comma-separated scope string into an ordered, de-duplicated list.
+def clean_scopes(raw_scopes: Iterable[str]) -> list[Scope]:
+    """Clean, trim, and de-duplicate a sequence of raw scopes.
 
     Whitespace around each scope is trimmed and empty entries are dropped.
     Insertion order is preserved so serialisation round-trips stably.
     """
-    cleaned = (part.strip() for part in raw.split(","))
+    cleaned = (part.strip() for part in raw_scopes)
     return [Scope(part) for part in dict.fromkeys(p for p in cleaned if p)]
+
+
+def parse_scopes(raw: str) -> list[Scope]:
+    """Parse a comma-separated scope string into an ordered, de-duplicated list."""
+    return clean_scopes(raw.split(","))
 
 
 def serialize_scopes(scopes: Iterable[Scope]) -> str:

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -16,7 +16,7 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from h4ckath0n.auth.authz import Scope, missing_scopes, parse_scopes
+from h4ckath0n.auth.authz import Scope, clean_scopes, missing_scopes, parse_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.realtime.auth import AUD_HTTP, AuthContext, AuthError, verify_device_jwt
 
@@ -84,7 +84,7 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[Scope] = {Scope(s.strip()) for s in scopes if s.strip()}
+    needed: set[Scope] = set(clean_scopes(scopes))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
         if missing := missing_scopes(parse_scopes(user.scopes), needed):

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import Scope, parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import clean_scopes, parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -143,9 +143,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        for scope in args.scope:
-            existing.append(Scope(scope.strip()))
-        user.scopes = serialize_scopes(existing)
+        user.scopes = serialize_scopes(clean_scopes(existing + args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -163,7 +161,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        to_remove = {s.strip() for s in args.scope}
+        to_remove = {str(s) for s in clean_scopes(args.scope)}
         remaining = [s for s in existing if s not in to_remove]
         user.scopes = serialize_scopes(remaining)
         session.commit()

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,6 +8,7 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    clean_scopes,
     missing_scopes,
     parse_scopes,
     serialize_scopes,
@@ -22,6 +23,12 @@ from h4ckath0n.auth.passkeys.errors import (
 
 
 class TestScopes:
+    def test_clean_scopes_trims_and_drops_empty(self):
+        assert clean_scopes(["  admin ", " demo", "", "  "]) == [Scope("admin"), Scope("demo")]
+
+    def test_clean_scopes_deduplicates_preserving_order(self):
+        assert clean_scopes(["a", "b", "a", "c", "b"]) == [Scope("a"), Scope("b"), Scope("c")]
+
     def test_parse_trims_and_drops_empty(self):
         assert parse_scopes("  admin , demo ,, ") == [Scope("admin"), Scope("demo")]
 


### PR DESCRIPTION
💡 **What:** Extracted an explicit `clean_scopes(Iterable[str]) -> list[Scope]` helper in `src/h4ckath0n/auth/authz.py`. Replaced scattered ad-hoc string stripping logic in `parse_scopes`, `require_scopes` (`src/h4ckath0n/auth/dependencies.py`), and CLI scope handlers (`src/h4ckath0n/cli/users.py`) with this pure function.
🎯 **Why:** Normalization rules for the `Scope` domain concept (such as trimming whitespace, filtering empty strings, and deduplicating while preserving order) were duplicated and inconsistently implemented across different call sites, increasing the risk of subtle bugs and making the code harder to reason about.
🧠 **Design:** By extracting a pure transformation helper `clean_scopes`, we establish a single source of truth for turning a raw iterable of strings into a canonical list of typed `Scope`s. This removes the need for calling components to implement their own list-comprehensions or loop-based cleanup logic.
λ **FP Angle:** This refactor aligns with FP principles by replacing scattered mutation and ad-hoc local filtering logic (e.g. `for scope in args.scope: existing.append(Scope(scope.strip()))`) with explicit transformation pipelines (e.g., `serialize_scopes(clean_scopes(existing + args.scope))`). It favors pure helper composition over inline mutable bookkeeping.
✅ **Verification:** Verified by running `uv run --locked pytest -v tests/test_authz.py` (which includes newly added tests for `clean_scopes` verifying trimming, filtering, and order preservation), and the full project CI gates (`ruff check`, `ruff format`, `mypy src`, and the full test suite).
🧪 **Edge cases:** Explicitly handles empty strings, whitespace-only strings, duplicate scopes out of order, and strings with leading/trailing spaces across all scope ingestion points.
⚠️ **Risk:** Low risk. No changes to public API schema or business logic. Strictly unifies existing normalization behavior.

---
*PR created automatically by Jules for task [11108829106685015799](https://jules.google.com/task/11108829106685015799) started by @ToolchainLab*