### PR TITLE
🧭 Atlas: Document missing configuration environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc env vars
+        run: uv run --locked scripts/check_doc_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Pydantic settings are prone to undocumented environment variables
+
+**Learning:** Configuration drift commonly happens when fields are added to `Settings` (pydantic-settings) but are not added to `README.md`. It is crucial to have a drift prevention check that ensures all fields mapped to environment variables are explicitly mentioned in the documentation.
+**Action:** Iterate over the `Settings.model_fields` dictionary to construct the expected environment variable names and ensure they appear in the markdown documentation.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string for background jobs (optional) |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline during development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads (`local` supported) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Directory for local file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum file size for uploads in bytes |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the frontend app (used in emails) |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address for emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file-based email outbox |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
 

--- a/scripts/check_doc_env_vars.py
+++ b/scripts/check_doc_env_vars.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every env var in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env_vars.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_env_vars() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    env_vars = []
+    for key in Settings.model_fields:
+        env_vars.append(f"H4CKATH0N_{key.upper()}")
+
+    return sorted(env_vars)
+
+
+def check_env_vars_in_readme(env_vars: list[str]) -> list[str]:
+    readme_text = README.read_text()
+    missing: list[str] = []
+    for var in env_vars:
+        if f"`{var}`" not in readme_text:
+            missing.append(var)
+    return missing
+
+
+def main() -> int:
+    env_vars = get_env_vars()
+    missing = check_env_vars_in_readme(env_vars)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for var in missing:
+            print(f"  {var}")
+        print("\nAdd these environment variables to the Configuration section in README.md.")
+        return 1
+
+    print(f"✅ All {len(env_vars)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Added missing environment variables from Settings to README.md.
🎯 Why: The configuration documentation had drifted from the actual pydantic settings model, causing ambiguity for users configuring Redis, storage, emails, and demo mode.
🧪 Verification: Run uv run --locked scripts/check_doc_env_vars.py locally.
🔒 Drift Prevention: Added a new script scripts/check_doc_env_vars.py to CI that checks all fields in Settings.model_fields are documented in README.md.
🗺️ Evidence: src/h4ckath0n/config.py was treated as the source of truth.

---
*PR created automatically by Jules for task [87412445650242296](https://jules.google.com/task/87412445650242296) started by @ToolchainLab*