### PR TITLE
⚡ Bolt: Use O(1) existence check instead of count() for first user check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2024-07-24 - Use limit(1) instead of count() for Existence Checks
+
+**Learning:** When checking if a database table is empty or has matching rows using SQLAlchemy, using `select(func.count())` forces the database to scan/count matching rows, which is O(N).
+**Action:** Use `await db.scalar(select(Model.id).limit(1))` and check if the result is `None`. The `limit(1)` operation turns it into a much faster O(1) existence check.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -11,7 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -41,9 +41,8 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        result = await db.scalar(select(User.id).limit(1))
+        if result is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: Replaced `func.count()` with `limit(1)` in `_is_bootstrap_admin` and removed the unused `func` import.
🎯 Why: `func.count()` scans all rows in the User table which is O(N). `limit(1)` is an O(1) operation.
📊 Impact: Prevents a potential database performance bottleneck during user registration.
🔬 Measurement: Verify via DB query logs or execution time for the registration endpoint.

---
*PR created automatically by Jules for task [16305542339480854008](https://jules.google.com/task/16305542339480854008) started by @ToolchainLab*