### PR TITLE
⚡ Bolt: O(1) fast existence check for bootstrap admin

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2024-05-18 - Fast existence check using limit(1)
+**Learning:** Using `func.count()` to check if a database table is empty forces the database to count all matching rows, which is an O(N) operation. This can become a performance bottleneck on large tables.
+**Action:** Use `await db.scalar(select(Model.id).limit(1))` and check if the result is `None` instead of using `func.count()`. The `limit(1)` operation turns it into a much faster O(1) existence check.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -11,7 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -41,9 +41,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Fast existence check using limit(1) instead of counting all rows
+        result = await db.scalar(select(User.id).limit(1))
+        if result is None:
             return True
     return False
 


### PR DESCRIPTION
- 💡 What: Replaced O(N) `func.count()` with O(1) `limit(1)` for checking if the `User` table is empty during user registration.
- 🎯 Why: When deciding if a newly-registered user should be an admin, the system checks if they are the first user. `func.count()` forces the database to count all rows (O(N)), which degrades in performance as the user base grows.
- 📊 Impact: Changes the database operation from an O(N) scan to a much faster O(1) existence check.
- 🔬 Measurement: Query plans will now show a rapid `LIMIT 1` exit instead of a full table or index scan.

---
*PR created automatically by Jules for task [9294140007117409096](https://jules.google.com/task/9294140007117409096) started by @ToolchainLab*