### PR TITLE
⚡ Bolt: Avoid PEM serialization overhead in device JWT decoding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2024-07-09 - Avoid PyJWT public key PEM serialization
+**Learning:** When using `pyjwt` to decode JWTs with `cryptography` elliptic curve public keys (e.g., `ECAlgorithm`), serializing the key to a PEM string (`public_bytes().decode()`) before passing to `jwt.decode` introduces redundant parsing overhead and decreases CPU performance in hot paths. The native key object can and should be passed directly to `jwt.decode`.
+**Action:** Always pass the native cryptography key object directly to `jwt.decode` instead of serializing it to a string.

--- a/src/h4ckath0n/auth/jwt.py
+++ b/src/h4ckath0n/auth/jwt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 
 import jwt
 from pydantic import BaseModel
@@ -25,12 +26,12 @@ class JWTClaims(BaseModel):
 def decode_device_token(
     token: str,
     *,
-    public_key_pem: str,
+    public_key: Any,
 ) -> JWTClaims:
     """Decode an ES256 device-signed JWT using the device's public key."""
     payload = jwt.decode(
         token,
-        public_key_pem,
+        public_key,
         algorithms=["ES256"],
         options={"verify_aud": False},
         leeway=timedelta(seconds=30),  # allow some clock skew

--- a/src/h4ckath0n/realtime/auth.py
+++ b/src/h4ckath0n/realtime/auth.py
@@ -12,7 +12,6 @@ import json
 from dataclasses import dataclass
 
 import jwt
-from cryptography.hazmat.primitives import serialization
 from fastapi import WebSocket
 from jwt.algorithms import ECAlgorithm
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -91,15 +90,11 @@ async def verify_device_jwt(
     try:
         jwk_dict = json.loads(device.public_key_jwk)
         public_key = ECAlgorithm(ECAlgorithm.SHA256).from_jwk(jwk_dict)
-        pem = public_key.public_bytes(  # type: ignore[union-attr]
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode()
     except (ValueError, KeyError, TypeError):
         raise AuthError("Invalid device key") from None
 
     try:
-        claims = decode_device_token(raw_jwt, public_key_pem=pem)
+        claims = decode_device_token(raw_jwt, public_key=public_key)
     except jwt.ExpiredSignatureError:
         raise AuthError("Token expired") from None
     except jwt.InvalidTokenError:


### PR DESCRIPTION
💡 What: Pass the parsed cryptography public key object directly to `jwt.decode` in `decode_device_token` instead of serializing it to a PEM string.
🎯 Why: Serializing the key to a PEM string using `.public_bytes(...)` adds redundant parsing and serialization overhead inside PyJWT during token validation, which happens in a hot path (device JWT verification).
📊 Impact: Eliminates a redundant PEM serialization/deserialization step, reducing CPU overhead during token validation.
🔬 Measurement: Microbenchmarks on SECP256R1 verify that passing the object directly to `jwt.decode` reduces the time per operation compared to passing the PEM string.

---
*PR created automatically by Jules for task [7052725065119292867](https://jules.google.com/task/7052725065119292867) started by @ToolchainLab*