### PR TITLE
∴ Vector: Centralize display name validation logic

### DIFF
--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin
+from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, clean_required_string
 
 # -- Registration --
 
@@ -22,10 +22,7 @@ class PasskeyRegisterStartRequest(BaseModel):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return clean_required_string(v, "Display name")
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-from h4ckath0n.auth.schemas import DISPLAY_NAME_MAX_LENGTH, DeviceBindingMixin, clean_required_string
+from h4ckath0n.auth.schemas import (
+    DISPLAY_NAME_MAX_LENGTH,
+    DeviceBindingMixin,
+    clean_required_string,
+)
 
 # -- Registration --
 

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -20,6 +20,14 @@ def _validate_display_name(v: str | None) -> str | None:
     return v
 
 
+def clean_required_string(v: str, field_name: str) -> str:
+    """Trim whitespace and reject empty-after-trim values for required fields."""
+    v = v.strip()
+    if not v:
+        raise ValueError(f"{field_name} must not be empty")
+    return v
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -40,10 +48,7 @@ class RegisterRequest(DeviceBindingMixin):
     @field_validator("display_name")
     @classmethod
     def _clean_display_name(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Display name must not be empty")
-        return v
+        return clean_required_string(v, "Display name")
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Extracted duplicated validation logic for `display_name` into a pure reusable helper `clean_required_string`.
- 🎯 Why: To reduce duplication and provide a single source of truth for normalizing and validating required string fields.
- 🧠 Design: Replaced identical inline logic in two Pydantic `@field_validator` methods with a call to the new `clean_required_string` helper in `src/h4ckath0n/auth/schemas.py`.
- λ FP Angle: Reduces scattered mutation-heavy validation logic in favor of a centralized pure transformation/validation helper with a sharper contract.
- ✅ Verification: Ran `uv run --locked pytest -v tests`, ensuring all existing auth and passkey validation tests continue to pass.
- 🧪 Edge cases: Preserved exact identical behavior for edge cases like whitespace-only inputs and empty inputs.
- ⚠️ Risk: Extremely low risk. The exact same ValueError string and behavior is maintained.

---
*PR created automatically by Jules for task [6494313426644573253](https://jules.google.com/task/6494313426644573253) started by @ToolchainLab*