### PR TITLE
🎨 Palette: [UX improvement] Add accessibility attributes to mobile navigation buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-10 - Duplicated UI Accessibility Pattern
+**Learning:** When duplicate interactive elements (like desktop/mobile toggles) share the same accessible name, it creates 'multiple elements found' errors in testing libraries.
+**Action:** Use `getAllByRole(...)[0]` in tests to resolve the error while preserving the valid a11y label.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.test.tsx
@@ -49,7 +49,7 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("system");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: system (dark)" }),
+        screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -58,14 +58,14 @@ describe("Layout theme preference", () => {
     mockMatchMedia(true);
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: system (dark)" });
+    const button = screen.getAllByRole("button", { name: "Theme: system (dark)" })[0]!;
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.getByRole("button", { name: "Theme: light" }),
+        screen.getAllByRole("button", { name: "Theme: light" })[0]!,
       ).toBeInTheDocument();
     });
   });
@@ -75,14 +75,14 @@ describe("Layout theme preference", () => {
     localStorage.setItem("theme-preference", "light");
     renderLayout();
 
-    const button = screen.getByRole("button", { name: "Theme: light" });
+    const button = screen.getAllByRole("button", { name: "Theme: light" })[0]!;
 
     fireEvent.click(button);
     await waitFor(() => {
       expect(localStorage.getItem("theme-preference")).toBe("dark");
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
       expect(
-        screen.getByRole("button", { name: "Theme: dark" }),
+        screen.getAllByRole("button", { name: "Theme: dark" })[0]!,
       ).toBeInTheDocument();
     });
 
@@ -91,8 +91,8 @@ describe("Layout theme preference", () => {
       expect(localStorage.getItem("theme-preference")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
       expect(
-        screen.queryByRole("button", { name: /Theme: system/ }),
-      ).not.toBeInTheDocument();
+        screen.queryAllByRole("button", { name: /Theme: system/ }).length,
+      ).toBe(0);
     });
   });
 });

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -191,6 +191,11 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={toggleTheme}
+                aria-label={
+                  themePreference === "system"
+                    ? `Theme: system (${effectiveTheme})`
+                    : `Theme: ${themePreference}`
+                }
                 className="mr-2"
               >
                 {effectiveTheme === "dark" ? (
@@ -203,6 +208,9 @@ export function Layout() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+                aria-expanded={isMobileMenuOpen}
+                aria-controls="mobile-menu"
               >
                 {isMobileMenuOpen ? (
                   <X className="w-5 h-5" />
@@ -216,7 +224,7 @@ export function Layout() {
 
         {/* Mobile Navigation */}
         {isMobileMenuOpen && (
-          <div className="md:hidden border-t border-border bg-surface">
+          <div id="mobile-menu" className="md:hidden border-t border-border bg-surface">
             <div className="px-4 py-4 space-y-2">
               {isAuthenticated ? (
                 <>


### PR DESCRIPTION
**💡 What:** 
Added `aria-label`, `aria-expanded`, and `aria-controls` to the mobile navigation toggle, and an `aria-label` to the mobile theme toggle in the `Layout` component.

**🎯 Why:**
The mobile hamburger menu and mobile theme toggle are icon-only buttons, making them inaccessible to screen readers without proper labels. Adding ARIA attributes ensures keyboard and screen reader users can identify the buttons and understand their interactive state (expanded/collapsed).

**📸 Before/After:**
*(Visual change only in screen reader output; UI styling remains identical)*

**♿ Accessibility:**
- Icon-only mobile buttons now announce properly to screen readers.
- The hamburger menu announces its open/closed state via `aria-expanded`.
- The `aria-controls` explicitly links the menu button to the dropdown.
- Addressed duplicate valid names in `Layout.test.tsx` by targeting `getAllByRole(...)[0]`.

---
*PR created automatically by Jules for task [2922837636123886008](https://jules.google.com/task/2922837636123886008) started by @ToolchainLab*