### PR TITLE
🧭 Atlas: Generate API routes from OpenAPI schema

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - FastAPI `app.routes` misses sub-routers
+**Learning:** Iterating over `app.routes` misses endpoints from included sub-routers (`_IncludedRouter`) in FastAPI v0.138+. Using regex parsing to verify manually maintained lists is fragile.
+**Action:** Parse the OpenAPI schema via `app.openapi()['paths']` to reliably extract all endpoints. Prefer generating endpoint docs from source and wrapping them in HTML comment markers rather than using regex parsing to verify manually maintained lists.

--- a/README.md
+++ b/README.md
@@ -61,39 +61,43 @@ uv run uvicorn your_module:app --reload
 - Protected routes require an `Authorization: Bearer <device_jwt>` header that the web
   template can mint after login.
 
-## Built-in routes
+## API Routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- BEGIN_API_ROUTES -->
+| Method | Path | Summary | Description |
+|---|---|---|---|
+| `GET` | `/` | Welcome | Default root route provided by h4ckath0n. |
+| `POST` | `/auth/login` | Login with password | Verify email and password, then bind an optional device key. |
+| `POST` | `/auth/passkey/add/finish` | Finish adding a passkey | Verify the WebAuthn attestation and attach the new passkey to the user. |
+| `POST` | `/auth/passkey/add/start` | Start adding a passkey | Begin adding a new passkey for the authenticated user and return registration options. |
+| `POST` | `/auth/passkey/login/finish` | Finish passkey login | Finish passkey login by verifying the WebAuthn assertion for the flow and binding an optional device key. |
+| `POST` | `/auth/passkey/login/start` | Start passkey login | Begin a username-less passkey login ceremony and return WebAuthn authentication options. |
+| `POST` | `/auth/passkey/register/finish` | Finish passkey registration | Finish passkey registration by verifying the WebAuthn attestation for the flow and binding an optional device key. |
+| `POST` | `/auth/passkey/register/start` | Start passkey registration | Begin a passkey registration ceremony. Creates a new user and a single-use challenge flow, then returns WebAuthn registration options. |
+| `GET` | `/auth/passkeys` | List passkeys | List all passkeys, including revoked entries, for the current user. |
+| `PATCH` | `/auth/passkeys/{key_id}` | Rename a passkey | Update the user-facing name of a passkey. |
+| `POST` | `/auth/passkeys/{key_id}/revoke` | Revoke a passkey | Revoke a passkey by its internal key ID. The last active passkey cannot be revoked and returns the LAST_PASSKEY error. |
+| `POST` | `/auth/password-reset/confirm` | Confirm password reset | Confirm a password reset token, set a new password, and bind an optional device key. |
+| `POST` | `/auth/password-reset/request` | Request a password reset | Request a password reset token for the account. Returns the same message even when the email is unknown. |
+| `POST` | `/auth/register` | Register with password | Create a new account using email and password, then bind an optional device key. |
+| `GET` | `/auth/session` | Current session | Return information about the currently authenticated session. |
+| `GET` | `/health` | Health | Basic health check for the app. |
+| `GET` | `/jobs` | List jobs | List recent jobs for the current user. |
+| `POST` | `/jobs` | Enqueue a job | Create a new background job. |
+| `GET` | `/jobs/{job_id}` | Get job | Get details of a specific job. |
+| `POST` | `/llm/chat` | Chat completion | Non-streaming chat completion. Requires OpenAI API key. |
+| `POST` | `/llm/chat/stream` | Streaming chat completion | Stream LLM tokens via SSE. Requires OpenAI API key. |
+| `GET` | `/uploads` | List uploads | List uploads for the current user. |
+| `POST` | `/uploads` | Upload a file | Upload a file (multipart/form-data). |
+| `GET` | `/uploads/{upload_id}` | Get upload metadata |  |
+| `GET` | `/uploads/{upload_id}/download` | Download a file | Stream the file back to the owner. |
+<!-- END_API_ROUTES -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn). See the API Routes section for the exact endpoints for registration, login, device management, and revocation.
 
 ### Device signed JWTs
 
@@ -146,11 +150,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -22,8 +22,8 @@ README = REPO_ROOT / "README.md"
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_app_routes() -> list[tuple[str, str, str, str]]:
+    """Return (method, path, summary, description) tuples from the live FastAPI app."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -33,57 +33,90 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    openapi = app.openapi()
+    routes: list[tuple[str, str, str, str]] = []
+
+    for path, methods in openapi["paths"].items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+        for method, op in methods.items():
+            routes.append(
+                (
+                    method.upper(),
+                    path,
+                    op.get("summary", ""),
+                    op.get("description", ""),
+                )
+            )
+
+    # Sort by path, then method
+    routes.sort(key=lambda x: (x[1], x[0]))
+    return routes
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+def generate_routes_markdown(routes: list[tuple[str, str, str, str]]) -> str:
+    """Generate a markdown table of routes."""
+    lines = [
+        "| Method | Path | Summary | Description |",
+        "|---|---|---|---|",
+    ]
+    for method, path, summary, description in routes:
+        # Clean up description (remove newlines to keep it in one table row)
+        desc_clean = description.replace("\n", " ").strip()
+        lines.append(f"| `{method}` | `{path}` | {summary} | {desc_clean} |")
+    return "\n".join(lines)
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
+
+def update_readme_routes(routes_md: str) -> None:
+    """Update README.md between the API routes markers."""
     readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+
+    pattern = re.compile(r"(<!-- BEGIN_API_ROUTES -->).*?(<!-- END_API_ROUTES -->)", re.DOTALL)
+
+    if not pattern.search(readme_text):
+        print(
+            "❌ Could not find <!-- BEGIN_API_ROUTES --> and "
+            "<!-- END_API_ROUTES --> markers in README.md."
+        )
+        sys.exit(1)
+
+    new_text = pattern.sub(lambda m: f"{m.group(1)}\n{routes_md}\n{m.group(2)}", readme_text)
+    README.write_text(new_text)
+
+
+def check_routes_in_readme(routes_md: str) -> bool:
+    """Check if the exact generated markdown block exists in the README."""
+    readme_text = README.read_text()
+
+    pattern = re.compile(r"<!-- BEGIN_API_ROUTES -->\n(.*?)\n<!-- END_API_ROUTES -->", re.DOTALL)
+    match = pattern.search(readme_text)
+
+    if not match:
+        print("❌ Could not find API route markers in README.md.")
+        return False
+
+    current_md = match.group(1).strip()
+    expected_md = routes_md.strip()
+
+    return current_md == expected_md
 
 
 def main() -> int:
+    fix_mode = "--fix" in sys.argv
     routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    routes_md = generate_routes_markdown(routes)
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    if fix_mode:
+        update_readme_routes(routes_md)
+        print(f"✅ Generated {len(routes)} API routes in README.md.")
+        return 0
+
+    if not check_routes_in_readme(routes_md):
+        print("❌ API routes in README.md are outdated or missing.")
+        print("Run `uv run scripts/check_doc_routes.py --fix` to update them.")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    print(f"✅ All {len(routes)} API routes are documented accurately in README.md.")
     return 0
 
 


### PR DESCRIPTION
💡 What: Replace hand-written API routes with a generated markdown table from the OpenAPI schema.
🎯 Why: Hand-written route lists are prone to drift. Iterating over `app.routes` misses sub-router endpoints in FastAPI, making regex-based checks fragile and inaccurate.
🧪 Verification: `uv run scripts/check_doc_routes.py` and `uv run --locked pytest -v`
🔒 Drift Prevention: `scripts/check_doc_routes.py --fix` now generates the routes directly from the source of truth (`app.openapi()['paths']`), ensuring the documentation always reflects the code.
🗺️ Evidence: `src/h4ckath0n/app.py`, `scripts/check_doc_routes.py`, `README.md`

---
*PR created automatically by Jules for task [595246304367326233](https://jules.google.com/task/595246304367326233) started by @ToolchainLab*