### PR TITLE
🧭 Atlas: Replace hand-written env var list with generated list from config loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN GENERATED ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
@@ -175,6 +176,24 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default background job queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend to use (`file`, `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default From address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for the file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP server username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP server password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
+<!-- END GENERATED ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env.py
+++ b/scripts/check_doc_env.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that the configuration env vars in README.md are up to date.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env.py
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+GENERATOR = REPO_ROOT / "scripts" / "generate_doc_env.py"
+
+START_MARKER = "<!-- BEGIN GENERATED ENV VARS -->"
+END_MARKER = "<!-- END GENERATED ENV VARS -->"
+
+
+def main() -> int:
+    readme_text = README.read_text()
+
+    # Run the generator
+    result = subprocess.run(
+        [sys.executable, str(GENERATOR)], capture_output=True, text=True, check=True
+    )
+    generated_content = result.stdout.strip()
+
+    pattern = re.compile(rf"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}", re.DOTALL)
+
+    match = pattern.search(readme_text)
+    if not match:
+        print(f"❌ Could not find {START_MARKER} in README.md")
+        return 1
+
+    current_content = match.group(0)
+
+    if current_content != generated_content:
+        print(
+            "❌ Env vars in README.md are out of date. Run `uv run scripts/sync_doc_env.py` "
+            "to fix."
+        )
+        return 1
+
+    print("✅ Env vars in README.md are up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_doc_env.py
+++ b/scripts/generate_doc_env.py
@@ -13,7 +13,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-from pydantic.fields import FieldInfo
+from pydantic.fields import FieldInfo  # noqa: E402
 
 
 def format_default(field_info: FieldInfo) -> str:

--- a/scripts/generate_doc_env.py
+++ b/scripts/generate_doc_env.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention generator: output markdown table of configuration env vars.
+
+Usage (from repo root):
+    uv run scripts/generate_doc_env.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+from pydantic.fields import FieldInfo
+
+
+def format_default(field_info: FieldInfo) -> str:
+    default = field_info.default
+    if default == "":
+        return "empty"
+    elif isinstance(default, bool):
+        return f"`{str(default).lower()}`"
+    elif isinstance(default, list):
+        return "`[]`"
+    return f"`{default}`"
+
+
+def get_description(field_name: str) -> str:
+    descriptions = {
+        "env": "`development` or `production`",
+        "database_url": "SQLAlchemy connection string",
+        "auto_upgrade": "Auto-run packaged DB migrations to head on startup",
+        "rp_id": "WebAuthn relying party ID, required in production",
+        "origin": "WebAuthn origin, required in production",
+        "webauthn_ttl_seconds": "WebAuthn challenge TTL in seconds",
+        "user_verification": "WebAuthn user verification requirement",
+        "attestation": "WebAuthn attestation preference",
+        "password_auth_enabled": "Enable password routes when the extra is installed",
+        "password_reset_expire_minutes": "Password reset token expiry in minutes",
+        "bootstrap_admin_emails": "JSON list of emails that become admin on password signup",
+        "first_user_is_admin": "First password signup becomes admin",
+        "openai_api_key": "OpenAI API key for the LLM wrapper",
+        "redis_url": "Redis connection string (optional)",
+        "jobs_inline_in_dev": "Run background jobs inline in development",
+        "jobs_default_queue": "Default background job queue name",
+        "storage_backend": "Storage backend (`local`)",
+        "storage_dir": "Local directory for storage backend",
+        "max_upload_bytes": "Maximum upload size in bytes",
+        "app_base_url": "Base URL of the frontend application",
+        "email_backend": "Email backend to use (`file`, `smtp`)",
+        "email_from": "Default From address for emails",
+        "email_outbox_dir": "Directory for the file email backend",
+        "smtp_host": "SMTP server host",
+        "smtp_port": "SMTP server port",
+        "smtp_username": "SMTP server username",
+        "smtp_password": "SMTP server password",
+        "smtp_starttls": "Use STARTTLS for SMTP",
+        "smtp_ssl": "Use SSL for SMTP",
+        "demo_mode": "Enable demo mode",
+    }
+    return descriptions.get(field_name, "")
+
+
+def main() -> int:
+    # Add src to sys.path to allow importing h4ckath0n
+    src_path = REPO_ROOT / "src"
+    sys.path.insert(0, str(src_path))
+
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    lines = [
+        "<!-- BEGIN GENERATED ENV VARS -->",
+        "| Variable | Default | Description |",
+        "|---|---|---|",
+    ]
+
+    for field_name, field_info in Settings.model_fields.items():
+        if field_name == "openai_api_key":
+            lines.append(f"| `OPENAI_API_KEY` | empty | {get_description(field_name)} |")
+            lines.append(
+                f"| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate {get_description(field_name)} |"
+            )
+            continue
+
+        env_var = f"H4CKATH0N_{field_name.upper()}"
+        default_val = format_default(field_info)
+
+        # Check if there are specific overrides
+        if field_name == "rp_id":
+            default_val = "`localhost` in development"
+        elif field_name == "origin":
+            default_val = "`http://localhost:8000` in development"
+
+        desc = get_description(field_name)
+        lines.append(f"| `{env_var}` | {default_val} | {desc} |")
+
+    lines.append("<!-- END GENERATED ENV VARS -->")
+
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_doc_env.py
+++ b/scripts/sync_doc_env.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention script: sync the environment variables table in README.md.
+
+Usage (from repo root):
+    uv run scripts/sync_doc_env.py
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+GENERATOR = REPO_ROOT / "scripts" / "generate_doc_env.py"
+
+START_MARKER = "<!-- BEGIN GENERATED ENV VARS -->"
+END_MARKER = "<!-- END GENERATED ENV VARS -->"
+
+
+def main() -> int:
+    readme_text = README.read_text()
+
+    # Run the generator
+    result = subprocess.run(
+        [sys.executable, str(GENERATOR)], capture_output=True, text=True, check=True
+    )
+    generated_content = result.stdout.strip()
+
+    pattern = re.compile(rf"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}", re.DOTALL)
+
+    if pattern.search(readme_text):
+        # Update existing
+        new_text = pattern.sub(generated_content, readme_text)
+        if new_text != readme_text:
+            README.write_text(new_text)
+            print("✅ Updated README.md with latest env vars.")
+        else:
+            print("✅ README.md env vars are already up to date.")
+    else:
+        print(f"❌ Could not find {START_MARKER} in README.md")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 **What**: Replaced the manually maintained list of environment variables in `README.md` with an automatically generated markdown table produced directly from `h4ckath0n.config.Settings`. Added drift-prevention scripts and CI enforcement.

🎯 **Why**: The configuration list in `README.md` was missing 17 environment variables (e.g., Redis, Email, Storage, Jobs config). Hard-coding configuration facts in markdown invariably leads to drift as the codebase evolves, causing frustration and misconfiguration during onboarding.

🧪 **Verification**:
- Locally run `uv run --locked ruff check .`, `uv run --locked ruff format .`, `uv run --locked mypy src`, and `uv run --locked pytest -v` (all passed).
- Verify drift check with `uv run --locked scripts/check_doc_env.py` (passes locally).

🔒 **Drift Prevention**: Added `scripts/check_doc_env.py` which fails if the table in `README.md` does not exactly match the generated output from the `Settings` model. This check is now integrated into the `backend` job of `.github/workflows/ci.yml`.

🗺️ **Evidence**:
- `src/h4ckath0n/config.py` (Source of truth for environment variables)
- `.github/workflows/ci.yml` (Where the verification is enforced)

---
*PR created automatically by Jules for task [3548039200000059194](https://jules.google.com/task/3548039200000059194) started by @ToolchainLab*