### PR TITLE
🛡️ Sentinel: [HIGH] Fix OOM DoS in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Fix unbounded memory read DoS in FastAPI uploads
+**Vulnerability:** Unbounded `await file.read()` calls bypassing disk spooling and loading the entire file into memory.
+**Learning:** OOM DoS vulnerabilities occur because FastAPI `UploadFile` endpoints using unbounded reads can be abused to load massive payloads into memory, crashing the app.
+**Prevention:** Always validate size first (using `file.size` if available) and bound read calls (e.g., `await file.read(max_upload_bytes + 1)`).

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,16 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+
+    # 🛡️ Sentinel: Prevent OOM DoS by validating size before and during read
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    # 🛡️ Sentinel: Bound the read to max + 1 to detect over-size streams safely
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded file.read() in uploads endpoint causing OOM DoS.
🎯 Impact: An attacker can crash the server by uploading excessively large files.
🔧 Fix: Added bounded file.read(max_upload_bytes + 1) and file.size validation.
✅ Verification: Tested upload limits locally.

---
*PR created automatically by Jules for task [12701107435039691617](https://jules.google.com/task/12701107435039691617) started by @ToolchainLab*