### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS via unbounded file read

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Prevent OOM DoS in File Uploads
+**Vulnerability:** Unbounded `await file.read()` calls in FastAPI upload endpoints can load excessively large files entirely into memory, leading to Out-Of-Memory (OOM) Denial of Service (DoS) attacks.
+**Learning:** Checking file size *after* reading the entire file into memory defeats the purpose of the size limit. FastAPI `UploadFile` endpoints bypass disk spooling if you immediately await read() on the whole file.
+**Prevention:** Always validate size first (e.g. `file.size` if available) and bound read calls (e.g., `await file.read(max_upload_bytes + 1)`), then check if the length exceeds the maximum before proceeding.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,12 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unbounded `await file.read()` calls in FastAPI upload endpoints can load excessively large files entirely into memory, leading to Out-Of-Memory (OOM) Denial of Service (DoS) attacks.
🎯 Impact: An attacker could upload a massive file (e.g., several gigabytes) that bypasses disk spooling and is read directly into memory, crashing the server process due to memory exhaustion.
🔧 Fix: Updated the `upload_file` endpoint to first validate the reported `file.size` if available, and then perform a bounded read using `await file.read(settings.max_upload_bytes + 1)`. If the read length exceeds the maximum allowed upload bytes, the request is rejected before the entire file can be loaded.
✅ Verification: Tested the application by running the full test suite (`uv run --locked pytest -v`) and static analysis checks (`ruff`, `mypy`), which all passed successfully, ensuring legitimate uploads still function.

---
*PR created automatically by Jules for task [13945047988778081762](https://jules.google.com/task/13945047988778081762) started by @ToolchainLab*