### PR TITLE
∴ Vector: Extract pure helpers for scope manipulation

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Centralize scope manipulations
+**Learning:** Scope strings were previously manually deserialized and manipulated locally across CLI functions leading to duplication.
+**Action:** Replaced local mutation logic with pure composable helpers (`normalize_scopes`, `add_scopes`, `remove_scopes`) grouped near the types they operate on.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,25 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def normalize_scopes(raw: str | Iterable[str]) -> str:
+    """Normalize scopes into a canonical comma-separated string."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(existing: str | Iterable[str], new: str | Iterable[str]) -> str:
+    """Add new scopes to the existing scopes, preserving order and removing duplicates.
+
+    Returns the canonical comma-separated representation.
+    """
+    return serialize_scopes((*parse_scopes(existing), *parse_scopes(new)))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from the existing scopes.
+
+    Returns the canonical comma-separated representation.
+    """
+    remove_set = set(parse_scopes(to_remove))
+    return serialize_scopes(s for s in parse_scopes(existing) if s not in remove_set)

--- a/src/h4ckath0n/cli/__init__.py
+++ b/src/h4ckath0n/cli/__init__.py
@@ -19,7 +19,6 @@ from h4ckath0n.cli._common import (
     EXIT_OK,
     EXIT_PROD_INIT,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from h4ckath0n.cli._parser import build_parser
 from h4ckath0n.cli.db import (
@@ -56,7 +55,6 @@ __all__ = [
     "build_parser",
     "alembic_command",
     "_normalize_db_url_for_sync",
-    "_normalize_scopes",
 ]
 
 # Backwards-compatible alias (the parser builder was previously private).

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -141,11 +140,6 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
             yield session
     finally:
         engine.dispose()
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,12 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, normalize_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_OK,
-    _normalize_scopes,
     _output,
     _require_yes,
     _sync_session,
@@ -142,8 +141,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +158,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -180,7 +175,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        user.scopes = _normalize_scopes(args.scopes)
+        user.scopes = normalize_scopes(args.scopes)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,11 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
+    normalize_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -59,6 +62,26 @@ class TestScopes:
     def test_role_constants(self):
         assert USER == "user"
         assert ADMIN == "admin"
+
+    def test_normalize_scopes(self):
+        assert normalize_scopes("a,b,c") == "a,b,c"
+        assert normalize_scopes("a,b,a") == "a,b"
+        assert normalize_scopes(" a , b , c ") == "a,b,c"
+        assert normalize_scopes("a,,b,,") == "a,b"
+        assert normalize_scopes("") == ""
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", "c") == "a,b,c"
+        assert add_scopes("a,b", "a,c") == "a,b,c"
+        assert add_scopes("a,b", ["c", "d"]) == "a,b,c,d"
+        assert add_scopes("", "a") == "a"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c", "b") == "a,c"
+        assert remove_scopes("a,b,c", "b,d") == "a,c"
+        assert remove_scopes("a,b,c", ["a", "c"]) == "b"
+        assert remove_scopes("a,b", "c") == "a,b"
+        assert remove_scopes("", "a") == ""
 
 
 class TestPasskeyErrors:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,11 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.authz import normalize_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert normalize_scopes("a,b,c") == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert normalize_scopes("a,b,a") == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert normalize_scopes(" a , b , c ") == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert normalize_scopes("a,,b,,") == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Extracted pure functional helpers (`normalize_scopes`, `add_scopes`, `remove_scopes`) for scopes to `authz.py`.
🎯 Why: Reduces duplicated ad-hoc mutation logic spread across CLI code and centralizes authorization domain logic near the types.
🧠 Design: Built on top of the existing `parse_scopes` and `serialize_scopes` logic to ensure backwards compatibility.
λ FP Angle: Replaced in-place mutations and explicit state juggling with pure composable transformations (`add_scopes(existing, new)`).
✅ Verification: Added unit tests and ran the existing test suite along with ruff and mypy.
🧪 Edge cases: Handled empty parsing safely and kept previous scope duplicate cleanup logic intact.
⚠️ Risk: Low risk, completely backward compatible.

---
*PR created automatically by Jules for task [11677023868534100855](https://jules.google.com/task/11677023868534100855) started by @ToolchainLab*