### PR TITLE
∴ Vector: Centralize scope mutation into pure FP helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-07-23 - Centralize Scope Transformations
+**Learning:** When handling user scope inputs, ad-hoc `parse_scopes` and `serialize_scopes` logic is prone to drift and mutation complexity.
+**Action:** Always use centralized pure helpers (`normalize_scopes`, `add_scopes`, and `remove_scopes`) in `h4ckath0n.auth.authz` to ensure consistent deduplication, order preservation, and validation.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,23 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def normalize_scopes(raw: str | Iterable[str]) -> str:
+    """Parse and re-serialize scopes to their canonical comma-separated form."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(current: str, to_add: str | Iterable[str]) -> str:
+    """Add new scopes to a serialized scope string, preserving order and deduplicating."""
+    existing = parse_scopes(current)
+    new = parse_scopes(to_add)
+    return serialize_scopes((*existing, *new))
+
+
+def remove_scopes(current: str, to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from a serialized scope string."""
+    existing = parse_scopes(current)
+    removing = set(parse_scopes(to_remove))
+    remaining = [s for s in existing if s not in removing]
+    return serialize_scopes(remaining)

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,7 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import normalize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -145,7 +145,7 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
 
 def _normalize_scopes(raw: str) -> str:
     """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
+    return normalize_scopes(raw)
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,12 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, normalize_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_OK,
-    _normalize_scopes,
     _output,
     _require_yes,
     _sync_session,
@@ -142,8 +141,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +158,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -180,7 +175,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        user.scopes = _normalize_scopes(args.scopes)
+        user.scopes = normalize_scopes(args.scopes)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,11 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
+    normalize_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +58,15 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_normalize_scopes(self):
+        assert normalize_scopes(" b , a,b, c ") == "b,a,c"
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", "b,c") == "a,b,c"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c", "b,d") == "a,c"
 
     def test_role_constants(self):
         assert USER == "user"


### PR DESCRIPTION
- 💡 What: Extracted `normalize_scopes`, `add_scopes`, and `remove_scopes` pure functions into `h4ckath0n.auth.authz`, replacing ad-hoc inline scope manipulation in the CLI commands.
- 🎯 Why: Scope handling (parsing comma-separated values, deduplicating, sorting, and serializing) was repeated across several call sites in the CLI, causing mutation-heavy and drift-prone code. Centralizing this logic ensures there is a single source of truth for scope strings.
- 🧠 Design: By keeping the actual behavior mathematically identical, these functions serve as pure FP-friendly pipeline steps. The original inline unpacking logic was extracted directly, minimizing risk.
- λ FP Angle: Replaced in-place variable modification and ad-hoc list comprehensions with pure data-in/data-out transformation pipelines.
- ✅ Verification: Ran the full `pytest` suite, `ruff` checks and formatters, and `mypy`. All passed successfully. Added specific unit tests in `test_authz.py`.
- 🧪 Edge cases: Normalization correctly trims whitespace and ignores empty string fragments, preserving identical behavior.
- ⚠️ Risk: Minimal risk. Behavior is completely isolated to the CLI domain and fully tested.

---
*PR created automatically by Jules for task [11753664386732107177](https://jules.google.com/task/11753664386732107177) started by @ToolchainLab*