### PR TITLE
🎨 Palette: [Add ARIA labels to mobile navigation]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-07-08 - Duplicate UI Element Testing
+**Learning:** When fixing accessibility by adding ARIA labels to duplicate UI elements (like desktop/mobile menus), React Testing Library queries must be updated from getByRole to getAllByRole(...)[0]! to prevent 'multiple elements found' test failures.
+**Action:** Anticipate test breakage when fixing a11y on responsive components with duplicate mobile/desktop variants and proactively update test queries.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0]!,
       ).toBeInTheDocument();
     });
 
@@ -91,8 +91,8 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+        screen.queryAllByRole("button", { name: /Theme: system/ }).length,
+      ).toBe(0);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -192,6 +192,11 @@ export function Layout() {
                 size="icon"
                 onClick={toggleTheme}
                 className="mr-2"
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
               >
                 {effectiveTheme === "dark" ? (
                   <Sun className="w-4 h-4" />
@@ -203,6 +208,8 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+                aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the mobile theme toggle and mobile menu buttons. Also added the `aria-expanded` attribute to the mobile menu toggle in `Layout.tsx`.
🎯 **Why**: The mobile theme toggle and menu toggle were icon-only buttons without accessible names, making them difficult for screen reader users to understand. Adding `aria-expanded` correctly communicates the state of the mobile menu.
📸 **Before/After**: Visually identical. Under the hood, these icon buttons are now fully accessible.
♿ **Accessibility**: Fixed missing ARIA labels and roles for screen reader friendliness, making navigation components robust across device sizes. Also proactively updated React Testing Library tests that expect duplicate UI components on the page.

---
*PR created automatically by Jules for task [2250673630765743058](https://jules.google.com/task/2250673630765743058) started by @ToolchainLab*