### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent OOM DoS in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-07-17 - Prevent OOM DoS in File Uploads
+**Vulnerability:** Unbounded `await file.read()` in `upload_file` could lead to OOM DoS attacks by loading massive files entirely into memory before size validation.
+**Learning:** Checking `len(data) > max_bytes` after reading the whole file is too late. The file content is already in RAM.
+**Prevention:** Use `file.size` for early rejection and bound the `read` call (e.g. `await file.read(max_bytes + 1)`) to avoid loading arbitrarily large amounts of data.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,13 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unbounded file read in upload endpoint.
🎯 Impact: An attacker could perform a DoS attack by uploading arbitrarily large files causing OOM crashes.
🔧 Fix: Bound `file.read` and add early `file.size` validation.
✅ Verification: Tested via existing test suite.

---
*PR created automatically by Jules for task [12010493565750924655](https://jules.google.com/task/12010493565750924655) started by @ToolchainLab*