### PR TITLE
⚡ Bolt: Avoid PEM serialization overhead in JWT validation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-24 - Avoid PEM Serialization in PyJWT
+
+**Learning:** When validating JWTs using `pyjwt` with EC public keys from the `cryptography` library, there is no need to serialize the key to a PEM string (`public_key.public_bytes(...)`). `pyjwt` supports the native `cryptography` key object directly. Serializing to PEM only to have `pyjwt` parse it back into a key object introduces unnecessary serialization and deserialization overhead in high-frequency authentication paths.
+
+**Action:** Always pass native `cryptography` key objects directly to `jwt.decode()` instead of converting them to strings or bytes.

--- a/src/h4ckath0n/auth/jwt.py
+++ b/src/h4ckath0n/auth/jwt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 
 import jwt
 from pydantic import BaseModel
@@ -25,12 +26,12 @@ class JWTClaims(BaseModel):
 def decode_device_token(
     token: str,
     *,
-    public_key_pem: str,
+    public_key: Any,
 ) -> JWTClaims:
     """Decode an ES256 device-signed JWT using the device's public key."""
     payload = jwt.decode(
         token,
-        public_key_pem,
+        public_key,
         algorithms=["ES256"],
         options={"verify_aud": False},
         leeway=timedelta(seconds=30),  # allow some clock skew

--- a/src/h4ckath0n/realtime/auth.py
+++ b/src/h4ckath0n/realtime/auth.py
@@ -12,7 +12,6 @@ import json
 from dataclasses import dataclass
 
 import jwt
-from cryptography.hazmat.primitives import serialization
 from fastapi import WebSocket
 from jwt.algorithms import ECAlgorithm
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -91,15 +90,11 @@ async def verify_device_jwt(
     try:
         jwk_dict = json.loads(device.public_key_jwk)
         public_key = ECAlgorithm(ECAlgorithm.SHA256).from_jwk(jwk_dict)
-        pem = public_key.public_bytes(  # type: ignore[union-attr]
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode()
     except (ValueError, KeyError, TypeError):
         raise AuthError("Invalid device key") from None
 
     try:
-        claims = decode_device_token(raw_jwt, public_key_pem=pem)
+        claims = decode_device_token(raw_jwt, public_key=public_key)
     except jwt.ExpiredSignatureError:
         raise AuthError("Token expired") from None
     except jwt.InvalidTokenError:


### PR DESCRIPTION
💡 What:
Removed the PEM serialization of the `cryptography` EC public key in `verify_device_jwt`, passing the key object directly to `jwt.decode` (via `decode_device_token`).

🎯 Why:
`pyjwt` supports native `cryptography` key objects natively. Serializing the object to a PEM string only for `pyjwt` to immediately parse it back into a usable object introduces unnecessary serialization/deserialization CPU overhead in a high-frequency code path (device authentication). 

📊 Impact:
Micro-optimization: Eliminates unnecessary CPU cycles and memory allocations per authenticated realtime/HTTP request that uses a device JWT.

🔬 Measurement:
Run the application backend tests and `test_realtime.py` test suite. The JWT logic remains identically correct and all tests pass.

---
*PR created automatically by Jules for task [12359687602308404067](https://jules.google.com/task/12359687602308404067) started by @ToolchainLab*