### PR TITLE
⚡ Bolt: Skip unnecessary JWT key PEM serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-18 - Skip Unnecessary JWT Key Serialization
+**Learning:** In hot paths like device JWT authentication (`verify_device_jwt`), parsing an elliptic curve public key and then unnecessarily serializing it back to a PEM string (`public_bytes(encoding=serialization.Encoding.PEM...`) to pass to `pyjwt` introduces measurable redundant CPU overhead. `pyjwt` supports decoding directly with the native `cryptography` key objects.
+**Action:** Pass the native `cryptography` EC key object directly to `jwt.decode()`. Avoid redundantly serializing and deserializing to PEM format in high-frequency validation logic.

--- a/src/h4ckath0n/auth/jwt.py
+++ b/src/h4ckath0n/auth/jwt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 
 import jwt
 from pydantic import BaseModel
@@ -25,12 +26,12 @@ class JWTClaims(BaseModel):
 def decode_device_token(
     token: str,
     *,
-    public_key_pem: str,
+    public_key: Any,
 ) -> JWTClaims:
     """Decode an ES256 device-signed JWT using the device's public key."""
     payload = jwt.decode(
         token,
-        public_key_pem,
+        public_key,
         algorithms=["ES256"],
         options={"verify_aud": False},
         leeway=timedelta(seconds=30),  # allow some clock skew

--- a/src/h4ckath0n/realtime/auth.py
+++ b/src/h4ckath0n/realtime/auth.py
@@ -12,7 +12,6 @@ import json
 from dataclasses import dataclass
 
 import jwt
-from cryptography.hazmat.primitives import serialization
 from fastapi import WebSocket
 from jwt.algorithms import ECAlgorithm
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -91,15 +90,11 @@ async def verify_device_jwt(
     try:
         jwk_dict = json.loads(device.public_key_jwk)
         public_key = ECAlgorithm(ECAlgorithm.SHA256).from_jwk(jwk_dict)
-        pem = public_key.public_bytes(  # type: ignore[union-attr]
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode()
     except (ValueError, KeyError, TypeError):
         raise AuthError("Invalid device key") from None
 
     try:
-        claims = decode_device_token(raw_jwt, public_key_pem=pem)
+        claims = decode_device_token(raw_jwt, public_key=public_key)
     except jwt.ExpiredSignatureError:
         raise AuthError("Token expired") from None
     except jwt.InvalidTokenError:


### PR DESCRIPTION
💡 What: Replaced serialization of `public_key` to a PEM string before validation. Passed the native `cryptography` EC key object directly to `jwt.decode`.
🎯 Why: Serializing and deserializing a PEM string in a hot path (`verify_device_jwt`) incurs redundant CPU overhead.
📊 Impact: Decreases latency in high-traffic endpoints by stripping cryptography serialization overhead.
🔬 Measurement: Benchmark the `verify_device_jwt` hotpath with native key objects versus PEM strings.

---
*PR created automatically by Jules for task [12436530808702797037](https://jules.google.com/task/12436530808702797037) started by @ToolchainLab*