### PR TITLE
∭ Vector: Extract shared display name validation logic

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import (
+    DISPLAY_NAME_MAX_LENGTH,
+    DeviceBindingMixin,
+    validate_required_display_name,
+)
 
 # -- Registration --
 
@@ -22,10 +26,7 @@ class PasskeyRegisterStartRequest(BaseModel):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return validate_required_display_name(v)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -20,6 +20,14 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def validate_required_display_name(v: str) -> str:
+    """Trim whitespace; raise ValueError if empty-after-trim."""
+    v = v.strip()
+    if not v:
+        raise ValueError("Display name must not be empty")
+    return v
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -40,10 +48,7 @@ class RegisterRequest(DeviceBindingMixin):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return validate_required_display_name(v)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted a shared `validate_required_display_name` helper in `auth/schemas.py` and reused it across `RegisterRequest` and `PasskeyRegisterStartRequest`.
- 🎯 Why: To remove duplicated normalization/validation logic for a critical field and centralize semantics in a single source of truth.
- 🧠 Design: A pure helper function is exposed in `auth/schemas.py` alongside the existing optional field validator `_validate_display_name`.
- λ FP Angle: Centralizes normalization rules into a single deterministic pure helper rather than repeating mutation/validation steps inline at multiple call sites.
- ✅ Verification: Ran `uv run pytest` and type checkers to ensure the existing Pydantic validation behavior and tests remain unbroken.
- 🧪 Edge cases: Preserves exact behavior for empty string (`ValueError`), whitespace-only (`ValueError`), and properly trims leading/trailing whitespace.
- ⚠️ Risk: Extremely low risk since it just extracts identical logic. Tests already cover these edge cases comprehensively.

---
*PR created automatically by Jules for task [15289726122961280970](https://jules.google.com/task/15289726122961280970) started by @ToolchainLab*