### PR TITLE
∿ Vector: centralize scope parsing in CLI commands

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-07-06 - Centralize CLI scope parsing
+**Learning:** The CLI tools for user scopes (`users scopes add` and `users scopes remove`) used ad-hoc string splitting that bypassed the centralized `parse_scopes` logic, leading to duplicate and unparsed scopes when users provided comma-separated lists inline (e.g. `--scope="admin, demo"`).
+**Action:** Always route external input strings through the primary domain normalization functions (`parse_scopes`) before manipulating collections, ensuring a single source of truth for semantic boundaries and eliminating manual looping over unparsed inputs.

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import Scope, parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -143,9 +143,8 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        for scope in args.scope:
-            existing.append(Scope(scope.strip()))
-        user.scopes = serialize_scopes(existing)
+        added = parse_scopes(",".join(args.scope))
+        user.scopes = serialize_scopes(existing + added)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -163,7 +162,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        to_remove = {s.strip() for s in args.scope}
+        to_remove = set(parse_scopes(",".join(args.scope)))
         remaining = [s for s in existing if s not in to_remove]
         user.scopes = serialize_scopes(remaining)
         session.commit()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -311,6 +311,57 @@ class TestCLIUsersOperations:
         assert "billing:read" in data["scopes"]
         assert "billing:write" in data["scopes"]
 
+    def test_users_scopes_add_comma_separated(self, tmp_path):
+        db_url = self._init_db(tmp_path)
+        uid = self._create_user(db_url)
+        result = _run_cli(
+            "users",
+            "scopes",
+            "add",
+            "--user-id",
+            uid,
+            "--scope",
+            "billing:read, billing:write ",
+            "--db",
+            db_url,
+            "--yes",
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "billing:read" in data["scopes"]
+        assert "billing:write" in data["scopes"]
+
+    def test_users_scopes_remove_comma_separated(self, tmp_path):
+        db_url = self._init_db(tmp_path)
+        uid = self._create_user(db_url)
+        _run_cli(
+            "users",
+            "scopes",
+            "set",
+            "--user-id",
+            uid,
+            "--scopes",
+            "a,b,c",
+            "--db",
+            db_url,
+            "--yes",
+        )
+        result = _run_cli(
+            "users",
+            "scopes",
+            "remove",
+            "--user-id",
+            uid,
+            "--scope",
+            "a, c ",
+            "--db",
+            db_url,
+            "--yes",
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["scopes"] == "b"
+
     def test_users_scopes_set(self, tmp_path):
         db_url = self._init_db(tmp_path)
         uid = self._create_user(db_url)


### PR DESCRIPTION
💡 What: Updates the `users scopes add` and `users scopes remove` commands in the CLI to use `parse_scopes` explicitly to parse incoming scopes before manipulating collections.
🎯 Why: Previously, these commands bypassed `parse_scopes` by appending raw user arguments directly to the parsed string. If a user provided comma-separated scopes as a single string (e.g. `--scope="admin, demo"`), the CLI would store `"admin, demo"` literally, introducing malformed elements.
🧠 Design: The change modifies the `add` and `remove` commands to parse comma-joined strings of `args.scope` first.
λ FP Angle: Enhances purity and centralizes domain validation logic, avoiding mutable `for` loops inside the command module.
✅ Verification: Ran `uv run --locked pytest -v tests/test_cli.py` passing properly with unit tests asserting comma-separated arguments properly deduplicate/add/remove correctly. Added journal entry to `.jules/vector.md`.
🧪 Edge cases: Tested against adding and removing comma-separated values successfully without introducing invalid strings to the list.
⚠️ Risk: None. Standard behavior for non-comma inputs remains unchanged.

---
*PR created automatically by Jules for task [14629696778498139502](https://jules.google.com/task/14629696778498139502) started by @ToolchainLab*