### PR TITLE
∴ Vector: Centralize scope normalization pipeline

### DIFF
--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -22,13 +22,15 @@ ADMIN: Role = "admin"
 Scope = NewType("Scope", str)
 
 
-def parse_scopes(raw: str) -> list[Scope]:
-    """Parse a comma-separated scope string into an ordered, de-duplicated list.
+def parse_scopes(raw: str | Iterable[str]) -> list[Scope]:
+    """Parse a comma-separated scope string (or iterable) into an ordered, de-duplicated list.
 
     Whitespace around each scope is trimmed and empty entries are dropped.
     Insertion order is preserved so serialisation round-trips stably.
     """
-    cleaned = (part.strip() for part in raw.split(","))
+    if isinstance(raw, str):
+        raw = [raw]
+    cleaned = (part.strip() for r in raw for part in r.split(","))
     return [Scope(part) for part in dict.fromkeys(p for p in cleaned if p)]
 
 

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import Scope, parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,10 +142,8 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        for scope in args.scope:
-            existing.append(Scope(scope.strip()))
-        user.scopes = serialize_scopes(existing)
+        combined = parse_scopes([user.scopes, *args.scope])
+        user.scopes = serialize_scopes(combined)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -163,7 +161,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        to_remove = {s.strip() for s in args.scope}
+        to_remove = set(parse_scopes(args.scope))
         remaining = [s for s in existing if s not in to_remove]
         user.scopes = serialize_scopes(remaining)
         session.commit()

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -32,6 +32,15 @@ class TestScopes:
         assert parse_scopes("") == []
         assert parse_scopes("   ") == []
 
+    def test_parse_iterable_of_strings(self):
+        assert parse_scopes(["a,b", "c", " d , e ", ""]) == [
+            Scope("a"),
+            Scope("b"),
+            Scope("c"),
+            Scope("d"),
+            Scope("e"),
+        ]
+
     def test_serialize_roundtrips(self):
         raw = "admin,demo,reports"
         assert serialize_scopes(parse_scopes(raw)) == raw


### PR DESCRIPTION
- **💡 What:** Enhanced `parse_scopes` in `h4ckath0n.auth.authz` to accept `str | Iterable[str]`. Refactored `_cmd_users_scopes_add` and `_cmd_users_scopes_remove` in `h4ckath0n.cli.users` to use this new capability instead of manually mutating list state. Added a test for the new signature.
- **🎯 Why:** The CLI previously duplicated the logic of splitting, stripping, appending, and deduplicating scopes. Moving this entirely into the domain layer's `parse_scopes` helper enforces a single source of truth for scope string normalization and semantic cleanup.
- **🧠 Design:** I leveraged the existing function but expanded its types to map smoothly over iterables of strings, then flattened and stripped them. The CLI code now simply combines lists and hands them back to the pure helper for processing.
- **λ FP Angle:** This moves the code from an imperative, mutation-heavy style (e.g. iterating over `args.scope` and mutating an `existing` list before serializing) to a declarative, transformation pipeline style where lists are just combined and passed to `parse_scopes` as a pure transformation before serialization.
- **✅ Verification:** Passed the tests, Ruff formatting, Ruff linting, and strictly typed via Mypy.
- **🧪 Edge cases:** Fixed a potential edge case where passing a comma-separated string to the `--scope` CLI flag (`--scope "a, b"`) during an `add` might not have cleanly deduplicated properly due to the ad-hoc appending logic, but now it natively handles it through the `parse_scopes` pipeline. Handled the empty string cases seamlessly.
- **⚠️ Risk:** Low risk. No public APIs broke, the `parse_scopes` type signature was cleanly expanded to handle the new iterable case while perfectly maintaining backwards compatibility for raw string calls.

---
*PR created automatically by Jules for task [15229233693266692187](https://jules.google.com/task/15229233693266692187) started by @ToolchainLab*