### PR TITLE
🧭 Atlas: Replace manual API routes with generated OpenAPI table

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2025-01-18 - Replacing manual route lists with generated OpenAPI blocks
+**Learning:** FastAPI (v0.138+) iterating `app.routes` misses endpoints from included sub-routers. To reliably extract all endpoints for route generation or drift checks, parse the OpenAPI schema via `app.openapi()['paths']`. Prefer generating endpoint docs from source and wrapping them in HTML comment markers rather than using regex parsing to verify manually maintained lists.
+**Action:** When auditing manually written route lists, replace them with dynamically generated markdown blocks using OpenAPI paths and tags to prevent drift and provide comprehensive documentation including path summaries.

--- a/README.md
+++ b/README.md
@@ -63,37 +63,74 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- routes-start -->
+### System
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/` | Welcome |
+| `GET` | `/health` | Health |
+
+### Passkeys (Default Auth)
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/auth/passkey/add/finish` | Finish adding a passkey |
+| `POST` | `/auth/passkey/add/start` | Start adding a passkey |
+| `POST` | `/auth/passkey/login/finish` | Finish passkey login |
+| `POST` | `/auth/passkey/login/start` | Start passkey login |
+| `POST` | `/auth/passkey/register/finish` | Finish passkey registration |
+| `POST` | `/auth/passkey/register/start` | Start passkey registration |
+| `GET` | `/auth/passkeys` | List passkeys |
+| `PATCH` | `/auth/passkeys/{key_id}` | Rename a passkey |
+| `POST` | `/auth/passkeys/{key_id}/revoke` | Revoke a passkey |
+
+### Password Auth (Optional)
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/auth/login` | Login with password |
+| `POST` | `/auth/password-reset/confirm` | Confirm password reset |
+| `POST` | `/auth/password-reset/request` | Request a password reset |
+| `POST` | `/auth/register` | Register with password |
 
 ### Session
-- `GET /auth/session` — returns the current user session details.
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/auth/session` | Current session |
 
 ### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/jobs` | List jobs |
+| `POST` | `/jobs` | Enqueue a job |
+| `GET` | `/jobs/{job_id}` | Get job |
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
+
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/uploads` | List uploads |
+| `POST` | `/uploads` | Upload a file |
+| `GET` | `/uploads/{upload_id}` | Get upload metadata |
+| `GET` | `/uploads/{upload_id}/download` | Download a file |
 
 ### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/llm/chat` | Chat completion |
+| `POST` | `/llm/chat/stream` | Streaming chat completion |
+
+<!-- routes-end -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn). These core flows are listed in the Built-in routes table under Passkeys.
 
 ### Device signed JWTs
 
@@ -147,10 +184,7 @@ def refund(user=require_scopes("billing:refund")):
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
 
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
+These routes are listed in the Built-in routes table under Password Auth.
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env -S uv run python
-"""Drift-prevention check: verify that every API route in the FastAPI app is documented.
+"""Drift-prevention check: verify that the API routes in README.md exactly match the app's OpenAPI schema.
 
 Usage (from repo root):
     uv run scripts/check_doc_routes.py
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, generates a markdown section of all routes,
+and checks that it matches the content between <!-- routes-start --> and <!-- routes-end --> in README.md.
 """
 
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 
@@ -21,11 +19,20 @@ README = REPO_ROOT / "README.md"
 # FastAPI internal paths that we do not require in user docs.
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
+TAG_TITLES = {
+    "System": "System",
+    "passkey": "Passkeys (Default Auth)",
+    "auth": "Session",
+    "jobs": "Background Jobs",
+    "uploads": "Uploads",
+    "llm": "LLM Chat",
+    "password-auth": "Password Auth (Optional)",
+}
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
-    from h4ckath0n.app import create_app  # noqa: E402
-    from h4ckath0n.config import Settings  # noqa: E402
+def generate_routes_markdown() -> str:
+    """Generate the markdown table of routes from the OpenAPI schema."""
+    from h4ckath0n.app import create_app
+    from h4ckath0n.config import Settings
 
     settings = Settings(
         database_url="sqlite+aiosqlite://",
@@ -33,57 +40,65 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    paths = app.openapi().get("paths", {})
+
+    routes_by_tag: dict[str, list[tuple[str, str, str]]] = {}
+    for path, methods in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method, op in methods.items():
+            if method.lower() == "head":
                 continue
-            routes.append((method, path))
-    return sorted(routes)
+            tags = op.get("tags", [])
+            tag = tags[0] if tags else "System"
+            summary = op.get("summary", "")
+            if tag not in routes_by_tag:
+                routes_by_tag[tag] = []
+            routes_by_tag[tag].append((method.upper(), path, summary))
 
+    lines = []
+    lines.append("<!-- routes-start -->")
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+    order = ["System", "passkey", "password-auth", "auth", "jobs", "uploads", "llm"]
+    sorted_tags = sorted(routes_by_tag.keys(), key=lambda t: order.index(t) if t in order else len(order))
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    for tag in sorted_tags:
+        title = TAG_TITLES.get(tag, tag.capitalize())
+        lines.append(f"### {title}")
+        lines.append("")
+        lines.append("| Method | Path | Summary |")
+        lines.append("|---|---|---|")
+        for method, path, summary in sorted(routes_by_tag[tag], key=lambda x: (x[1], x[0])):
+            lines.append(f"| `{method}` | `{path}` | {summary} |")
+        lines.append("")
+
+    lines.append("<!-- routes-end -->")
+    return "\n".join(lines)
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    readme_text = README.read_text()
+    start_marker = "<!-- routes-start -->"
+    end_marker = "<!-- routes-end -->"
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print("❌ Could not find <!-- routes-start --> or <!-- routes-end --> markers in README.md.")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    expected_md = generate_routes_markdown()
+
+    start_idx = readme_text.index(start_marker)
+    end_idx = readme_text.index(end_marker) + len(end_marker)
+    actual_md = readme_text[start_idx:end_idx]
+
+    if actual_md != expected_md:
+        print("❌ The API routes in README.md are out of date or incorrectly formatted.")
+        print("Expected block:\n")
+        print(expected_md)
+        print("\n\nPlease update README.md to match exactly, or update scripts/check_doc_routes.py.")
+        return 1
+
+    print("✅ All API routes in README.md are correctly documented and up to date.")
     return 0
 
 

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env -S uv run python
-"""Drift-prevention check: verify that the API routes in README.md exactly match the app's OpenAPI schema.
+"""Drift-prevention check: verify that the API routes in README.md match the app's OpenAPI schema.
 
 Usage (from repo root):
     uv run scripts/check_doc_routes.py
 
 The script imports the h4ckath0n app, generates a markdown section of all routes,
-and checks that it matches the content between <!-- routes-start --> and <!-- routes-end --> in README.md.
+and checks that it matches the content between <!-- routes-start --> and <!-- routes-end -->.
 """
 
 from __future__ import annotations
@@ -28,6 +28,7 @@ TAG_TITLES = {
     "llm": "LLM Chat",
     "password-auth": "Password Auth (Optional)",
 }
+
 
 def generate_routes_markdown() -> str:
     """Generate the markdown table of routes from the OpenAPI schema."""
@@ -60,7 +61,9 @@ def generate_routes_markdown() -> str:
     lines.append("<!-- routes-start -->")
 
     order = ["System", "passkey", "password-auth", "auth", "jobs", "uploads", "llm"]
-    sorted_tags = sorted(routes_by_tag.keys(), key=lambda t: order.index(t) if t in order else len(order))
+    sorted_tags = sorted(
+        routes_by_tag.keys(), key=lambda t: order.index(t) if t in order else len(order)
+    )
 
     for tag in sorted_tags:
         title = TAG_TITLES.get(tag, tag.capitalize())
@@ -82,7 +85,9 @@ def main() -> int:
     end_marker = "<!-- routes-end -->"
 
     if start_marker not in readme_text or end_marker not in readme_text:
-        print("❌ Could not find <!-- routes-start --> or <!-- routes-end --> markers in README.md.")
+        print(
+            "❌ Could not find <!-- routes-start --> or <!-- routes-end --> markers in README.md."
+        )
         return 1
 
     expected_md = generate_routes_markdown()
@@ -95,7 +100,9 @@ def main() -> int:
         print("❌ The API routes in README.md are out of date or incorrectly formatted.")
         print("Expected block:\n")
         print(expected_md)
-        print("\n\nPlease update README.md to match exactly, or update scripts/check_doc_routes.py.")
+        print(
+            "\n\nPlease update README.md to match exactly, or update scripts/check_doc_routes.py."
+        )
         return 1
 
     print("✅ All API routes in README.md are correctly documented and up to date.")


### PR DESCRIPTION
💡 What: Replaced manual API routes in `README.md` with an autogenerated markdown table parsed from the OpenAPI schema and updated `scripts/check_doc_routes.py` to enforce drift prevention against `README.md`.
🎯 Why: Handwritten route listings are highly prone to drift, as seen by multiple redundant sublists (like password auth and passkey defaults). Creating a strict, verifiable section prevents future route regressions and brings the docs exactly in line with the code's behavior.
🔬 Verification: Run `uv run scripts/check_doc_routes.py` locally and ensure it reports `✅ All API routes in README.md are correctly documented and up to date.` Run `uv run --locked pytest -v` to ensure no functionality is affected.
🔒 Drift Prevention: `scripts/check_doc_routes.py` no longer uses regex for partial matches; it generates the full markdown table block from source and verifies it perfectly matches the `README.md` block bounded by `<!-- routes-start -->` and `<!-- routes-end -->`.
🗺️ Evidence: `src/h4ckath0n/app.py` OpenAPI paths logic, `README.md`, `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [18229126863383027685](https://jules.google.com/task/18229126863383027685) started by @ToolchainLab*