### PR TITLE
🧭 Atlas: Implement environment variable and route drift prevention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check env vars
+        run: uv run --locked scripts/check_env_vars.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,11 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-07-12 - FastAPI nested routes hiding in older enumeration methods
+**Learning:** Iterating over `app.routes` in FastAPI >= 0.115.0 misses routes added via `include_router` because they are nested inside `_IncludedRouter` objects. This causes false positives in documentation drift checks.
+**Action:** To accurately enumerate all flattened API paths for drift checks, parse the generated OpenAPI schema (`app.openapi().get('paths', {})`) instead of `app.routes`.
+
+## 2024-07-12 - Ensure Pydantic Settings drift prevention
+**Learning:** Configuration defined in `pydantic-settings` `BaseSettings` classes frequently drifts from the `README.md` documentation when new settings are added without updating the docs.
+**Action:** Implement a CI script that iterates over `Settings.model_fields`, constructs the expected environment variable names, and asserts their explicit presence in the documentation.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run jobs inline in development |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default queue for jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | Storage backend (`local`) |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local storage directory |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max upload size in bytes (50 MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL for the frontend app |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | Email backend (`file` or `smtp`) |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | From email address |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory for file email backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP host for email |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode limitations |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -34,17 +34,12 @@ def get_app_routes() -> list[tuple[str, str]]:
     app = create_app(settings)
 
     routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    paths = app.openapi().get("paths", {})
+    for path, path_item in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
+        for method in sorted(path_item.keys()):
+            routes.append((method.upper(), path))
     return sorted(routes)
 
 

--- a/scripts/check_env_vars.py
+++ b/scripts/check_env_vars.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every Settings field is documented."""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def check_env_vars() -> int:
+    from h4ckath0n.config import Settings
+
+    readme_text = README.read_text()
+    missing = []
+    for field in Settings.model_fields:
+        env_name = f"H4CKATH0N_{field.upper()}"
+        if field == "openai_api_key":
+            if "OPENAI_API_KEY" not in readme_text:
+                missing.append("OPENAI_API_KEY")
+        else:
+            if env_name not in readme_text:
+                missing.append(env_name)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for m in missing:
+            print(f"  {m}")
+        return 1
+    print(
+        f"✅ All {len(Settings.model_fields)} environment variables are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check_env_vars())


### PR DESCRIPTION
💡 What: Added `scripts/check_env_vars.py` to ensure all Pydantic `Settings` environment variables are documented in `README.md`, updated the config table in `README.md`, and fixed a bug in `scripts/check_doc_routes.py` where nested FastAPI routes were hidden in FastAPI >= 0.115.0 by parsing the OpenAPI schema instead.
🎯 Why: Configuration drifts rapidly when new Pydantic settings are added but not documented, causing setup friction. Additionally, newer FastAPI versions hide nested routes in `app.routes`, causing false positives in the existing route drift checker.
🧪 Verification: Locally run `uv run --locked scripts/check_env_vars.py` and `uv run --locked scripts/check_doc_routes.py`. The standard test suite passes (`uv run --locked pytest -v`).
🔒 Drift Prevention: Added `check_env_vars.py` as a required step in the CI backend job to prevent any future undocumented config variables. 
🗺️ Evidence: Used `src/h4ckath0n/config.py` and the FastAPI `app.openapi()` schema as the source of truth for the codebase configuration and routes.

---
*PR created automatically by Jules for task [1555544411173468602](https://jules.google.com/task/1555544411173468602) started by @ToolchainLab*