### PR TITLE
🗺️ Atlas: Document environment variables and add drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Check doc environments
+        run: uv run --locked scripts/check_doc_env.py
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,8 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Add drift check for settings environment variables
+
+**Learning:** Environment variables in settings often drift because developers forget to document new config additions. Using Pydantic's `Settings.model_fields` provides an automated way to compare code expectations against README claims.
+**Action:** Always write a check script iterating over `model_fields` to verify environment variable documentation parity when configuration uses Pydantic.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
 | `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
+| `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development mode |
+| `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for background jobs |
+| `H4CKATH0N_STORAGE_BACKEND` | `local` | `local` storage backend |
+| `H4CKATH0N_STORAGE_DIR` | `./.h4ckath0n_storage` | Local directory for uploaded files |
+| `H4CKATH0N_MAX_UPLOAD_BYTES` | `52428800` | Max file upload size in bytes (50MB) |
+| `H4CKATH0N_APP_BASE_URL` | `http://localhost:5173` | Base URL of the app for email links |
+| `H4CKATH0N_EMAIL_BACKEND` | `file` | `file` or `smtp` backend for emails |
+| `H4CKATH0N_EMAIL_FROM` | `noreply@localhost` | Sender address for outgoing emails |
+| `H4CKATH0N_EMAIL_OUTBOX_DIR` | `./.h4ckath0n_email_outbox` | Directory to save emails when using the `file` backend |
+| `H4CKATH0N_SMTP_HOST` | empty | SMTP server host |
+| `H4CKATH0N_SMTP_PORT` | `587` | SMTP server port |
+| `H4CKATH0N_SMTP_USERNAME` | empty | SMTP authentication username |
+| `H4CKATH0N_SMTP_PASSWORD` | empty | SMTP authentication password |
+| `H4CKATH0N_SMTP_STARTTLS` | `true` | Use STARTTLS for SMTP connections |
+| `H4CKATH0N_SMTP_SSL` | `false` | Use SSL for SMTP connections |
+| `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env.py
+++ b/scripts/check_doc_env.py
@@ -22,10 +22,7 @@ def main() -> int:
 
     # We iterate over the dictionary directly to avoid SIM118
     for field_name in Settings.model_fields:
-        if field_name == "env":
-            env_name = "H4CKATH0N_ENV"
-        else:
-            env_name = f"H4CKATH0N_{field_name.upper()}"
+        env_name = "H4CKATH0N_ENV" if field_name == "env" else f"H4CKATH0N_{field_name.upper()}"
 
         if env_name not in readme_text:
             missing.append(env_name)

--- a/scripts/check_doc_env.py
+++ b/scripts/check_doc_env.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S uv run python
+"""Drift-prevention check: verify that every environment variable in Settings is documented.
+
+Usage (from repo root):
+    uv run scripts/check_doc_env.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def main() -> int:
+    from h4ckath0n.config import Settings
+
+    readme_text = README.read_text()
+    missing = []
+
+    # We iterate over the dictionary directly to avoid SIM118
+    for field_name in Settings.model_fields:
+        if field_name == "env":
+            env_name = "H4CKATH0N_ENV"
+        else:
+            env_name = f"H4CKATH0N_{field_name.upper()}"
+
+        if env_name not in readme_text:
+            missing.append(env_name)
+
+    if missing:
+        print("❌ The following environment variables are NOT documented in README.md:\n")
+        for env_name in missing:
+            print(f"  {env_name}")
+        print("\nAdd these to the Configuration section in README.md.")
+        return 1
+
+    print(
+        f"✅ All {len(Settings.model_fields)} environment variables are documented in README.md."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Documented missing environment variables (e.g. Redis, SMTP, Storage, Jobs) in the `README.md` Configuration section.
🎯 Why: The configuration options available in the codebase drifted from the documentation, leaving new developers unaware of available settings and causing ambiguity.
✅ Verification: Ran `uv run --locked scripts/check_doc_env.py` which passes. Also verified the full test and lint suite with `uv run --locked ruff check .`, `uv run --locked pytest -v`, etc.
🔒 Drift Prevention: Added `scripts/check_doc_env.py` which iterates over Pydantic's `Settings.model_fields` and ensures each corresponds to an explicit claim in `README.md`. Bound this script into the `.github/workflows/ci.yml` pipeline.
🖼️ Evidence: `src/h4ckath0n/config.py` (Source of truth for variables), `.github/workflows/ci.yml`, and `README.md`.

---
*PR created automatically by Jules for task [15826729243325913392](https://jules.google.com/task/15826729243325913392) started by @ToolchainLab*