### PR TITLE
🧭 Atlas: Add missing config variables and prevent env var drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for email links and auth redirects |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env.py
+++ b/scripts/check_doc_env.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env -S uv run python
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    from h4ckath0n.config import Settings
+
+    readme_text = README.read_text()
+    missing = []
+
+    for field_name in Settings.model_fields:
+        env_var = f"H4CKATH0N_{field_name.upper()}"
+
+        # some exceptions:
+        if field_name == "openai_api_key":
+            if "OPENAI_API_KEY" not in readme_text and env_var not in readme_text:
+                missing.append(env_var)
+            continue
+
+        if env_var not in readme_text:
+            missing.append(env_var)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  {env_var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(
+        f"✅ All {len(Settings.model_fields)} environment variables are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Documented missing environment variables in `README.md`.
🎯 Why: Users are blind to 15+ available configuration options (like storage, redis, emails).
🧪 Verification: Executed `PYTHONPATH=src uv run scripts/check_doc_env.py` to ensure all `h4ckath0n` settings are documented.
🔒 Drift Prevention: Added `scripts/check_doc_env.py` to assert parity between `src/h4ckath0n/config.py` and `README.md`, and wired it into CI.
🗺️ Evidence: `src/h4ckath0n/config.py` and `README.md`.

---
*PR created automatically by Jules for task [16477012989011114739](https://jules.google.com/task/16477012989011114739) started by @ToolchainLab*