### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded UploadFile read OOM DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Unbounded FastAPI UploadFile Read OOM DoS
+**Vulnerability:** Calling `await file.read()` on FastAPI `UploadFile` objects without a size limit or size check first.
+**Learning:** This bypasses FastAPI's disk spooling, loads the entire file into memory regardless of size, and causes Out-Of-Memory (OOM) Denial of Service (DoS) vulnerabilities if an attacker uploads a massive file.
+**Prevention:** Always validate size first using `file.size` if available, and bound `file.read()` calls (e.g., `await file.read(max_upload_bytes + 1)`) to enforce size limits before reading the entire content into memory.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,14 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `POST /uploads` route called `await file.read()` on FastAPI `UploadFile` objects without a prior size limit check. This bypassed FastAPI's disk spooling, loaded the entire file into memory regardless of size, and created an Out-Of-Memory (OOM) Denial of Service (DoS) risk if an attacker uploaded a massive file.
🎯 Impact: A malicious actor could easily exhaust server memory by uploading very large files, crashing the application and causing a Denial of Service.
🔧 Fix: Added a `file.size` check to fast-fail if the known size exceeds `settings.max_upload_bytes`. Additionally bounded the `await file.read()` call to `settings.max_upload_bytes + 1` to strictly enforce memory limits during the read operation itself.
✅ Verification: Ran `uv run --locked pytest -v` to ensure tests passed and standard upload functionality remains unbroken. Checked code visually to ensure OOM vulnerability is patched.

---
*PR created automatically by Jules for task [2410690613647110174](https://jules.google.com/task/2410690613647110174) started by @ToolchainLab*