### PR TITLE
🧭 Atlas: Add missing env vars to docs and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc envs
+        run: uv run --locked scripts/check_doc_envs.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2025-01-20 - Missing Configuration Documentation
+**Learning:** Environment variables in Pydantic settings easily drift from the README. Validating env var names via introspection (Settings.model_fields) and regex matching against markdown prevents this.
+**Action:** Enforce programmatic drift checks against README documentation for all Pydantic settings configurations by adding a check script in CI.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,22 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | `local` storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | `file` or `smtp` |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_envs.py
+++ b/scripts/check_doc_envs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env -S uv run python
+"""Drift check: verify that every environment variable in the Settings class is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_envs.py
+
+The script imports the Settings model, enumerates all fields, and checks that
+README.md mentions each one. Settings intended for internal framework usage
+can be excluded via FRAMEWORK_ENVS.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+# Settings that we intentionally omit from documentation.
+FRAMEWORK_ENVS = frozenset({"H4CKATH0N_DEMO_MODE"})
+
+
+def get_app_envs() -> list[str]:
+    """Return environment variable names from the live Settings model."""
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    envs: list[str] = []
+    for field_name in Settings.model_fields:
+        env_var = "H4CKATH0N_" + field_name.upper()
+        if env_var in FRAMEWORK_ENVS:
+            continue
+        envs.append(env_var)
+    return sorted(envs)
+
+
+def check_envs_in_readme(envs: list[str]) -> list[str]:
+    """Return env vars that are not mentioned as code blocks in README.md."""
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for env in envs:
+        # OPENAI_API_KEY is an exception that is documented directly
+        if env == "H4CKATH0N_OPENAI_API_KEY":
+            if "OPENAI_API_KEY" not in readme_text:
+                missing.append(env)
+            continue
+
+        # Ensure it appears as a code block (e.g. `H4CKATH0N_ENV`)
+        if f"`{env}`" not in readme_text:
+            missing.append(env)
+    return missing
+
+
+def main() -> int:
+    envs = get_app_envs()
+    missing = check_envs_in_readme(envs)
+
+    if missing:
+        print("❌ The following env vars are NOT documented in README.md:\n")
+        for env in missing:
+            print(f"  {env}")
+        print(
+            "\nAdd these to the Configuration section in README.md or, "
+            "if intentionally undocumented, add them to FRAMEWORK_ENVS in this script."
+        )
+        return 1
+
+    print(f"✅ All {len(envs)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- 💡 What: Added missing environment variables to README configuration. Added `check_doc_envs.py` to prevent drift.
- 🎯 Why: Configuration drift causes onboarding friction. Automatically ensuring all Pydantic fields are documented keeps the repo truthful.
- 🧪 Verification: Validated with `uv run scripts/check_doc_envs.py`.
- 🔒 Drift Prevention: CI now checks that new settings fields are documented.
- 🗺️ Evidence: Used `src/h4ckath0n/config.py` `Settings.model_fields` as source of truth.

---
*PR created automatically by Jules for task [4081940834972599038](https://jules.google.com/task/4081940834972599038) started by @ToolchainLab*