### PR TITLE
🧭 Atlas: Add drift check for environment variable documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2025-02-14 - Env Var Doc Drift Prevention
+**Learning:** The project relies on pydantic-settings to extract `H4CKATH0N_` prefixed variables, but new variables are frequently added without documenting them in `README.md`.
+**Action:** Implemented `scripts/check_doc_env_vars.py` to assert that all fields defined in `Settings` are documented in the Configuration table. This check is run in CI to catch future omissions.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for `file` email backend |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name for jobs |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline during development |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes (50 MB) |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_SSL` | `false` | Enable SSL/TLS for SMTP |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for storing uploads |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every env var in Settings is documented in README.md.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    vars_list = []
+    for key in Settings.model_fields:
+        vars_list.append(f"H4CKATH0N_{key.upper()}")
+    return sorted(vars_list)
+
+
+def check_vars_in_readme(env_vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+
+    match = re.search(r"(## Configuration\n\n.*?)(?=\n## )", readme_text, re.DOTALL)
+    if not match:
+        print("❌ Could not find '## Configuration' section in README.md")
+        return env_vars
+
+    config_section = match.group(1)
+
+    missing = []
+    for var in env_vars:
+        # OPENAI_API_KEY is documented differently
+        if var == "H4CKATH0N_OPENAI_API_KEY" and "H4CKATH0N_OPENAI_API_KEY" in config_section:
+            continue
+
+        if f"`{var}`" not in config_section:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    missing = check_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added scripts/check_doc_env_vars.py to assert all config env vars are documented and updated the Configuration table in README.md with missing variables.
🎯 Why: Prevents configuration documentation drift by ensuring new pydantic Settings fields are always represented in the docs.
🧪 Verification: run uv run --locked scripts/check_doc_env_vars.py
🔒 Drift Prevention: Added scripts/check_doc_env_vars.py to CI backend job
🗺️ Evidence: src/h4ckath0n/config.py is used as the single source of truth for config settings.

---
*PR created automatically by Jules for task [4485400237808034693](https://jules.google.com/task/4485400237808034693) started by @ToolchainLab*