### PR TITLE
∴ Vector: Centralize scope transformation helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-07-19 - Centralize scope transformation helpers
+**Learning:** The codebase had duplicated and ad-hoc scope normalization and manipulation logic (e.g. `_normalize_scopes` in `cli/_common.py`, list manipulation in `cli/users.py`). This duplication increases the risk of subtle bugs or inconsistent string normalization of comma-separated domains.
+**Action:** Centralize string parsing and array transformation functions (`normalize_scopes`, `add_scopes`, `remove_scopes`) into the core `authz.py` domain module. Using pure helpers creates a single source of truth for authorization value manipulation across the CLI and backend.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,19 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def normalize_scopes(raw: str | Iterable[str]) -> str:
+    """Normalize scopes into a canonical comma-separated string."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(existing: str | Iterable[str], to_add: str | Iterable[str]) -> str:
+    """Return a new serialized scope string with *to_add* appended."""
+    return serialize_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> str:
+    """Return a new serialized scope string with *to_remove* stripped out."""
+    remove_set = set(parse_scopes(to_remove))
+    return serialize_scopes(s for s in parse_scopes(existing) if s not in remove_set)

--- a/src/h4ckath0n/cli/__init__.py
+++ b/src/h4ckath0n/cli/__init__.py
@@ -19,7 +19,6 @@ from h4ckath0n.cli._common import (
     EXIT_OK,
     EXIT_PROD_INIT,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from h4ckath0n.cli._parser import build_parser
 from h4ckath0n.cli.db import (
@@ -56,7 +55,6 @@ __all__ = [
     "build_parser",
     "alembic_command",
     "_normalize_db_url_for_sync",
-    "_normalize_scopes",
 ]
 
 # Backwards-compatible alias (the parser builder was previously private).

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -141,11 +140,6 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
             yield session
     finally:
         engine.dispose()
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,12 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, normalize_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_OK,
-    _normalize_scopes,
     _output,
     _require_yes,
     _sync_session,
@@ -142,8 +141,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +158,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -180,7 +175,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        user.scopes = _normalize_scopes(args.scopes)
+        user.scopes = normalize_scopes(args.scopes)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -60,6 +60,25 @@ class TestScopes:
         assert USER == "user"
         assert ADMIN == "admin"
 
+    def test_normalize_scopes(self):
+        from h4ckath0n.auth.authz import normalize_scopes
+
+        assert normalize_scopes("a,b,c") == "a,b,c"
+        assert normalize_scopes("a,b,a") == "a,b"
+        assert normalize_scopes(" a , b , c ") == "a,b,c"
+        assert normalize_scopes("a,,b,,") == "a,b"
+        assert normalize_scopes("") == ""
+
+    def test_add_scopes(self):
+        from h4ckath0n.auth.authz import add_scopes
+
+        assert add_scopes("a,b", "b,c") == "a,b,c"
+
+    def test_remove_scopes(self):
+        from h4ckath0n.auth.authz import remove_scopes
+
+        assert remove_scopes("a,b,c", "b") == "a,c"
+
 
 class TestPasskeyErrors:
     def test_hierarchy_subclasses_value_error(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -130,23 +129,6 @@ class TestAlembicUrlNormalization:
 # ---------------------------------------------------------------------------
 # Scopes normalization
 # ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Centralize string parsing and array transformation functions (`normalize_scopes`, `add_scopes`, `remove_scopes`) into the core `authz.py` domain module, replacing local wrappers and inline logic in the CLI.

🎯 Why: The codebase had duplicated and ad-hoc scope normalization and list manipulation logic (e.g. `_normalize_scopes` in `cli/_common.py`, explicit add/remove in `cli/users.py`). This duplication increases the risk of subtle bugs or inconsistent string normalization of comma-separated domains across different boundaries.

🧠 Design: I introduced three new pure helper functions to the domain module. These act as the single source of truth for scope state transformations, taking a raw string or list and guaranteeing a cleanly formatted, canonical, deduplicated comma-separated string out. I then ported the CLI to lean entirely on these.

λ FP Angle: This shifts scattered mutation (`list` and `set` casting, list comprehensions mapped over existing arrays) into clean data-in/data-out transformation pipelines. State is passed in and transformed state is returned explicitly.

✅ Verification: Ran `uv run --locked pytest -v`, `uv run --locked ruff format .`, `uv run --locked ruff check .`, and `uv run --locked mypy src`. All checks pass, proving types and runtime behavior are correct.

🧪 Edge cases: `add_scopes` explicitly unpacks iterables via `(*parse_scopes(existing), *parse_scopes(to_add))` to guarantee safety, handling empty strings, trailing commas, and duplicate values seamlessly before serialization. Tests covering deduplication, whitespace trimming, and empty segments were ported over to verify the core `authz` logic handles all edge cases perfectly.

⚠️ Risk: Very low. This changes no business logic or behavior, purely relocating scattered string manipulation into testable, proven utilities.

---
*PR created automatically by Jules for task [5070640250144962686](https://jules.google.com/task/5070640250144962686) started by @ToolchainLab*