### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-07-21 - [Prevent OOM DoS in File Uploads]
+ **Vulnerability:** Unbounded `await file.read()` calls in FastAPI load entire files into memory, causing OOM DoS vulnerabilities.
+ **Learning:** FastAPI's `UploadFile` bypasses disk spooling when read completely at once if no bounds are enforced.
+ **Prevention:** Always validate size first (using `file.size`) and bound read calls (e.g., `await file.read(max_upload_bytes + 1)`).

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,15 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+
+    # 🛡️ Sentinel: Prevent OOM DoS by checking size and using a bounded read
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unbounded `file.read()` loads the entire file into memory, leading to an OOM DoS vulnerability.
🎯 Impact: An attacker could upload a massive file and exhaust server memory.
🔧 Fix: Implemented early size validation using `file.size` and bounded the read to `max_upload_bytes + 1`.
✅ Verification: Tested uploading files within and exceeding size limits. Tested via automated test suite.

---
*PR created automatically by Jules for task [6090018848039226879](https://jules.google.com/task/6090018848039226879) started by @ToolchainLab*