### PR TITLE
⚡ Bolt: Replace func.count() with limit(1) for O(1) existence check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-22 - Avoid count() for Existence Checks
+**Learning:** When checking if a database table is empty or has any rows matching a condition using SQLAlchemy, using `select(func.count())` forces the database to count all matching rows.
+**Action:** Use `await db.scalar(select(Model.id).limit(1))` and check if the result is `None` instead of using `count`. This turns it into a much faster O(1) existence check.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -11,7 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -41,9 +41,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Use limit(1) instead of count() for O(1) existence check
+        existing = await db.scalar(select(User.id).limit(1))
+        if existing is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: 
- Replaced `select(func.count())` with `select(User.id).limit(1)` when checking if the `User` table is empty in `_is_bootstrap_admin`.
- Removed the unused `func` import from `sqlalchemy`.
- Updated the `.jules/bolt.md` journal with the new performance learning.

🎯 Why: 
Using `func.count()` forces the database to scan all matching rows (or the index) to determine the exact count, resulting in O(N) complexity. For existence checks (e.g., checking if the count is 0), it is much more efficient to use `limit(1)` and check if the result is `None`, which is an O(1) operation.

📊 Impact: 
Significantly reduces database CPU and I/O overhead during the first user check (or any similar existence check) by avoiding a full index/table scan, especially as the table grows.

🔬 Measurement: 
To verify, you can monitor the generated SQL query or database query performance. The tests (`uv run --locked pytest -v`) confirm that the existence check logic still functions correctly.

---
*PR created automatically by Jules for task [2539895976026469315](https://jules.google.com/task/2539895976026469315) started by @ToolchainLab*