### PR TITLE
🧭 Atlas: [Document missing configuration variables and add drift check]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc config
+        run: uv run --locked scripts/check_doc_config.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Pydantic settings drift in README documentation
+**Learning:** The configuration variables derived from `pydantic-settings` easily drift from `README.md` as new features (like Redis, Storage, and Email support) are added to the `Settings` class without corresponding documentation updates.
+**Action:** Implement a configuration drift-check script (`check_doc_config.py`) that iterates over `Settings.model_fields` and ensures every expected environment variable (with prefix `H4CKATH0N_`) appears in the `README.md`.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local storage backend |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend application |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default from address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host for email backend |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_config.py
+++ b/scripts/check_doc_config.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every configuration variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_config.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    from h4ckath0n.config import Settings  # noqa: E402
+
+    readme_text = README.read_text(encoding="utf-8")
+    missing: list[str] = []
+
+    for key in Settings.model_fields:
+        env_var_name = f"H4CKATH0N_{key.upper()}"
+        if key == "openai_api_key":
+            if not re.search(r"`OPENAI_API_KEY`", readme_text):
+                missing.append("OPENAI_API_KEY")
+            continue
+
+        if not re.search(rf"`{env_var_name}`", readme_text):
+            missing.append(env_var_name)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_var in missing:
+            print(f"  {env_var}")
+        print("\nAdd these variables to the Configuration table in README.md.")
+        return 1
+
+    print(
+        f"✅ All {len(Settings.model_fields)} configuration variables are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added all missing configuration environment variables to `README.md` (e.g. Redis, storage, email settings). Created a `check_doc_config.py` script to enforce that every variable in `Settings` is documented, and wired it into `ci.yml`.
🎯 Why: Over time, new configuration options were added to `Settings` but missing in the docs. This left new contributors unaware of how to configure features like background jobs, uploads, or SMTP email. This drift leads to bad onboarding experience and misconfiguration.
🧪 Verification: Ran `uv run --locked scripts/check_doc_config.py` which passes successfully, confirming parity.
🔒 Drift Prevention: Added `scripts/check_doc_config.py` to the `backend` CI pipeline, forcing future PRs that add variables to `Settings.model_fields` to document them in `README.md`.
🗺️ Evidence: Used `src/h4ckath0n/config.py` (`Settings.model_fields`) as the authoritative source of truth.

---
*PR created automatically by Jules for task [6061023844915387203](https://jules.google.com/task/6061023844915387203) started by @ToolchainLab*