### PR TITLE
🧭 Atlas: [docs] Add drift prevention for API routes and env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc envs
+        run: uv run --locked scripts/check_doc_envs.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2025-03-01 - Fix doc drift prevention mechanisms
+**Learning:** In FastAPI >= 0.115.0, `app.routes` no longer reliably exposes nested included routes. Pydantic `BaseSettings` configurations are also highly susceptible to drift, requiring an automated parser using `Settings.model_fields` and string matching against the docs.
+**Action:** Use `app.openapi().get('paths', {})` instead of `app.routes` for authoritative API route enumeration. Enforce environment variable drift prevention by generating and checking all possible names against markdown docs in CI.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection URL |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue name |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend for uploads |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for file uploads |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Maximum upload size in bytes (50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Default sender address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Local directory for file-based emails |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use implicit SSL/TLS for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode restrictions |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
 

--- a/scripts/check_doc_envs.py
+++ b/scripts/check_doc_envs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_envs.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_expected_envs() -> list[str]:
+    from h4ckath0n.config import Settings
+
+    envs = []
+    for key in Settings.model_fields:
+        prefix = Settings.model_config.get("env_prefix", "")
+        envs.append((prefix + key).upper())
+    return envs
+
+
+def check_envs_in_readme(envs: list[str]) -> list[str]:
+    readme_text = README.read_text(encoding="utf-8")
+    missing = []
+    for env in envs:
+        pattern = rf"`{env}`"
+        if not re.search(pattern, readme_text):
+            missing.append(env)
+    return missing
+
+
+def main() -> int:
+    envs = get_expected_envs()
+    missing = check_envs_in_readme(envs)
+    if "H4CKATH0N_OPENAI_API_KEY" in missing:
+        missing.remove("H4CKATH0N_OPENAI_API_KEY")
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env in missing:
+            print(f"  {env}")
+        print("\nAdd these environment variables to README.md.")
+        return 1
+    print(f"✅ All {len(envs)} environment variables are documented in README.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -34,17 +34,14 @@ def get_app_routes() -> list[tuple[str, str]]:
     app = create_app(settings)
 
     routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    openapi = app.openapi()
+    for path, path_item in openapi.get("paths", {}).items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method in sorted(path_item.keys()):
+            if method.upper() == "HEAD":
                 continue
-            routes.append((method, path))
+            routes.append((method.upper(), path))
     return sorted(routes)
 
 


### PR DESCRIPTION
💡 What: Fixed an issue where `app.routes` failed to surface included routes in FastAPI >= 0.115.0 by switching to `app.openapi().get('paths', {})` for route enumeration. Additionally, created a new CI drift prevention check `check_doc_envs.py` that verifies all configuration keys in Pydantic `Settings.model_fields` are explicitly documented in `README.md`.
🎯 Why: Documentation inevitably drifts from the underlying application logic and configurations over time unless strictly enforced. This eliminates false negatives in API route documentation parity and completely mitigates environment variable drift, significantly reducing onboarding friction caused by undocumented configuration keys.
🧪 Verification: Run `uv run --locked scripts/check_doc_routes.py` and `uv run --locked scripts/check_doc_envs.py` to assert that all current routes and config flags are correctly documented.
🔒 Drift Prevention: Added `check_doc_envs.py` to the GitHub Actions CI workflow to fail tests when a new environment variable is added to `Settings` but missing from the README. Modified the route drift checker to be fully compatible with upstream FastAPI releases.
🗺️ Evidence: Inspected `src/h4ckath0n/config.py` as the source of truth for all configurations and `src/h4ckath0n/app.py` for API routes. Used `README.md` as the main documentation surface to achieve total alignment.

---
*PR created automatically by Jules for task [7747694495830486707](https://jules.google.com/task/7747694495830486707) started by @ToolchainLab*