### PR TITLE
🧭 Atlas: Update API route drift check to parse OpenAPI schema

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - FastAPI nested router paths missing from app.routes
+**Learning:** Iterating over `app.routes` in FastAPI does not yield routes nested within an `_IncludedRouter` correctly, leading to massive false negatives in drift-prevention checks. The true flat list of endpoints is available via OpenAPI schema generation (`app.openapi().get("paths", {})`).
+**Action:** When validating or enumerating APIs in drift checks, use the generated OpenAPI schema rather than `app.routes`.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -34,17 +34,15 @@ def get_app_routes() -> list[tuple[str, str]]:
     app = create_app(settings)
 
     routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    schema = app.openapi()
+    for path, path_item in schema.get("paths", {}).items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method in path_item:
+            method_upper = method.upper()
+            if method_upper == "HEAD":
                 continue
-            routes.append((method, path))
+            routes.append((method_upper, path))
     return sorted(routes)
 
 


### PR DESCRIPTION
💡 What: Update `scripts/check_doc_routes.py` to extract routes from `app.openapi().get("paths", {})` instead of `app.routes`.
🎯 Why: In modern FastAPI versions, routes added via `include_router` are encapsulated in `_IncludedRouter` wrappers, causing `app.routes` iteration to miss the vast majority of API routes. This fixes a major false-negative in the drift prevention check.
🧪 Verification: Run `uv run python scripts/check_doc_routes.py`, which now correctly finds and verifies 25 API routes instead of just 2.
🔒 Drift Prevention: Strengthens the existing automated `check_doc_routes.py` script.
🗺️ Evidence: `scripts/check_doc_routes.py`, `h4ckath0n.app.create_app`, `h4ckath0n/README.md`.

---
*PR created automatically by Jules for task [16769902651790163269](https://jules.google.com/task/16769902651790163269) started by @ToolchainLab*