### PR TITLE
🧭 Atlas: Generate API routes documentation from OpenAPI

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2026-03-01 - Replace hand-written API docs with OpenAPI generated tables
+**Learning:** Hand-written API endpoints in documentation quickly fall out of sync or get hidden behind new FastAPI structures (e.g., `_IncludedRouter`). Testing them via regex search can result in false positives or masking.
+**Action:** Replace manual endpoint lists with markdown markers (`<!-- BEGIN API ROUTES -->`) and dynamically generate API documentation tables directly from the `app.openapi()` schema. Ensure the drift check verifies table inclusion rather than just keyword presence.

--- a/README.md
+++ b/README.md
@@ -63,26 +63,37 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- BEGIN API ROUTES -->
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/` | Welcome |
+| `GET` | `/auth/passkeys` | List passkeys |
+| `GET` | `/auth/session` | Current session |
+| `GET` | `/health` | Health |
+| `GET` | `/jobs` | List jobs |
+| `GET` | `/jobs/{job_id}` | Get job |
+| `GET` | `/uploads` | List uploads |
+| `GET` | `/uploads/{upload_id}` | Get upload metadata |
+| `GET` | `/uploads/{upload_id}/download` | Download a file |
+| `PATCH` | `/auth/passkeys/{key_id}` | Rename a passkey |
+| `POST` | `/auth/login` | Login with password |
+| `POST` | `/auth/passkey/add/finish` | Finish adding a passkey |
+| `POST` | `/auth/passkey/add/start` | Start adding a passkey |
+| `POST` | `/auth/passkey/login/finish` | Finish passkey login |
+| `POST` | `/auth/passkey/login/start` | Start passkey login |
+| `POST` | `/auth/passkey/register/finish` | Finish passkey registration |
+| `POST` | `/auth/passkey/register/start` | Start passkey registration |
+| `POST` | `/auth/passkeys/{key_id}/revoke` | Revoke a passkey |
+| `POST` | `/auth/password-reset/confirm` | Confirm password reset |
+| `POST` | `/auth/password-reset/request` | Request a password reset |
+| `POST` | `/auth/register` | Register with password |
+| `POST` | `/jobs` | Enqueue a job |
+| `POST` | `/llm/chat` | Chat completion |
+| `POST` | `/llm/chat/stream` | Streaming chat completion |
+| `POST` | `/uploads` | Upload a file |
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- END API ROUTES -->
 
 ## Auth model
 

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -22,8 +22,8 @@ README = REPO_ROOT / "README.md"
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_app_routes() -> list[tuple[str, str, str]]:
+    """Return (method, path, summary) tuples from the live FastAPI app."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -33,58 +33,58 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    routes: list[tuple[str, str, str]] = []
+    openapi_schema = app.openapi()
+    paths = openapi_schema.get("paths", {})
+    http_methods = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+    for path, methods in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
+        for method, op in methods.items():
+            if method.lower() in http_methods:
+                summary = op.get("summary", "")
+                routes.append((method.upper(), path, summary))
     return sorted(routes)
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+def generate_routes_table(routes: list[tuple[str, str, str]]) -> str:
+    """Format the routes into a Markdown table."""
+    lines = ["| Method | Path | Description |", "|---|---|---|"]
+    for method, path, summary in routes:
+        lines.append(f"| `{method}` | `{path}` | {summary} |")
+    return "\n".join(lines)
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
+
+def update_readme(check_only: bool = False) -> int:
+    routes = get_app_routes()
+    table = generate_routes_table(routes)
     readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+
+    pattern = r"(<!-- BEGIN API ROUTES -->).*?(<!-- END API ROUTES -->)"
+    replacement = rf"\1\n\n{table}\n\n\2"
+
+    new_text, count = re.subn(pattern, replacement, readme_text, flags=re.DOTALL)
+    if count == 0:
+        print("❌ Could not find API ROUTES markers in README.md")
+        return 1
+
+    if new_text != readme_text:
+        if check_only:
+            print(
+                "❌ README.md API routes are out of date. "
+                "Run scripts/check_doc_routes.py --update to fix."
+            )
+            return 1
+        README.write_text(new_text)
+        print("✅ Updated API routes in README.md")
+    else:
+        print(f"✅ All {len(routes)} API routes are correctly documented in README.md.")
+    return 0
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
-
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
-        return 1
-
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+    check_only = "--update" not in sys.argv
+    return update_readme(check_only)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Replaced the hand-written API endpoint list in `README.md` with an auto-generated markdown table driven directly by the FastAPI `openapi()` schema. Updated `scripts/check_doc_routes.py` to function as both the table generator (`--update`) and the strict drift checker.
🎯 Why: Hand-written endpoints were drifting and the previous drift checker was silently failing on FastAPI >= 0.115.0 due to `_IncludedRouter` nesting. This removes manual duplication and makes the true API contract the authoritative source of truth.
🧪 Verification: Run `PYTHONPATH=src uv run python scripts/check_doc_routes.py`. Tested successfully. All unit tests and linters pass.
🔒 Drift Prevention: `scripts/check_doc_routes.py` now statically verifies that the exact generated markdown table exists inside the `README.md` markers, failing CI if any endpoint is missing or wrongly documented.
🗺️ Evidence: `src/h4ckath0n/app.py` -> `app.openapi().get("paths")`

---
*PR created automatically by Jules for task [16857985156474054158](https://jules.google.com/task/16857985156474054158) started by @ToolchainLab*