### PR TITLE
🧭 Atlas: Generate API route documentation from OpenAPI

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2025-01-01 - FastAPI _IncludedRouter hides endpoints
+**Learning:** Iterating `app.routes` in FastAPI v0.138+ misses endpoints from included sub-routers (`_IncludedRouter`), causing silent drift-check failures.
+**Action:** Parse the OpenAPI schema via `app.openapi()['paths']` to reliably extract all endpoints for route generation or drift checks. Prefer generating endpoint docs from source and wrapping them in HTML comment markers rather than using regex parsing to verify manually maintained lists.

--- a/README.md
+++ b/README.md
@@ -63,37 +63,51 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- BEGIN_API_ROUTES -->
+### Auth
+- `GET /auth/session` — Current session
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+### Default
+- `GET /` — Welcome
+- `GET /health` — Health
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+### Jobs
+- `GET /jobs` — List jobs
+- `POST /jobs` — Enqueue a job
+- `GET /jobs/{job_id}` — Get job
+
+### Llm
+- `POST /llm/chat` — Chat completion
+- `POST /llm/chat/stream` — Streaming chat completion
+
+### Passkey
+- `POST /auth/passkey/register/start` — Start passkey registration
+- `POST /auth/passkey/register/finish` — Finish passkey registration
+- `POST /auth/passkey/login/start` — Start passkey login
+- `POST /auth/passkey/login/finish` — Finish passkey login
+- `POST /auth/passkey/add/start` — Start adding a passkey
+- `POST /auth/passkey/add/finish` — Finish adding a passkey
+- `GET /auth/passkeys` — List passkeys
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey
+- `PATCH /auth/passkeys/{key_id}` — Rename a passkey
+
+### Password-Auth
+- `POST /auth/register` — Register with password
+- `POST /auth/login` — Login with password
+- `POST /auth/password-reset/request` — Request a password reset
+- `POST /auth/password-reset/confirm` — Confirm password reset
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+- `GET /uploads` — List uploads
+- `POST /uploads` — Upload a file
+- `GET /uploads/{upload_id}` — Get upload metadata
+- `GET /uploads/{upload_id}/download` — Download a file<!-- END_API_ROUTES -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn).
 
 ### Device signed JWTs
 
@@ -146,11 +160,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -22,8 +22,8 @@ README = REPO_ROOT / "README.md"
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_openapi_routes() -> str:
+    """Return a markdown list of endpoints from the OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -32,59 +32,65 @@ def get_app_routes() -> list[tuple[str, str]]:
         password_auth_enabled=True,
     )
     app = create_app(settings)
+    paths = app.openapi()["paths"]
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    routes_by_tag: dict[str, list[tuple[str, str, str]]] = {}
+    for path, path_item in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method, info in path_item.items():
+            if method.upper() == "HEAD":
                 continue
-            routes.append((method, path))
-    return sorted(routes)
+            tags = info.get("tags", ["default"])
+            tag = tags[0] if tags else "default"
+            if tag not in routes_by_tag:
+                routes_by_tag[tag] = []
+            routes_by_tag[tag].append((method.upper(), path, info.get("summary", "")))
+
+    # Print markdown
+    lines = []
+    for tag in sorted(routes_by_tag.keys()):
+        lines.append(f"### {tag.title()}")
+        for method, path, summary in routes_by_tag[tag]:
+            lines.append(f"- `{method} {path}` — {summary}")
+        lines.append("")
+    return "\n".join(lines).strip()
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
-
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
+def check_routes_in_readme(expected_markdown: str, update: bool = False) -> int:
+    """Verify or update the API routes block in README.md."""
     readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+
+    pattern = re.compile(r"(<!-- BEGIN_API_ROUTES -->\n)(.*?)(<!-- END_API_ROUTES -->)", re.DOTALL)
+
+    match = pattern.search(readme_text)
+    if not match:
+        print("❌ Could not find BEGIN_API_ROUTES and END_API_ROUTES markers in README.md.")
+        return 1
+
+    current_markdown = match.group(2).strip()
+
+    if current_markdown == expected_markdown:
+        print("✅ API routes in README.md are up to date.")
+        return 0
+
+    if update:
+        new_text = pattern.sub(rf"\1{expected_markdown}\3", readme_text)
+        README.write_text(new_text)
+        print("✅ Updated API routes in README.md.")
+        return 0
+
+    print("❌ API routes in README.md are out of date.\n")
+    print("Expected:")
+    print(expected_markdown)
+    print("\nRun with --update to fix.")
+    return 1
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
-
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
-        return 1
-
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+    update = "--update" in sys.argv
+    expected_markdown = get_openapi_routes()
+    return check_routes_in_readme(expected_markdown, update=update)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Replace the hand-written route list in `README.md` with a generated block grouped by route tags, powered by the OpenAPI schema. Updates `scripts/check_doc_routes.py` to parse the OpenAPI schema directly and adds an `--update` flag.
🎯 Why: Iterating `app.routes` in FastAPI v0.138+ silently misses endpoints within `_IncludedRouter`s, leading to false negatives in the drift checker and duplicated/inaccurate endpoints in the docs. Generating from source completely eliminates this documentation drift.
🧪 Verification: Run `PYTHONPATH=src uv run scripts/check_doc_routes.py` to ensure the checks pass.
🔒 Drift Prevention: The CI job now dynamically compares the README's `<!-- BEGIN_API_ROUTES -->` block against the actual app OpenAPI schema, preventing any API additions/removals from silently diverging from the docs.
🗺️ Evidence: `src/h4ckath0n/app.py` and `scripts/check_doc_routes.py`

---
*PR created automatically by Jules for task [11151303616089682667](https://jules.google.com/task/11151303616089682667) started by @ToolchainLab*