### PR TITLE
∴ Vector: Centralize display name validation using Pydantic Annotated types

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-07-18 - Centralize Pydantic Validation with Annotated types
+**Learning:** Using `@field_validator` across multiple models leads to duplicated boilerplate for common fields like `display_name`.
+**Action:** Use Pydantic V2's `typing.Annotated` combined with `Field` and `AfterValidator` to create reusable, self-validating custom types that centralize both schema constraints and normalisation logic.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -5,28 +5,21 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from h4ckath0n.auth.schemas import (
-    DISPLAY_NAME_MAX_LENGTH,
     DeviceBindingMixin,
-    normalize_display_name,
+    DisplayName,
 )
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        return normalize_display_name(v)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import AfterValidator, BaseModel, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
@@ -18,6 +18,14 @@ def normalize_display_name(value: str) -> str:
     return cleaned
 
 
+# Reusable, self-validating type for display names.
+DisplayName = Annotated[
+    str,
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH),
+    AfterValidator(normalize_display_name),
+]
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -29,16 +37,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayName = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        return normalize_display_name(v)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
- 💡 What: Replaced duplicated `Field(max_length=...)` and `@field_validator` boilerplate across auth request models with a centralized `DisplayName` type using Pydantic V2's `typing.Annotated` and `AfterValidator`.
- 🎯 Why: To remove duplicated schema validation logic, reduce boilerplate in model definitions, and centralize the rules for display names into a single source of truth.
- 🧠 Design: Pydantic V2's `Annotated` types allow bundling both field constraints (like `max_length`) and custom functional validators (`AfterValidator(normalize_display_name)`) into a single reusable Python type hint.
- λ FP Angle: Transforms scattered object-oriented `@classmethod` validators into a centralized, declarative type pipeline that applies a pure normalization helper function transparently.
- ✅ Verification: Ran the entire `pytest` suite, passing all existing tests for display name validation (empty, whitespace, length, trimming). Ran `ruff` formatting, linting, and `mypy` typechecking.
- 🧪 Edge cases: Ensured that the `DisplayName` type correctly inherits the max length constraint of 200 characters and accurately trims and rejects empty/whitespace strings across all models utilizing it.
- ⚠️ Risk: Minimal. This is a standard Pydantic V2 refactor pattern that perfectly preserves the existing validation behavior and API schema.

---
*PR created automatically by Jules for task [16054372162977966631](https://jules.google.com/task/16054372162977966631) started by @ToolchainLab*