### PR TITLE
🛡️ Sentinel: [HIGH] Fix OOM DoS via unbounded UploadFile read

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Unbounded File Read OOM DoS
+**Vulnerability:** Calling `await file.read()` on FastAPI `UploadFile` objects without a size limit reads the entire file into memory, causing OOM DoS.
+**Learning:** Validation via `len(data) > max_bytes` after reading is too late, because the unbounded read has already occurred.
+**Prevention:** Always check `file.size` first (if available) and bound the read using `await file.read(max_upload_bytes + 1)` before validating the length of the read chunk.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,14 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    # 🛡️ Sentinel: Bound read to prevent OOM DoS
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Calling `await file.read()` on FastAPI `UploadFile` objects without a size limit bypasses disk spooling and reads the entire file into memory, causing an Out-Of-Memory Denial-Of-Service (OOM DoS) vulnerability if a massive file is uploaded.
🎯 Impact: Attackers can crash the server by uploading extremely large files, resulting in a denial of service for all users.
🔧 Fix: Checked `file.size` upfront if available, and bounded the read using `await file.read(settings.max_upload_bytes + 1)`. If the bounded read returns more than `max_upload_bytes`, it correctly raises a 413 error without exhausting memory.
✅ Verification: Ran the full backend test suite (`uv run --locked pytest -v`) and confirmed all tests pass without regression. Checked that the fix is applied and properly handles large file logic securely.

---
*PR created automatically by Jules for task [13442493471204548413](https://jules.google.com/task/13442493471204548413) started by @ToolchainLab*