### PR TITLE
🧭 Atlas: Replace hand-written API routes with generated OpenAPI list

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-07-22 - Extract endpoints accurately from OpenAPI for generated doc routes
+**Learning:** In FastAPI (v0.138+), iterating `app.routes` misses endpoints from included sub-routers (`_IncludedRouter`), causing drift-prevention checks to fail to verify all endpoints.
+**Action:** To reliably extract all endpoints for route generation or drift checks, parse the OpenAPI schema via `app.openapi()['paths']` instead. Prefer generating endpoint docs from source and wrapping them in HTML comment markers rather than using regex parsing to verify manually maintained lists.

--- a/README.md
+++ b/README.md
@@ -63,37 +63,54 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- GENERATED_ROUTES_START -->
+
+### General
+- `GET /` — Default root route provided by h4ckath0n.
+- `GET /health` — Basic health check for the app.
 
 ### Session
-- `GET /auth/session` — returns the current user session details.
+- `GET /auth/session` — Return information about the currently authenticated session.
+
+### Passkeys
+- `POST /auth/passkey/register/start` — Begin a passkey registration ceremony.
+- `POST /auth/passkey/register/finish` — Finish passkey registration by verifying the WebAuthn attestation for the flow and binding an optional device key.
+- `POST /auth/passkey/login/start` — Begin a username-less passkey login ceremony and return WebAuthn authentication options.
+- `POST /auth/passkey/login/finish` — Finish passkey login by verifying the WebAuthn assertion for the flow and binding an optional device key.
+- `POST /auth/passkey/add/start` — Begin adding a new passkey for the authenticated user and return registration options.
+- `POST /auth/passkey/add/finish` — Verify the WebAuthn attestation and attach the new passkey to the user.
+- `GET /auth/passkeys` — List all passkeys, including revoked entries, for the current user.
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey by its internal key ID.
+- `PATCH /auth/passkeys/{key_id}` — Update the user-facing name of a passkey.
+
+### Password Auth
+- `POST /auth/register` — Create a new account using email and password, then bind an optional device key.
+- `POST /auth/login` — Verify email and password, then bind an optional device key.
+- `POST /auth/password-reset/request` — Request a password reset token for the account.
+- `POST /auth/password-reset/confirm` — Confirm a password reset token, set a new password, and bind an optional device key.
 
 ### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+- `GET /jobs` — List recent jobs for the current user.
+- `POST /jobs` — Create a new background job.
+- `GET /jobs/{job_id}` — Get details of a specific job.
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
+- `GET /uploads` — List uploads for the current user.
+- `POST /uploads` — Upload a file (multipart/form-data).
+- `GET /uploads/{upload_id}` — Get upload metadata.
+- `GET /uploads/{upload_id}/download` — Stream the file back to the owner.
 
 ### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+- `POST /llm/chat` — Non-streaming chat completion.
+- `POST /llm/chat/stream` — Stream LLM tokens via SSE.
+
+<!-- GENERATED_ROUTES_END -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn). See the Built-in routes section above for the exact endpoints.
 
 ### Device signed JWTs
 
@@ -145,12 +162,7 @@ def refund(user=require_scopes("billing:refund")):
 ## Password auth (optional)
 
 Password routes mount only when the password extra is installed and
-`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
+`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`. See the Built-in routes section above for the exact endpoints.
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -2,28 +2,29 @@
 """Drift-prevention check: verify that every API route in the FastAPI app is documented.
 
 Usage (from repo root):
-    uv run scripts/check_doc_routes.py
+    uv run scripts/check_doc_routes.py [--update]
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, enumerates all routes via OpenAPI, groups them
+by tags, and checks that README.md contains this text exactly between the
+<!-- GENERATED_ROUTES_START --> and <!-- GENERATED_ROUTES_END --> markers.
 """
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
+from collections import defaultdict
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
 
-# FastAPI internal paths that we do not require in user docs.
-FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
+MARKER_START = "<!-- GENERATED_ROUTES_START -->"
+MARKER_END = "<!-- GENERATED_ROUTES_END -->"
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def generate_routes_markdown() -> str:
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -32,58 +33,89 @@ def get_app_routes() -> list[tuple[str, str]]:
         password_auth_enabled=True,
     )
     app = create_app(settings)
+    openapi = app.openapi()
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
+    groups = defaultdict(list)
+    for path, methods in openapi.get("paths", {}).items():
+        for method, operation in methods.items():
+            tags = operation.get("tags")
+            # If no tags, bucket to "General"
+            tag = tags[0] if tags else "General"
+
+            summary = operation.get("summary", "")
+            desc = operation.get("description", "")
+
+            # Use only the first sentence of the description
+            first_sentence = desc.split(".")[0] + "." if desc else ""
+            if not first_sentence:
+                first_sentence = summary + "." if summary else ""
+
+            groups[tag].append((method.upper(), path, first_sentence))
+
+    # Order and map raw tags to nice headers
+    tag_order = [
+        "General",
+        "auth",
+        "passkey",
+        "password-auth",
+        "jobs",
+        "uploads",
+        "llm",
+    ]
+
+    header_map = {
+        "General": "General",
+        "auth": "Session",
+        "passkey": "Passkeys",
+        "password-auth": "Password Auth",
+        "jobs": "Background Jobs",
+        "uploads": "Uploads",
+        "llm": "LLM Chat",
+    }
+
+    lines = []
+    for tag in tag_order:
+        if tag not in groups:
             continue
-        path: str = route.path  # type: ignore[union-attr]
-        if path in FRAMEWORK_PATHS:
-            continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
 
+        header = header_map.get(tag, tag.title())
+        lines.append(f"### {header}")
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+        for m, p, d in groups[tag]:
+            text = f"- `{m} {p}` — {d}"
+            lines.append(text)
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+        lines.append("")
+
+    return "\n".join(lines).strip()
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    parser = argparse.ArgumentParser(description="Check or update documented routes.")
+    parser.add_argument("--update", action="store_true", help="Update README.md inline")
+    args = parser.parse_args()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    readme_text = README.read_text(encoding="utf-8")
+    if MARKER_START not in readme_text or MARKER_END not in readme_text:
+        print(f"❌ Error: {MARKER_START} or {MARKER_END} not found in README.md")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    generated_md = generate_routes_markdown()
+    pattern = re.compile(rf"{re.escape(MARKER_START)}.*?{re.escape(MARKER_END)}", re.DOTALL)
+    expected_text = f"{MARKER_START}\n\n{generated_md}\n\n{MARKER_END}"
+    new_text = pattern.sub(expected_text, readme_text)
+
+    if new_text != readme_text:
+        if args.update:
+            README.write_text(new_text, encoding="utf-8")
+            print("✅ Updated README.md with generated API routes.")
+            return 0
+        else:
+            print("❌ The API routes documented in README.md are out of date.")
+            print("Run `uv run scripts/check_doc_routes.py --update` to fix.")
+            return 1
+
+    print("✅ All API routes are documented correctly in README.md.")
     return 0
 
 


### PR DESCRIPTION
💡 What: Replaced manually maintained API endpoint lists in `README.md` with a dynamically generated block between HTML comment markers.
🎯 Why: Iterating `app.routes` in FastAPI v0.138+ can miss endpoints mounted via sub-routers. Manually maintaining API endpoints in `README.md` leads to drift. This change uses `app.openapi()['paths']` to dynamically fetch and inject the exact API routes the application exposes.
🔬 Verification: Run `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run --locked pytest -v`. Also check local generation by running `uv run scripts/check_doc_routes.py --update`.
🔒 Drift Prevention: Updated `scripts/check_doc_routes.py` to extract all routes accurately from `app.openapi()['paths']`, group them, build a markdown string, and check that `README.md` contains the exact generated markdown. 
🗺️ Evidence: See `README.md` and `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [10886880773113897367](https://jules.google.com/task/10886880773113897367) started by @ToolchainLab*