### PR TITLE
⚡ Bolt: Use db.get() for primary key lookups

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -358,13 +358,9 @@ async def rename_passkey(
     Raises :class:`PasskeyNotFoundError` if not found / not owned and
     :class:`PasskeyRevokedError` if the credential is revoked.
     """
-    result = await db.execute(
-        select(WebAuthnCredential).filter(
-            WebAuthnCredential.id == key_id,
-            WebAuthnCredential.user_id == user.id,
-        )
-    )
-    if (cred := result.scalars().first()) is None:
+    if (cred := await db.get(WebAuthnCredential, key_id)) is None:
+        raise PasskeyNotFoundError
+    if cred.user_id != user.id:
         raise PasskeyNotFoundError
     if cred.revoked_at is not None:
         raise PasskeyRevokedError
@@ -395,13 +391,9 @@ async def revoke_passkey(db: AsyncSession, user: User, key_id: str) -> None:
         # Per-user mutex. In SQLite, FOR UPDATE is ignored (acceptable for dev/tests).
         await db.execute(select(User.id).filter(User.id == user.id).with_for_update())
 
-        result = await db.execute(
-            select(WebAuthnCredential).filter(
-                WebAuthnCredential.id == key_id,
-                WebAuthnCredential.user_id == user.id,
-            )
-        )
-        if (cred := result.scalars().first()) is None:
+        if (cred := await db.get(WebAuthnCredential, key_id)) is None:
+            raise PasskeyNotFoundError
+        if cred.user_id != user.id:
             raise PasskeyNotFoundError
         if cred.revoked_at is not None:
             raise PasskeyAlreadyRevokedError

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -165,11 +165,10 @@ def _resolve_user(session: Session, args: argparse.Namespace) -> User | None:
         return None
 
     if user_id:
-        stmt = select(User).where(User.id == user_id)
+        return session.get(User, user_id)
     else:
         stmt = select(User).where(User.email == email)
-
-    return session.execute(stmt).scalars().first()
+        return session.execute(stmt).scalars().first()
 
 
 def _user_or_exit(session: Session, args: argparse.Namespace) -> tuple[User | None, int | None]:


### PR DESCRIPTION
**💡 What:**
Replaced `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` queries with `await db.get(Model, pk)` across the codebase (specifically in `WebAuthnCredential` and `User` lookups).

**🎯 Why:**
Using `.filter(Model.id == pk)` forces a roundtrip to the database and full ORM hydration every time. `db.get()` first checks the SQLAlchemy session's Identity Map. If the object was already fetched earlier in the request lifecycle, this completely eliminates the database query and parsing overhead.

**📊 Impact:**
Reduces database query load and memory allocation in hot paths like CLI lookups and passkey renaming/revoking. For cached entities, lookup time drops from network latency (ms) to hash map access (ns).

**🔬 Measurement:**
Verified by running `uv run --locked pytest -v` (all tests passed), along with strict `mypy` type checking and `ruff` linting.

---
*PR created automatically by Jules for task [10412721720121154800](https://jules.google.com/task/10412721720121154800) started by @ToolchainLab*