### PR TITLE
∴ Vector: Centralize scope manipulation helpers in authz

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-07-22 - Centralized authorization scope manipulation
+**Learning:** When handling user scope inputs (e.g., from CLI arguments or variadic dependencies), always use the centralized pure helpers in `h4ckath0n.auth.authz` (such as `parse_scopes`, `normalize_scopes`, `add_scopes`, and `remove_scopes`) rather than implementing ad-hoc string manipulation locally. This ensures consistent deduplication, order preservation, and validation.
+**Action:** Prefer explicit transformation pipelines and centralized normalization logic. Do not duplicate domain-specific string manipulation in CLI or routing modules.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,23 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def normalize_scopes(raw: str | Iterable[str]) -> str:
+    """Normalize a scope string or iterable into the canonical comma-separated form."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(existing: str | Iterable[str], to_add: str | Iterable[str]) -> str:
+    """Add new scopes to existing scopes, returning the normalized string."""
+    current = parse_scopes(existing)
+    new_scopes = parse_scopes(to_add)
+    return serialize_scopes((*current, *new_scopes))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from existing scopes, returning the normalized string."""
+    current = parse_scopes(existing)
+    removing = set(parse_scopes(to_remove))
+    remaining = [s for s in current if s not in removing]
+    return serialize_scopes(remaining)

--- a/src/h4ckath0n/cli/__init__.py
+++ b/src/h4ckath0n/cli/__init__.py
@@ -19,7 +19,6 @@ from h4ckath0n.cli._common import (
     EXIT_OK,
     EXIT_PROD_INIT,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from h4ckath0n.cli._parser import build_parser
 from h4ckath0n.cli.db import (
@@ -56,7 +55,6 @@ __all__ = [
     "build_parser",
     "alembic_command",
     "_normalize_db_url_for_sync",
-    "_normalize_scopes",
 ]
 
 # Backwards-compatible alias (the parser builder was previously private).

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -141,11 +140,6 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
             yield session
     finally:
         engine.dispose()
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,12 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, normalize_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_OK,
-    _normalize_scopes,
     _output,
     _require_yes,
     _sync_session,
@@ -142,8 +141,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +158,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -180,7 +175,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        user.scopes = _normalize_scopes(args.scopes)
+        user.scopes = normalize_scopes(args.scopes)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,11 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
+    normalize_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +58,33 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_normalize_scopes_basic(self):
+        assert normalize_scopes("a,b,c") == "a,b,c"
+
+    def test_normalize_scopes_dedup(self):
+        assert normalize_scopes("a,b,a") == "a,b"
+
+    def test_normalize_scopes_trim(self):
+        assert normalize_scopes(" a , b , c ") == "a,b,c"
+
+    def test_normalize_scopes_empty_segments(self):
+        assert normalize_scopes("a,,b,,") == "a,b"
+
+    def test_normalize_scopes_empty_string(self):
+        assert normalize_scopes("") == ""
+
+    def test_add_scopes_merges_and_deduplicates(self):
+        assert add_scopes("a,b", "b,c") == "a,b,c"
+        assert add_scopes("a,b", "a") == "a,b"
+        assert add_scopes("", "a,b") == "a,b"
+        assert add_scopes("a", "") == "a"
+
+    def test_remove_scopes_filters_out_targets(self):
+        assert remove_scopes("a,b,c", "b,d") == "a,c"
+        assert remove_scopes("a,b", "a,b") == ""
+        assert remove_scopes("a", "") == "a"
+        assert remove_scopes("", "a") == ""
 
     def test_role_constants(self):
         assert USER == "user"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -125,28 +124,6 @@ class TestAlembicUrlNormalization:
         exit_code = cli_module._cmd_db_migrate_current(args)
         assert exit_code == 0
         assert make_url(captured["sqlalchemy.url"]) == make_url("sqlite:///./test.db")
-
-
-# ---------------------------------------------------------------------------
-# Scopes normalization
-# ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 **What:** Extracts comma-separated scope formatting and manipulation logic (`normalize_scopes`, `add_scopes`, `remove_scopes`) out of the CLI implementation into centralized pure helpers inside `h4ckath0n.auth.authz`.
- 🎯 **Why:** Authorization scopes were being handled as raw strings with ad-hoc CSV manipulations distributed across CLI handlers (`users.py` and `_common.py`). This led to duplicated transformation logic, risking drift and inconsistent deduplication/preservation.
- 🧠 **Design:** Extracted the core string manipulation into pure, stateless functions that take strings and return canonical strings. The CLI layer now merely imports and calls these, stripping out domain specific business logic from command handlers.
- λ **FP Angle:** Transforms mutation-heavy local logic involving temporary sets/lists into explicit transformation pipelines governed by a single source of truth. Enhances predictability and composability.
- ✅ **Verification:** Passed all 205 local Pytest test cases. Validated with MyPy and Ruff.
- 🧪 **Edge cases:** Handles duplicate scopes, whitespace trimming, empty inputs, and idempotent removals consistently across the application. New unit tests verify these edge cases rigorously.
- ⚠️ **Risk:** Extremely low. The internal behaviors remain exactly identical; this purely centralizes where the operations happen. All usage boundaries are statically verified by MyPy.

---
*PR created automatically by Jules for task [9904304799692309141](https://jules.google.com/task/9904304799692309141) started by @ToolchainLab*