### PR TITLE
🎨 Palette: Add focus visible styles to password toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-21 - Absolute Positioned Focus Rings
+**Learning:** Absolute positioned interactive elements inside inputs (like password toggles) lose their native focus rings and can become invisible to keyboard users when tabbing.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) to these nested interactive elements to ensure they remain accessible.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring styles to the absolute positioned password visibility toggle button.
🎯 Why: Keyboard users tabbing through the form could not see when the toggle button received focus because it was absolutely positioned over the input and lacked explicit focus styles.
📸 Before/After: N/A
♿ Accessibility: Ensured the interactive toggle button has a visible focus indicator using `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl`.

---
*PR created automatically by Jules for task [4134784053995548778](https://jules.google.com/task/4134784053995548778) started by @ToolchainLab*