### PR TITLE
🧭 Atlas: Document all configuration environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Env vars configuration drift
+**Learning:** There was a documentation gap where configuration environment variables available via `pydantic-settings` were not documented in the README. We can introspect Pydantic V2 `BaseSettings` via `.model_fields` and extract all env vars.
+**Action:** Add a drift-prevention script that parses `Settings.model_fields` to automatically detect missing env var docs and run it in CI to prevent regression.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development without queue |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file storage |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum allowed upload size in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend app |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server hostname |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode (restricts certain actions) |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every env var in the config is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from h4ckath0n.config import Settings  # noqa: E402
+
+
+def main() -> int:
+    readme_text = README.read_text()
+    missing: list[str] = []
+
+    for name in Settings.model_fields:
+        env_name = f"H4CKATH0N_{name.upper()}"
+        if f"`{env_name}`" not in readme_text:
+            missing.append(env_name)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for m in missing:
+            print(f"  {m}")
+        print("\nAdd these variables to the Configuration section in README.md.")
+        return 1
+
+    print("✅ All configuration environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**💡 What:** Documented all 17 previously undocumented configuration environment variables (like `H4CKATH0N_REDIS_URL`, `H4CKATH0N_STORAGE_BACKEND`, etc.) in `README.md` and added a script that verifies docs coverage for all `Settings.model_fields`.

**🎯 Why:** The `pydantic-settings` model defined many more configuration options than were documented. This causes confusion for new users trying to configure features like local storage, SMTP email, or background jobs. The new CI script ensures that any future additions to `Settings` will break CI if not documented.

**🧪 Verification:** 
- `uv run scripts/check_doc_env_vars.py` passes locally.
- Tests pass (`uv run --locked pytest -v`).
- Lints pass (`uv run --locked ruff check .`).

**🔒 Drift Prevention:** Added `scripts/check_doc_env_vars.py`, which introspects the Pydantic `Settings.model_fields` and asserts that every generated environment variable string is present in `README.md`. This script has been added to `.github/workflows/ci.yml`.

**🗺️ Evidence:** The source of truth for configuration is `src/h4ckath0n/config.py` (`Settings` class).

---
*PR created automatically by Jules for task [10857153595615683427](https://jules.google.com/task/10857153595615683427) started by @ToolchainLab*