### PR TITLE
🎨 Palette: Add focus ring to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-18 - [Accessibility] Added focus styles to absolute positioned inputs
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
- 💡 What: Added focus ring styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl`) to the absolute positioned password visibility toggle button in `PasswordField.tsx`.
- 🎯 Why: To ensure keyboard navigators can easily identify when the button is focused. Absolute positioned interactive elements inside inputs often miss native focus rings or inherit clipped bounds.
- 📸 Before/After: Visual changes to the focus outline when navigating via keyboard (tabbing) onto the toggle.
- ♿ Accessibility: Improved keyboard accessibility and visibility of focus state for the visibility toggle button, addressing the learning that such elements need explicit focus styling.

---
*PR created automatically by Jules for task [11541860896178775087](https://jules.google.com/task/11541860896178775087) started by @ToolchainLab*