### PR TITLE
🎨 Palette: Add ARIA labels to mobile icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-06 - Added accessible attributes to duplicate UI elements
+**Learning:** When adding accessible attributes (like aria-label) to duplicate UI elements (e.g. mobile vs. desktop variants) in the React frontend, update corresponding React Testing Library queries from getByRole to getAllByRole(...)[0]! to prevent 'multiple elements found' test failures and satisfy TypeScript strict mode constraints during Vite builds.
+**Action:** Remember this pattern when writing or updating tests for responsive UI components.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0]!,
       ).toBeInTheDocument();
     });
 
@@ -91,8 +91,8 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+        screen.queryAllByRole("button", { name: /Theme: system/ }).length === 0,
+      ).toBe(true);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -192,6 +192,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +208,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label="Toggle menu"
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to the mobile theme toggle and mobile menu toggle icon-only buttons in `Layout.tsx`. Also updated the corresponding `Layout.test.tsx` file to accommodate the duplicate accessible elements between desktop and mobile break points.

### 🎯 Why
Icon-only buttons are completely inaccessible to screen reader users unless they have an `aria-label`. This change ensures all primary navigation interactions are accessible to all users regardless of viewport size.

### 📸 Before/After
Before: Mobile buttons were missing `aria-label` entirely.
After: Mobile theme button properly reflects current active theme state, and mobile menu properly describes its purpose and state (`aria-expanded`).

### ♿ Accessibility
* Added `aria-label` to the mobile theme toggle.
* Added `aria-label` and `aria-expanded` to the mobile menu toggle button.
* Ensured testing library functions correctly resolve queries to handle these accessibility enhancements.

---
*PR created automatically by Jules for task [3622642901968463979](https://jules.google.com/task/3622642901968463979) started by @ToolchainLab*