### PR TITLE
∴ Vector: Centralize scope parsing and array deduplication

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Centralize scope parsing
+**Learning:** `parse_scopes` was being duplicated across CLI handling and route dependencies (e.g., ad-hoc comma splitting and whitespace stripping).
+**Action:** Enhance `parse_scopes` to handle iterables of strings (`str | Iterable[str]`) and route all scope inputs (CLI, variadic dependencies) through it to prevent edge-cases where commas embedded in list items bypass deduplication.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -23,7 +23,7 @@ Scope = NewType("Scope", str)
 
 
 def parse_scopes(raw: str | Iterable[str]) -> list[Scope]:
-    """Parse a comma-separated scope string, or iterable of strings, into an ordered, de-duplicated list.
+    """Parse a scope string (or iterable of strings) into an ordered, de-duplicated list.
 
     Whitespace around each scope is trimmed and empty entries are dropped.
     Insertion order is preserved so serialisation round-trips stably.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -22,13 +22,15 @@ ADMIN: Role = "admin"
 Scope = NewType("Scope", str)
 
 
-def parse_scopes(raw: str) -> list[Scope]:
-    """Parse a comma-separated scope string into an ordered, de-duplicated list.
+def parse_scopes(raw: str | Iterable[str]) -> list[Scope]:
+    """Parse a comma-separated scope string, or iterable of strings, into an ordered, de-duplicated list.
 
     Whitespace around each scope is trimmed and empty entries are dropped.
     Insertion order is preserved so serialisation round-trips stably.
     """
-    cleaned = (part.strip() for part in raw.split(","))
+    if isinstance(raw, str):
+        raw = [raw]
+    cleaned = (part.strip() for item in raw for part in item.split(","))
     return [Scope(part) for part in dict.fromkeys(p for p in cleaned if p)]
 
 

--- a/src/h4ckath0n/auth/dependencies.py
+++ b/src/h4ckath0n/auth/dependencies.py
@@ -84,7 +84,7 @@ def require_admin() -> Any:
 def require_scopes(*scopes: str) -> Any:
     """Dependency that requires the user to have specific scopes (from DB)."""
 
-    needed: set[Scope] = {Scope(s.strip()) for s in scopes if s.strip()}
+    needed: set[Scope] = set(parse_scopes(scopes))
 
     async def _scoped(user: User = Depends(_get_current_user)) -> User:
         if missing := missing_scopes(parse_scopes(user.scopes), needed):

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import Scope, parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -143,9 +143,8 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        for scope in args.scope:
-            existing.append(Scope(scope.strip()))
-        user.scopes = serialize_scopes(existing)
+        to_add = parse_scopes(args.scope)
+        user.scopes = serialize_scopes(existing + to_add)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -163,7 +162,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
         assert user is not None
 
         existing = parse_scopes(user.scopes)
-        to_remove = {s.strip() for s in args.scope}
+        to_remove = set(parse_scopes(args.scope))
         remaining = [s for s in existing if s not in to_remove]
         user.scopes = serialize_scopes(remaining)
         session.commit()

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -32,6 +32,10 @@ class TestScopes:
         assert parse_scopes("") == []
         assert parse_scopes("   ") == []
 
+    def test_parse_iterable_of_strings(self):
+        assert parse_scopes(["admin,demo", "reports"]) == [Scope("admin"), Scope("demo"), Scope("reports")]
+        assert parse_scopes(("  a, b", " c,d  ")) == [Scope("a"), Scope("b"), Scope("c"), Scope("d")]
+
     def test_serialize_roundtrips(self):
         raw = "admin,demo,reports"
         assert serialize_scopes(parse_scopes(raw)) == raw

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -33,8 +33,17 @@ class TestScopes:
         assert parse_scopes("   ") == []
 
     def test_parse_iterable_of_strings(self):
-        assert parse_scopes(["admin,demo", "reports"]) == [Scope("admin"), Scope("demo"), Scope("reports")]
-        assert parse_scopes(("  a, b", " c,d  ")) == [Scope("a"), Scope("b"), Scope("c"), Scope("d")]
+        assert parse_scopes(["admin,demo", "reports"]) == [
+            Scope("admin"),
+            Scope("demo"),
+            Scope("reports"),
+        ]
+        assert parse_scopes(("  a, b", " c,d  ")) == [
+            Scope("a"),
+            Scope("b"),
+            Scope("c"),
+            Scope("d"),
+        ]
 
     def test_serialize_roundtrips(self):
         raw = "admin,demo,reports"


### PR DESCRIPTION
💡 What: Updated `parse_scopes` to accept `str | Iterable[str]` and routed variadic inputs from CLI/dependencies through it.
🎯 Why: Prevents edge-cases where commas embedded in list items bypass deduplication and removes duplicate whitespace stripping logic.
🧠 Design: By allowing `parse_scopes` to normalize lists/tuples seamlessly, we centralize this critical semantics without creating new helper functions.
λ FP Angle: Enhances a pure helper function (`parse_scopes`) to act as the single normalisation pipeline for scope processing, replacing ad-hoc inline iteration at call sites.
✅ Verification: Run `uv run --locked pytest -v`. Added unit tests for list inputs.
🧪 Edge cases: `["a,b", "c"]` properly normalized to `["a", "b", "c"]` instead of evaluating `"a,b"` as a single invalid scope.
⚠️ Risk: None. Existing inputs (strings) are gracefully handled.

---
*PR created automatically by Jules for task [15781986366918749347](https://jules.google.com/task/15781986366918749347) started by @ToolchainLab*