### PR TITLE
🎨 Palette: Add keyboard focus ring to password toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-16 - Password Toggle Keyboard Accessibility
+**Learning:** Absolute positioned interactive elements inside inputs (like password visibility toggles) often miss native focus rings or inherit clipped bounds, making them invisible during keyboard navigation.
+**Action:** Always explicitly add `focus-visible:outline-none focus-visible:ring-2` to absolutely positioned icon buttons inside forms.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
**💡 What:** 
Added explicit `focus-visible` styling (`focus-visible:outline-none`, `focus-visible:ring-2`, `focus-visible:ring-primary`, `rounded-xl`) to the password visibility toggle button inside the `PasswordField` component.

**🎯 Why:** 
Absolute positioned interactive elements inside inputs often lack native focus rings or inherit clipped bounds, making them invisible during keyboard navigation. This prevents keyboard-only or screen reader users from knowing they have successfully focused the "Show/Hide Password" toggle.

**📸 Before/After:**
* **Before:** Tabbing to the password toggle button resulted in no visible focus indicator.
* **After:** Tabbing to the password toggle button highlights it clearly with a primary-colored focus ring that pleasantly hugs the icon due to the new `rounded-xl` shape.

**♿ Accessibility:** 
Improves keyboard navigability (WCAG 2.4.7 Focus Visible) for critical authentication forms.

---
*PR created automatically by Jules for task [15130302638135703590](https://jules.google.com/task/15130302638135703590) started by @ToolchainLab*