### PR TITLE
🛡️ Sentinel: [HIGH] Fix OOM DoS in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-16 - OOM DoS via Unbounded UploadFile Read
+**Vulnerability:** Unbounded `await file.read()` in FastAPI `UploadFile` endpoint loaded the entire file into memory before checking its size, creating a Denial of Service (OOM) risk.
+**Learning:** FastAPI's `UploadFile` caches uploads in memory or spools to disk, but `await file.read()` reads everything into the application's RAM at once, bypassing the spooling protection.
+**Prevention:** Always check `file.size` first if available, and use bounded reads like `await file.read(max_bytes + 1)` when reading file contents into memory, raising an error if the bound is exceeded.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,13 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+    # 🛡️ Sentinel: Validate size first and bound read to prevent OOM DoS
+    if getattr(file, "size", None) is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded `await file.read()` in the FastAPI `UploadFile` endpoint loaded the entire file into memory before checking its size, creating a Denial of Service (OOM) risk bypassing spooling protection.
🎯 Impact: An attacker could crash the server by uploading massively large files, causing it to run out of memory.
🔧 Fix: Added a bounded read `await file.read(max_upload_bytes + 1)` and an initial fast-fail check using `file.size` if available.
✅ Verification: Ran `uv run --locked pytest -v` successfully.

---
*PR created automatically by Jules for task [15084558423914551065](https://jules.google.com/task/15084558423914551065) started by @ToolchainLab*