### PR TITLE
🎨 Palette: Add focus states for keyboard accessibility in Settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-29 - Keyboard accessibility for custom inputs and hover elements
+ **Learning:** When creating accessible UI elements with `sr-only` inputs inside `<label>` wrappers, or action buttons hidden by `opacity-0 group-hover:opacity-100`, native focus states are lost or invisible to keyboard users.
+ **Action:** In Tailwind v4, apply `has-[:focus-visible]:ring-2` (and related ring utilities) on the wrapper to reveal focus for screen-reader-only inputs, and add `focus-visible:opacity-100` alongside hover classes to expose hidden actions to keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -149,7 +149,7 @@ function PasskeyName({
           variant="ghost"
           data-testid="passkey-edit-btn"
           onClick={startEdit}
-          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />
@@ -290,7 +290,7 @@ export function Settings() {
               <label
                 key={option}
                 className={cn(
-                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all",
+                  "cursor-pointer rounded-xl border-2 p-4 hover:bg-surface-alt transition-all has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-offset-2",
                   themePreference === option
                     ? "border-primary bg-primary/5"
                     : "border-border",


### PR DESCRIPTION
### 💡 What
Added missing focus-visible classes in `Settings.tsx` to properly support keyboard navigation for two custom components.

### 🎯 Why
When keyboard users tab through the Settings page:
1. The "Edit passkey name" button was only visible on hover (`opacity-0 group-hover:opacity-100`). Keyboard users could tab to it, but it remained invisible, causing confusion.
2. The custom Theme selector blocks (Light, Dark, System) wrap an `sr-only` radio input. Tabbing into these inputs didn't visually indicate focus because the `<label>` wasn't styled for focus-within states.

### 📸 Before/After
**Before:**
Tabbing past the passkey name seemingly disappeared the focus outline. Tabbing through Theme selections did nothing visually.

**After:**
The pencil edit icon becomes visible when focused, and the theme buttons receive the primary focus ring `ring-2 ring-primary ring-offset-2`.

### ♿ Accessibility
- Improves WCAG 2.4.7 Focus Visible by ensuring all interactive elements have a visible focus indicator.
- Allows full keyboard navigation of passkey management and theme preferences.

---
*PR created automatically by Jules for task [13170854357341582780](https://jules.google.com/task/13170854357341582780) started by @ToolchainLab*