### PR TITLE
🛡️ Sentinel: [HIGH] Fix unbounded file read

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-19 - Prevent OOM DoS from Unbounded File Reads
+**Vulnerability:** FastAPI `UploadFile.read()` called without arguments reads the entire file into memory at once, which can cause OOM DoS.
+**Learning:** Checking length after an unbounded read is too late as the memory is already allocated.
+**Prevention:** Use `file.size` where available to reject early, and pass a bound to `file.read()` (e.g., `await file.read(max_bytes + 1)`).

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,13 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: FastAPI `UploadFile.read()` called without arguments reads the entire file into memory at once, causing an Out-Of-Memory (OOM) Denial of Service (DoS) vulnerability.
🎯 Impact: Attackers could crash the server by uploading massively large files, exhausting system memory.
🔧 Fix: Reject files early based on `file.size` if provided, and apply a strict read bound `await file.read(max_upload_bytes + 1)` to limit memory allocation. If the file slightly exceeds this limit, an error is appropriately thrown without unbounded reading.
✅ Verification: Ran `pytest` suite and visual checks, ensuring files are bounded prior to memory allocation without regressions.

---
*PR created automatically by Jules for task [3036644619500765281](https://jules.google.com/task/3036644619500765281) started by @ToolchainLab*