### PR TITLE
🧭 Atlas: Replace manual API routes list with OpenAPI-generated docs

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-07-24 - Missed FastAPI Routes in Drift Checks
+**Learning:** In FastAPI (v0.138+), iterating `app.routes` misses endpoints from included sub-routers (`_IncludedRouter`), causing drift checks to falsely under-report total endpoints.
+**Action:** To reliably extract all endpoints for route generation or drift checks, always parse the OpenAPI schema via `app.openapi()['paths']` instead of iterating `app.routes`.

--- a/README.md
+++ b/README.md
@@ -61,39 +61,41 @@ uv run uvicorn your_module:app --reload
 - Protected routes require an `Authorization: Bearer <device_jwt>` header that the web
   template can mint after login.
 
-## Built-in routes
+## API routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- BEGIN API ROUTES -->
+- `POST /auth/passkey/register/start` — Start passkey registration
+- `POST /auth/passkey/register/finish` — Finish passkey registration
+- `POST /auth/passkey/login/start` — Start passkey login
+- `POST /auth/passkey/login/finish` — Finish passkey login
+- `POST /auth/passkey/add/start` — Start adding a passkey
+- `POST /auth/passkey/add/finish` — Finish adding a passkey
+- `GET /auth/passkeys` — List passkeys
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey
+- `PATCH /auth/passkeys/{key_id}` — Rename a passkey
+- `GET /auth/session` — Current session
+- `GET /jobs` — List jobs
+- `POST /jobs` — Enqueue a job
+- `GET /jobs/{job_id}` — Get job
+- `GET /uploads` — List uploads
+- `POST /uploads` — Upload a file
+- `GET /uploads/{upload_id}` — Get upload metadata
+- `GET /uploads/{upload_id}/download` — Download a file
+- `POST /llm/chat` — Chat completion
+- `POST /llm/chat/stream` — Streaming chat completion
+- `POST /auth/register` — Register with password
+- `POST /auth/login` — Login with password
+- `POST /auth/password-reset/request` — Request a password reset
+- `POST /auth/password-reset/confirm` — Confirm password reset
+- `GET /` — Welcome
+- `GET /health` — Health
+<!-- END API ROUTES -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn).
 
 ### Device signed JWTs
 
@@ -146,11 +148,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -1,29 +1,28 @@
 #!/usr/bin/env -S uv run python
-"""Drift-prevention check: verify that every API route in the FastAPI app is documented.
+"""Drift-prevention check: verify that API routes in the FastAPI app are documented.
 
 Usage (from repo root):
-    uv run scripts/check_doc_routes.py
+    uv run scripts/check_doc_routes.py [--fix]
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script generates a list of API routes from the OpenAPI schema and ensures
+it perfectly matches the block between <!-- BEGIN API ROUTES --> and
+<!-- END API ROUTES --> in README.md.
 """
 
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
 
-# FastAPI internal paths that we do not require in user docs.
-FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
+START_MARKER = "<!-- BEGIN API ROUTES -->"
+END_MARKER = "<!-- END API ROUTES -->"
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_openapi_routes() -> str:
+    """Return formatted Markdown string of all API routes."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -32,59 +31,49 @@ def get_app_routes() -> list[tuple[str, str]]:
         password_auth_enabled=True,
     )
     app = create_app(settings)
+    openapi = app.openapi()
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
-        if path in FRAMEWORK_PATHS:
-            continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+    lines = []
+    for path, path_item in openapi.get("paths", {}).items():
+        for method, op in path_item.items():
+            if method.lower() not in ("get", "post", "put", "patch", "delete", "options"):
                 continue
-            routes.append((method, path))
-    return sorted(routes)
+            summary = op.get("summary", "")
+            lines.append(f"- `{method.upper()} {path}` — {summary}")
 
-
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
-
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    return "\n".join(lines) + "\n"
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    fix = "--fix" in sys.argv
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    readme_text = README.read_text()
+    start_idx = readme_text.find(START_MARKER)
+    end_idx = readme_text.find(END_MARKER)
+
+    if start_idx == -1 or end_idx == -1:
+        print("❌ Markers not found in README.md")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+    generated = get_openapi_routes()
+
+    prefix = readme_text[:start_idx + len(START_MARKER)] + "\n"
+    suffix = readme_text[end_idx:]
+
+    current_block = readme_text[start_idx + len(START_MARKER):end_idx].lstrip("\n")
+
+    if current_block == generated:
+        print("✅ API routes in README.md are up to date.")
+        return 0
+
+    if fix:
+        README.write_text(prefix + generated + suffix)
+        print("🔧 Updated API routes in README.md.")
+        return 0
+
+    print("❌ API routes in README.md are out of date.")
+    print("Run `uv run scripts/check_doc_routes.py --fix` to update.")
+    return 1
 
 
 if __name__ == "__main__":

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -57,10 +57,10 @@ def main() -> int:
 
     generated = get_openapi_routes()
 
-    prefix = readme_text[:start_idx + len(START_MARKER)] + "\n"
+    prefix = readme_text[: start_idx + len(START_MARKER)] + "\n"
     suffix = readme_text[end_idx:]
 
-    current_block = readme_text[start_idx + len(START_MARKER):end_idx].lstrip("\n")
+    current_block = readme_text[start_idx + len(START_MARKER) : end_idx].lstrip("\n")
 
     if current_block == generated:
         print("✅ API routes in README.md are up to date.")


### PR DESCRIPTION
💡 What: Replaced the manually maintained API route lists in the README with a single generated section powered by OpenAPI parsing, and updated `check_doc_routes.py` to support automatic `--fix` generation.
🎯 Why: The previous drift check script iterated `app.routes` which silently missed all sub-routers (due to FastAPI's `_IncludedRouter` nesting). It only verified 2 out of 25 routes. This fix ensures the README accurately and verifiably documents the complete API.
🧪 Verification: Run `uv run scripts/check_doc_routes.py` and `uv run pytest -v`.
🔒 Drift Prevention: `scripts/check_doc_routes.py` now parses `app.openapi()['paths']` and stringently enforces that the Markdown block in `README.md` is perfectly up-to-date.
🗺️ Evidence: `src/h4ckath0n/app.py`, `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [12554261155952520105](https://jules.google.com/task/12554261155952520105) started by @ToolchainLab*