### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS vulnerability in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-07-24 - Unbounded File Read in Uploads
+**Vulnerability:** Unbounded `await file.read()` calls bypassing disk spooling and loading entire files into memory.
+**Learning:** FastAPI's `UploadFile.read()` without a size limit can cause Out-Of-Memory (OOM) Denial of Service (DoS) attacks when processing large files.
+**Prevention:** Always check `file.size` if available, and bound `file.read()` calls to `max_upload_bytes + 1` to strictly enforce memory usage limits.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,12 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unbounded `await file.read()` in uploads router causing potential OOM DoS
🎯 Impact: An attacker could upload massive files causing the application to crash due to memory exhaustion
🔧 Fix: Implemented early size rejection using `file.size` and bounded the `file.read` call to `max_upload_bytes + 1`
✅ Verification: Covered by existing upload test suite and verified manually

---
*PR created automatically by Jules for task [15242422540923360967](https://jules.google.com/task/15242422540923360967) started by @ToolchainLab*