### PR TITLE
🎨 Palette: Improve keyboard focus accessibility in Settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-14 - Keyboard accessibility for custom radio buttons and hidden elements
+**Learning:** Custom UI elements like hidden interactive icons (`opacity-0` revealed on hover) and visually replaced radio buttons (where native `<input>` is `sr-only`) often silently fail keyboard accessibility by lacking focus states.
+**Action:** Always ensure `focus-visible:opacity-100` is applied alongside `hover:opacity-100`, and use `has-[:focus-visible]` on the wrapper label for custom radio button groups to properly highlight the active selection.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -149,7 +149,7 @@ function PasskeyName({
           variant="ghost"
           data-testid="passkey-edit-btn"
           onClick={startEdit}
-          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />
@@ -290,7 +290,7 @@ export function Settings() {
               <label
                 key={option}
                 className={cn(
-                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all",
+                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-offset-2 ring-offset-surface",
                   themePreference === option
                     ? "border-primary bg-primary/5"
                     : "border-border",


### PR DESCRIPTION
💡 What: Added keyboard focus styles to custom UI elements in Settings.tsx. Specifically, added `focus-visible:opacity-100` to the passkey edit button and `has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-offset-2 ring-offset-surface` to the appearance theme radio button wrappers.
🎯 Why: To ensure that keyboard navigators can see focus rings on custom interactive elements (hidden icons and visually replaced radio buttons).
📸 Before/After: Visual focus states are now correctly applied when tabbing through the Settings page.
♿ Accessibility: Improves WCAG 2.1 Focus Visible compliance by restoring missing focus indicators for keyboard users.

---
*PR created automatically by Jules for task [6079565991275989008](https://jules.google.com/task/6079565991275989008) started by @ToolchainLab*