### PR TITLE
🎨 Palette: Add focus ring to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-07-20 - Focus Ring on Absolute Positioned Inputs
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2`) to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-r-xl disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Add focus ring styling to absolute positioned password toggle button.
🎯 Why: To ensure the toggle button is visible during keyboard navigation.
📸 Before/After: The password toggle is now visible on focus.
♿ Accessibility: Improved keyboard navigation visibility for the toggle button.

---
*PR created automatically by Jules for task [9053663770393900376](https://jules.google.com/task/9053663770393900376) started by @ToolchainLab*