### PR TITLE
⚡ Bolt: Avoid redundant public key serialization in JWT decoding

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -1,0 +1,1 @@
+# Let's do the changes and verify

--- a/src/h4ckath0n/auth/jwt.py
+++ b/src/h4ckath0n/auth/jwt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 
 import jwt
 from pydantic import BaseModel
@@ -25,12 +26,12 @@ class JWTClaims(BaseModel):
 def decode_device_token(
     token: str,
     *,
-    public_key_pem: str,
+    public_key: Any,
 ) -> JWTClaims:
     """Decode an ES256 device-signed JWT using the device's public key."""
     payload = jwt.decode(
         token,
-        public_key_pem,
+        public_key,
         algorithms=["ES256"],
         options={"verify_aud": False},
         leeway=timedelta(seconds=30),  # allow some clock skew

--- a/src/h4ckath0n/realtime/auth.py
+++ b/src/h4ckath0n/realtime/auth.py
@@ -12,7 +12,6 @@ import json
 from dataclasses import dataclass
 
 import jwt
-from cryptography.hazmat.primitives import serialization
 from fastapi import WebSocket
 from jwt.algorithms import ECAlgorithm
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -91,15 +90,11 @@ async def verify_device_jwt(
     try:
         jwk_dict = json.loads(device.public_key_jwk)
         public_key = ECAlgorithm(ECAlgorithm.SHA256).from_jwk(jwk_dict)
-        pem = public_key.public_bytes(  # type: ignore[union-attr]
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode()
     except (ValueError, KeyError, TypeError):
         raise AuthError("Invalid device key") from None
 
     try:
-        claims = decode_device_token(raw_jwt, public_key_pem=pem)
+        claims = decode_device_token(raw_jwt, public_key=public_key)
     except jwt.ExpiredSignatureError:
         raise AuthError("Token expired") from None
     except jwt.InvalidTokenError:


### PR DESCRIPTION
💡 What: Pass the native EC public key object directly to `jwt.decode` and avoid serializing to PEM.
🎯 Why: Serializing to a string via `public_bytes().decode()` just to have `jwt.decode` parse it back into a native key introduces unnecessary CPU overhead on a hot path.
📊 Impact: Eliminates a redundant parse step, saving CPU cycles and reducing response latency for every authenticated endpoint.
🔬 Measurement: Run the test suite. Correctness is maintained, and fewer instructions are executed for JWT validation.

---
*PR created automatically by Jules for task [11295171619884471410](https://jules.google.com/task/11295171619884471410) started by @ToolchainLab*