### PR TITLE
🎨 Palette: Add keyboard focus styles to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-24 - Focus rings on absolute positioned interactive elements
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2`) to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) to the absolute-positioned password visibility toggle button in `PasswordField.tsx`.
🎯 Why: To ensure the toggle button is clearly visible during keyboard navigation. Absolute positioned interactive elements often miss native focus rings or inherit clipped bounds.
📸 Before/After: The button now shows a primary colored focus ring when focused via keyboard (verified via screenshot and video).
♿ Accessibility: Improved keyboard navigation accessibility by providing a clear visual indicator of focus for screen reader and keyboard-only users.

---
*PR created automatically by Jules for task [2321237185962777300](https://jules.google.com/task/2321237185962777300) started by @ToolchainLab*