### PR TITLE
∴ Vector: centralize scope parsing into a shared variadic normalizer

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,6 @@
+## 2026-07-07 - Centralize scope parsing
+**Learning:** Extracted multiple places doing parsing arrays, splitting them by commas, and deduplicating arrays manually by updating  to support variadic inputs. This makes parsing of scopes consistent everywhere. Ruff linting fails when fixing imports sometimes and running `ruff format` after checking code helps.
+**Action:** Next time prefer modifying core extraction utility rather than trying to replicate same logic on callers and running checks multiple times.
+## 2026-07-07 - Centralize scope parsing
+**Learning:** Extracted multiple places doing parsing arrays, splitting them by commas, and deduplicating arrays manually by updating parse_scopes to support variadic inputs. This makes parsing of scopes consistent everywhere. Ruff linting fails when fixing imports sometimes and running ruff format after checking code helps.
+**Action:** Next time prefer modifying core extraction utility rather than trying to replicate same logic on callers and running checks multiple times.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -22,13 +22,13 @@ ADMIN: Role = "admin"
 Scope = NewType("Scope", str)
 
 
-def parse_scopes(raw: str) -> list[Scope]:
-    """Parse a comma-separated scope string into an ordered, de-duplicated list.
+def parse_scopes(*raw: str) -> list[Scope]:
+    """Parse comma-separated scope strings into an ordered, de-duplicated list.
 
     Whitespace around each scope is trimmed and empty entries are dropped.
     Insertion order is preserved so serialisation round-trips stably.
     """
-    cleaned = (part.strip() for part in raw.split(","))
+    cleaned = (part.strip() for r in raw if r for part in r.split(","))
     return [Scope(part) for part in dict.fromkeys(p for p in cleaned if p)]
 
 

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -84,7 +84,7 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[Scope] = {Scope(s.strip()) for s in scopes if s.strip()}
+    needed: set[Scope] = set(parse_scopes(*scopes))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
         if missing := missing_scopes(parse_scopes(user.scopes), needed):

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import Scope, parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -142,9 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        for scope in args.scope:
-            existing.append(Scope(scope.strip()))
+        existing = parse_scopes(user.scopes, *args.scope)
         user.scopes = serialize_scopes(existing)
         session.commit()
         session.refresh(user)
@@ -163,7 +161,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        to_remove = {s.strip() for s in args.scope}
+        to_remove = set(parse_scopes(*args.scope))
         remaining = [s for s in existing if s not in to_remove]
         user.scopes = serialize_scopes(remaining)
         session.commit()

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -28,6 +28,9 @@ class TestScopes:
     def test_parse_deduplicates_preserving_order(self):
         assert parse_scopes("a,b,a,c,b") == [Scope("a"), Scope("b"), Scope("c")]
 
+    def test_parse_multiple_args(self):
+        assert parse_scopes("a,b", " c , d ", "e") == [Scope("a"), Scope("b"), Scope("c"), Scope("d"), Scope("e")]
+
     def test_parse_empty_string_yields_empty_list(self):
         assert parse_scopes("") == []
         assert parse_scopes("   ") == []

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -29,7 +29,13 @@ class TestScopes:
         assert parse_scopes("a,b,a,c,b") == [Scope("a"), Scope("b"), Scope("c")]
 
     def test_parse_multiple_args(self):
-        assert parse_scopes("a,b", " c , d ", "e") == [Scope("a"), Scope("b"), Scope("c"), Scope("d"), Scope("e")]
+        assert parse_scopes("a,b", " c , d ", "e") == [
+            Scope("a"),
+            Scope("b"),
+            Scope("c"),
+            Scope("d"),
+            Scope("e"),
+        ]
 
     def test_parse_empty_string_yields_empty_list(self):
         assert parse_scopes("") == []


### PR DESCRIPTION
💡 What
Updated `parse_scopes` to accept `*raw: str` varargs, centralizing the processing, trimming, and strict deduplication of comma-separated scope strings. Replaced multi-step loops and explicit parsing pipelines in CLI user mutations (`users.py`) and FastAPI dependencies (`dependencies.py`) with this single pure helper.

🎯 Why
By accepting variadic arguments in the normalizer, we drastically reduce repeated iteration and parsing code across the API and CLI modules. Previously, `_cmd_users_scopes_add` bypassed deduplication by explicitly appending manually to a parsed list; this refactoring mitigates the latent bug where multiple duplicate scopes could accumulate.

🧠 Design
`parse_scopes` is already the source of truth for parsing scope strings. Upgrading it to take multiple strings and parsing/flattening them natively prevents callers from needing custom collection logic. 

λ FP Angle
This removes mutable append loops (e.g. `existing.append(...)`) in favor of deterministic data-in/data-out functional transformation (`existing = parse_scopes(user.scopes, *args.scope)`).

✅ Verification
Ran full `uv run --locked pytest -v` test suite which passes perfectly.

🧪 Edge cases
Covered edge cases like `parse_scopes("a,b", " c, d ", "e")` to prove spacing, multi-args, and commas inside single args all resolve safely into an ordered, deduplicated list. 

⚠️ Risk
Minimal risk. All call sites that passed exactly one argument continue working normally. The return type and structural integrity of the `Scope` objects remain identical.

---
*PR created automatically by Jules for task [14319205550747044794](https://jules.google.com/task/14319205550747044794) started by @ToolchainLab*