### PR TITLE
🎨 Palette: Add focus ring to password toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-19 - Password Toggle Keyboard Focus
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2`) to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2`) to the password visibility toggle button in `PasswordField.tsx`.
🎯 Why: Absolute positioned interactive elements inside inputs often miss native focus rings or inherit clipped bounds, making them invisible during keyboard navigation.
📸 Before/After: N/A (Visual changes are only seen when focusing on the button via keyboard).
♿ Accessibility: Ensures the password toggle button is clearly visible when navigated to via keyboard (tabbing).

---
*PR created automatically by Jules for task [15989979779234869385](https://jules.google.com/task/15989979779234869385) started by @ToolchainLab*