### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix memory exhaustion DoS in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Fix Memory Exhaustion DoS in File Uploads]
+**Vulnerability:** Unbounded `await file.read()` loaded the entire uploaded file into RAM before checking size against `max_upload_bytes`, allowing an attacker to cause an Out-Of-Memory (OOM) crash by uploading a massive file.
+**Learning:** FastAPI `UploadFile` handles large files by spooled temporary files on disk, but calling `.read()` without arguments pulls the entire contents into a `bytes` string in memory.
+**Prevention:** Always check `file.size` first if available, and bound the `.read(limit)` call to `max_upload_bytes + 1` to gracefully reject oversized files without exhausting server RAM.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,14 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `/uploads` route called `await file.read()` without any limit. This reads the entire uploaded file directly into server RAM, bypassing FastAPI's default disk spooling for large files. An attacker could exploit this by uploading extremely large files, causing the server process to crash due to memory exhaustion (OOM).
🎯 Impact: Denial of Service (DoS). A single malicious user could bring down the entire backend application.
🔧 Fix: Added a check against `file.size` if the client provides it, and bounded the `.read()` call to `max_upload_bytes + 1` so the server safely truncates reading and rejects oversized payloads without loading them fully into memory.
✅ Verification: Ran the `pytest` test suite, specifically `test_phase1.py::TestUploadsEndpoint`, and all tests passed. Visual inspection confirms the read limit is securely enforced before rejecting the upload.

---
*PR created automatically by Jules for task [8218094730772675968](https://jules.google.com/task/8218094730772675968) started by @ToolchainLab*