### PR TITLE
🧭 Atlas: Replace manual endpoint lists with generated OpenAPI tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,37 +63,77 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- ROUTES_START -->
+### Auth
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/auth/session` | Current session |
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+### Uncategorized
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/` | Welcome |
+| `GET` | `/health` | Health |
+
+### Jobs
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/jobs` | List jobs |
+| `POST` | `/jobs` | Enqueue a job |
+| `GET` | `/jobs/{job_id}` | Get job |
+
+### Llm
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/llm/chat` | Chat completion |
+| `POST` | `/llm/chat/stream` | Streaming chat completion |
+
+### Passkey
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/auth/passkey/register/start` | Start passkey registration |
+| `POST` | `/auth/passkey/register/finish` | Finish passkey registration |
+| `POST` | `/auth/passkey/login/start` | Start passkey login |
+| `POST` | `/auth/passkey/login/finish` | Finish passkey login |
+| `POST` | `/auth/passkey/add/start` | Start adding a passkey |
+| `POST` | `/auth/passkey/add/finish` | Finish adding a passkey |
+| `GET` | `/auth/passkeys` | List passkeys |
+| `POST` | `/auth/passkeys/{key_id}/revoke` | Revoke a passkey |
+| `PATCH` | `/auth/passkeys/{key_id}` | Rename a passkey |
+
+### Password Auth
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/auth/register` | Register with password |
+| `POST` | `/auth/register` | Register with password |
+| `POST` | `/auth/login` | Login with password |
+| `POST` | `/auth/login` | Login with password |
+| `POST` | `/auth/password-reset/request` | Request a password reset |
+| `POST` | `/auth/password-reset/request` | Request a password reset |
+| `POST` | `/auth/password-reset/confirm` | Confirm password reset |
+| `POST` | `/auth/password-reset/confirm` | Confirm password reset |
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
 
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/uploads` | List uploads |
+| `POST` | `/uploads` | Upload a file |
+| `GET` | `/uploads/{upload_id}` | Get upload metadata |
+| `GET` | `/uploads/{upload_id}/download` | Download a file |
+<!-- ROUTES_END -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn). See the [Built-in routes](#built-in-routes) section for the core passkey flows.
 
 ### Device signed JWTs
 
@@ -145,12 +185,7 @@ def refund(user=require_scopes("billing:refund")):
 ## Password auth (optional)
 
 Password routes mount only when the password extra is installed and
-`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
+`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`. See the [Built-in routes](#built-in-routes) section for available password endpoints.
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -2,28 +2,27 @@
 """Drift-prevention check: verify that every API route in the FastAPI app is documented.
 
 Usage (from repo root):
-    uv run scripts/check_doc_routes.py
+    uv run scripts/check_doc_routes.py [--update]
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, generates a markdown table of routes grouped by tag
+from the OpenAPI schema, and ensures that it matches the contents between
+<!-- ROUTES_START --> and <!-- ROUTES_END --> in README.md.
 """
 
 from __future__ import annotations
 
-import re
+import argparse
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- ROUTES_START -->\n"
+END_MARKER = "<!-- ROUTES_END -->\n"
 
-# FastAPI internal paths that we do not require in user docs.
-FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
-
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_routes_markdown() -> str:
+    """Generate markdown table of routes from the live FastAPI app's OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -32,59 +31,61 @@ def get_app_routes() -> list[tuple[str, str]]:
         password_auth_enabled=True,
     )
     app = create_app(settings)
+    paths = app.openapi()["paths"]
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
-        if path in FRAMEWORK_PATHS:
-            continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+    groups: dict[str, list[tuple[str, str, str]]] = {}
+    for path, methods in paths.items():
+        for method, op in methods.items():
+            tags: list[str] = op.get("tags", ["default"])
+            for tag in tags:
+                groups.setdefault(tag, []).append((method.upper(), path, op.get("summary", "")))
 
+    lines: list[str] = []
+    for tag in sorted(groups.keys()):
+        title = tag.replace("-", " ").title()
+        if title == "Default":
+            title = "Uncategorized"
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+        lines.append(f"### {title}")
+        lines.append("")
+        lines.append("| Method | Path | Summary |")
+        lines.append("|---|---|---|")
+        for method, path, summary in groups[tag]:
+            lines.append(f"| `{method}` | `{path}` | {summary} |")
+        lines.append("")
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    return "\n".join(lines).strip() + "\n"
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true", help="Update README.md in place")
+    args = parser.parse_args()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    generated_md = get_routes_markdown()
+
+    readme_text = README.read_text()
+
+    if START_MARKER not in readme_text or END_MARKER not in readme_text:
+        print("❌ Could not find ROUTES_START or ROUTES_END markers in README.md", file=sys.stderr)
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+    before_marker, rest = readme_text.split(START_MARKER, 1)
+    current_content, after_marker = rest.split(END_MARKER, 1)
+
+    if current_content == generated_md:
+        print("✅ API routes in README.md are up to date.")
+        return 0
+
+    if args.update:
+        new_readme = before_marker + START_MARKER + generated_md + END_MARKER + after_marker
+        README.write_text(new_readme)
+        print("✅ Updated API routes in README.md.")
+        return 0
+    else:
+        print("❌ API routes in README.md are out of date.", file=sys.stderr)
+        print("Run `uv run scripts/check_doc_routes.py --update` to fix.", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Replaces hardcoded lists of endpoints in README.md with generated markdown tables sourced directly from the FastAPI OpenAPI schema.
🎯 Why: Prevents documentation drift. Hardcoded lists easily fall out of sync with code additions, removals, or route name changes. Sourcing them from OpenAPI guarantees a single source of truth.
🧪 Verification: Run `uv run scripts/check_doc_routes.py` locally to verify the README matches the current code.
🔒 Drift Prevention: Refactored `scripts/check_doc_routes.py` from a naive regex-matcher into a full OpenAPI path extractor and markdown generator. CI will fail if the README routes are outdated.
🗺️ Evidence: Used `app.openapi()['paths']` from the initialized FastAPI app as the ultimate source of truth.

---
*PR created automatically by Jules for task [2393732494865185972](https://jules.google.com/task/2393732494865185972) started by @ToolchainLab*