### PR TITLE
🎨 Palette: Add focus rings to interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-23 - Focus Rings on Absolute Positioned Interactive Elements
+**Learning:** Absolute positioned interactive elements inside inputs (like password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl`) to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Layout.tsx
@@ -253,7 +253,7 @@ export function Layout() {
                   <div className="border-t border-border my-2" />
                   <button
                     onClick={() => void logout()}
-                    className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-danger hover:bg-danger/10 transition-colors"
+                    className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-danger hover:bg-danger/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger"
                     data-testid="nav-logout-mobile"
                   >
                     <LogOut className="w-4 h-4" />

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring styling (`focus-visible:ring-2`) to absolute positioned interactive elements, specifically the password visibility toggle and mobile logout button.
🎯 Why: Elements with absolute positioning or specific reset styles often miss native focus rings, making them functionally invisible to keyboard users when focused.
📸 Before/After: The password toggle and mobile logout buttons now show a visible outline when navigated to via keyboard.
♿ Accessibility: Improved keyboard navigation support by ensuring focused interactive elements are always visible to screen reader and keyboard-only users.

---
*PR created automatically by Jules for task [2538604900628409696](https://jules.google.com/task/2538604900628409696) started by @ToolchainLab*