### PR TITLE
⚡ Bolt: Replace O(N) table count with O(1) existence check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-20 - Replace O(N) Table Count with O(1) limit(1)
+**Learning:** Checking if a database table is empty or has matching rows using `select(func.count())` forces the database to scan all matching rows (O(N) operation).
+**Action:** When checking for existence, always use `await db.scalar(select(Model.id).limit(1))` and check if the result is `None`. This turns it into an O(1) operation.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -11,7 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -41,9 +41,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Use limit(1) instead of count() for O(1) existence check
+        first_user_id = await db.scalar(select(User.id).limit(1))
+        if first_user_id is None:
             return True
     return False
 
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Use scalar() for ID-only lookup instead of full ORM instantiation
+    if await db.scalar(select(User.id).filter(User.email == email).limit(1)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(


### PR DESCRIPTION
💡 What: Replaced O(N) `select(func.count())` and full ORM instantiation with O(1) `select(User.id).limit(1)` in database existence checks inside `src/h4ckath0n/auth/service.py`. Removed unused `func` import.
🎯 Why: Using `.scalars().first()` forces SQLAlchemy to parse and hydrate the full ORM object. `func.count()` forces the database to count all matching rows. Using `.limit(1)` and `.scalar()` avoids ORM hydration and database scanning overhead, significantly improving efficiency.
📊 Impact: Existence checks like `register_user` and `_is_bootstrap_admin` will execute much faster, especially as the database grows, reducing memory allocations and database load.
🔬 Measurement: Run `uv run --locked pytest -v` to ensure tests continue passing. Benchmark auth operations before and after under load.

---
*PR created automatically by Jules for task [9899759871814801455](https://jules.google.com/task/9899759871814801455) started by @ToolchainLab*