### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS via unbounded file read

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-20 - [Fix OOM DoS via unbounded file read]
+**Vulnerability:** FastAPIs `UploadFile.read()` without bounds allows users to exhaust server memory, leading to an Out-Of-Memory (OOM) DoS.
+**Learning:** The memory limit check `len(data) > limit` occurred *after* the entire file was loaded into memory.
+**Prevention:** Use `file.size` to fail early, and strictly bound the read operation with `await file.read(max_upload_bytes + 1)` so that large files cannot exhaust memory.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,16 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+
+    # 🛡️ Sentinel: Early size check if provided by the client/framework
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    # 🛡️ Sentinel: Bounded read to prevent OOM DoS
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unbounded file read in UploadFile endpoint leading to OOM DoS
🎯 Impact: Attackers can upload large files that crash the backend by exhausting memory limits before the check is triggered
🔧 Fix: Implemented early file.size checking and bounded read with await file.read(max_upload_bytes + 1)
✅ Verification: Added file size and read byte limit, confirmed locally

---
*PR created automatically by Jules for task [710948678029359699](https://jules.google.com/task/710948678029359699) started by @ToolchainLab*