### PR TITLE
∴ Vector: Centralize scope normalisation and manipulation logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - Centralize scope transformations in authz
+**Learning:** Repetitive scope processing (parsing, mutating, serializing) spread across CLI routines risked diverging normalizations and was mutation-heavy.
+**Action:** Created explicit `add_scopes`, `remove_scopes`, and `normalize_scopes` pure helpers in `authz.py` that handle the data-in/data-out canonicalization pipelines, replacing imperative CLI logic.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,20 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def normalize_scopes(raw: str | Iterable[str]) -> str:
+    """Parse and serialize scopes back into the canonical comma-separated form."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(current: str | Iterable[str], new: str | Iterable[str]) -> str:
+    """Add new scopes to a current scope string, returning the canonical form."""
+    return serialize_scopes((*parse_scopes(current), *parse_scopes(new)))
+
+
+def remove_scopes(current: str | Iterable[str], to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from a current scope string, returning the canonical form."""
+    existing = parse_scopes(current)
+    removing = set(parse_scopes(to_remove))
+    return serialize_scopes(s for s in existing if s not in removing)

--- a/src/h4ckath0n/cli/__init__.py
+++ b/src/h4ckath0n/cli/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 
+from h4ckath0n.auth.authz import normalize_scopes as _normalize_scopes
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
@@ -19,7 +20,6 @@ from h4ckath0n.cli._common import (
     EXIT_OK,
     EXIT_PROD_INIT,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from h4ckath0n.cli._parser import build_parser
 from h4ckath0n.cli.db import (

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -141,11 +140,6 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
             yield session
     finally:
         engine.dispose()
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,12 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, normalize_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_OK,
-    _normalize_scopes,
     _output,
     _require_yes,
     _sync_session,
@@ -142,8 +141,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +158,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -180,7 +175,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        user.scopes = _normalize_scopes(args.scopes)
+        user.scopes = normalize_scopes(args.scopes)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -56,6 +56,21 @@ class TestScopes:
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
 
+    def test_normalize_scopes(self):
+        from h4ckath0n.auth.authz import normalize_scopes
+
+        assert normalize_scopes(" b , a ,, b, c ") == "b,a,c"
+
+    def test_add_scopes(self):
+        from h4ckath0n.auth.authz import add_scopes
+
+        assert add_scopes("a,b", "b,c") == "a,b,c"
+
+    def test_remove_scopes(self):
+        from h4ckath0n.auth.authz import remove_scopes
+
+        assert remove_scopes("a,b,c,d", "b,d,e") == "a,c"
+
     def test_role_constants(self):
         assert USER == "user"
         assert ADMIN == "admin"


### PR DESCRIPTION
- 💡 **What:** Extracted scattered, ad-hoc scope parsing and mutation logic out of CLI handlers (`users.py` and `_common.py`) and centralized it into explicit, pure helper functions (`add_scopes`, `remove_scopes`, `normalize_scopes`) inside `authz.py`.
- 🎯 **Why:** Scope logic (comma separation, deduplication, trimming) is a domain concept. Scattering its mutation and normalization across the CLI layer leads to potential drift and logic repetition. 
- 🧠 **Design:** Created data-in/data-out pipeline functions directly within the `authz.py` module. Re-exposed `normalize_scopes` within the CLI internal interface to prevent any upstream breakages.
- λ **FP Angle:** Transforms mutation-heavy local logic (parsing, filtering arrays, and serializing) into straightforward, reusable transformations. The new pure helpers centralize semantics and guarantee deterministic behavior.
- ✅ **Verification:** 
  - Ran `uv run --locked pytest -v` (all tests passed)
  - Ran `uv run --locked ruff format .` and `ruff check .` (linter clean)
  - Ran `uv run --locked mypy src` (type checks passed)
- 🧪 **Edge cases:** Edge cases around string parsing, extra commas, and deduplication are inherently handled by `parse_scopes` underlying the new helper implementations, heavily tested inside `test_authz.py`.
- ⚠️ **Risk:** Extremely low. The transformations remain functionally identical to the previous implementation, simply extracted into composable functions. No public API limits were modified.

---
*PR created automatically by Jules for task [18215822748266319333](https://jules.google.com/task/18215822748266319333) started by @ToolchainLab*