### PR TITLE
∴ Vector: Centralize and harden scope parsing for Iterables

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,5 @@
+## 2025-05-24 - Centralize and Harden Scope Parsing
+
+**Learning:** Scope parsing in `h4ckath0n` involved ad-hoc comma splitting logic scattered across dependencies and CLI handlers. The existing `parse_scopes` was strictly typed for `str`, leading to duplicated manual collection lists and redundant set parsing when building requirements arrays.
+
+**Action:** Upgraded `parse_scopes(str | Iterable[str])` to robustly accept, split, flatten, trim, and deduplicate iterables of scopes. This allows dependencies and CLI wrappers to just feed raw arguments to the central parser without manually breaking strings first. Reduces bugs related to embedded commas in CLI args.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -22,13 +22,14 @@ ADMIN: Role = "admin"
 Scope = NewType("Scope", str)
 
 
-def parse_scopes(raw: str) -> list[Scope]:
-    """Parse a comma-separated scope string into an ordered, de-duplicated list.
+def parse_scopes(raw: str | Iterable[str]) -> list[Scope]:
+    """Parse a comma-separated scope string or iterable into an ordered, de-duplicated list.
 
-    Whitespace around each scope is trimmed and empty entries are dropped.
-    Insertion order is preserved so serialisation round-trips stably.
+    Whitespace around each scope is trimmed, embedded commas are split, and empty entries
+    are dropped. Insertion order is preserved so serialisation round-trips stably.
     """
-    cleaned = (part.strip() for part in raw.split(","))
+    raw_iterable = [raw] if isinstance(raw, str) else raw
+    cleaned = (part.strip() for item in raw_iterable for part in item.split(","))
     return [Scope(part) for part in dict.fromkeys(p for p in cleaned if p)]
 
 

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -84,7 +84,7 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[Scope] = {Scope(s.strip()) for s in scopes if s.strip()}
+    needed: set[Scope] = set(parse_scopes(scopes))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
         if missing := missing_scopes(parse_scopes(user.scopes), needed):

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import Scope, parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,10 +142,8 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        for scope in args.scope:
-            existing.append(Scope(scope.strip()))
-        user.scopes = serialize_scopes(existing)
+        combined = parse_scopes([user.scopes, *args.scope])
+        user.scopes = serialize_scopes(combined)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -163,7 +161,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        to_remove = {s.strip() for s in args.scope}
+        to_remove = set(parse_scopes(args.scope))
         remaining = [s for s in existing if s not in to_remove]
         user.scopes = serialize_scopes(remaining)
         session.commit()

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -32,6 +32,15 @@ class TestScopes:
         assert parse_scopes("") == []
         assert parse_scopes("   ") == []
 
+    def test_parse_iterable_of_strings(self):
+        assert parse_scopes(["a, b", "c", " d, e "]) == [
+            Scope("a"),
+            Scope("b"),
+            Scope("c"),
+            Scope("d"),
+            Scope("e"),
+        ]
+
     def test_serialize_roundtrips(self):
         raw = "admin,demo,reports"
         assert serialize_scopes(parse_scopes(raw)) == raw


### PR DESCRIPTION
💡 What: Upgraded `parse_scopes` to accept `str | Iterable[str]`, allowing it to flatten embedded commas in iterables, and refactored scattered ad-hoc parsing logic to use this centralized utility.

🎯 Why: The previous setup required call sites (like the FastAPI `require_scopes` dependency and CLI commands) to manually map over iterables or perform secondary set manipulations. 

🧠 Design: By letting the single source of truth (`parse_scopes`) handle both bare strings and iterables, we eliminate redundant looping logic in `dependencies.py` and `cli/users.py`, pushing edge-case handling into a well-tested boundary.

λ FP Angle: Moves away from ad-hoc mutation (`for scope in args.scope: existing.append(Scope(scope.strip()))`) toward explicit, pure data-in/data-out transformation (`combined = parse_scopes([user.scopes, *args.scope])`).

✅ Verification: Run `uv run --locked pytest -v`, `uv run --locked ruff check .`, `uv run --locked ruff format .`, and `uv run --locked mypy src`. All green.

🧪 Edge cases: `parse_scopes` now successfully handles lists containing elements with embedded commas (e.g. `["admin, demo", "reports"]`), deduplicates across all elements securely, and trims whitespace cleanly.

⚠️ Risk: Low risk. Safe backwards-compatible change to typing signatures that removes duplication. Tested extensively via pytest suite.

---
*PR created automatically by Jules for task [18210728760567787550](https://jules.google.com/task/18210728760567787550) started by @ToolchainLab*