### PR TITLE
∴ Vector: Centralize authz scope transformations

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-03-22 - Centralize authz scope transformations
+**Learning:** Logic for adding and removing comma-separated scopes was duplicated in the CLI using ad-hoc `parse_scopes` / `serialize_scopes` manipulation, which obscures intent and misses a shared normalization boundary.
+**Action:** Always centralize string serialization/manipulation (like user scopes) into pure, tested domain helpers (e.g. `add_scopes`, `remove_scopes`) rather than inline `serialize_scopes((*existing, *parse_scopes(to_add)))` at call sites.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -38,6 +38,26 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
     return ",".join(dict.fromkeys(str(s) for s in scopes if s))
 
 
+def normalize_scopes(raw: str) -> str:
+    """Normalize a comma-separated scopes string."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(raw: str, scopes_to_add: Iterable[str]) -> str:
+    """Add new scopes to an existing scope string, preserving order."""
+    existing = parse_scopes(raw)
+    to_add = parse_scopes(scopes_to_add)
+    return serialize_scopes((*existing, *to_add))
+
+
+def remove_scopes(raw: str, scopes_to_remove: Iterable[str]) -> str:
+    """Remove scopes from an existing scope string."""
+    existing = parse_scopes(raw)
+    to_remove = set(parse_scopes(scopes_to_remove))
+    remaining = [s for s in existing if s not in to_remove]
+    return serialize_scopes(remaining)
+
+
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)

--- a/src/h4ckath0n/cli/__init__.py
+++ b/src/h4ckath0n/cli/__init__.py
@@ -19,7 +19,6 @@ from h4ckath0n.cli._common import (
     EXIT_OK,
     EXIT_PROD_INIT,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from h4ckath0n.cli._parser import build_parser
 from h4ckath0n.cli.db import (
@@ -56,7 +55,6 @@ __all__ = [
     "build_parser",
     "alembic_command",
     "_normalize_db_url_for_sync",
-    "_normalize_scopes",
 ]
 
 # Backwards-compatible alias (the parser builder was previously private).

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -141,11 +140,6 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
             yield session
     finally:
         engine.dispose()
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,12 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, normalize_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_OK,
-    _normalize_scopes,
     _output,
     _require_yes,
     _sync_session,
@@ -142,8 +141,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +158,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -180,7 +175,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        user.scopes = _normalize_scopes(args.scopes)
+        user.scopes = normalize_scopes(args.scopes)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,11 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
+    normalize_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -45,6 +48,19 @@ class TestScopes:
 
     def test_serialize_deduplicates(self):
         assert serialize_scopes([Scope("a"), Scope("a"), Scope("b")]) == "a,b"
+
+    def test_normalize_scopes(self):
+        assert normalize_scopes(" a , b,a, c ") == "a,b,c"
+        assert normalize_scopes("") == ""
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", ["c,d", "a"]) == "a,b,c,d"
+        assert add_scopes("a,b", "b,c") == "a,b,c"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c,d", ["b,e", "d"]) == "a,c"
+        assert remove_scopes("a,b,c", "c,d") == "a,b"
+        assert remove_scopes("a,b", "") == "a,b"
 
     def test_missing_scopes_returns_difference(self):
         granted = parse_scopes("admin,demo")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,11 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.authz import normalize_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -134,19 +134,19 @@ class TestAlembicUrlNormalization:
 
 class TestNormalizeScopes:
     def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
+        assert normalize_scopes("a,b,c") == "a,b,c"
 
     def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
+        assert normalize_scopes("a,b,a") == "a,b"
 
     def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
+        assert normalize_scopes(" a , b , c ") == "a,b,c"
 
     def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
+        assert normalize_scopes("a,,b,,") == "a,b"
 
     def test_empty_string(self):
-        assert _normalize_scopes("") == ""
+        assert normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Extract pure helper functions `normalize_scopes`, `add_scopes`, and `remove_scopes` in `h4ckath0n.auth.authz`.
🎯 Why: Replaces ad-hoc string manipulation (parsing, unpacking, filtering, serializing) in CLI mutation logic with centralized, tested, intent-revealing domain helpers.
🧠 Design: Pushes scope manipulation to the edge (domain module) maintaining pure data-in/data-out invariants.
λ FP Angle: Eliminates repeated mutation logic in favor of declarative and composable transformation pipelines on the immutable strings.
✅ Verification: Run full pytest suite, mypy, and ruff formatting/linting check.
🧪 Edge cases: Normalizes empty segments and duplicates naturally via `parse_scopes` and provides unit tests in `test_authz.py`.
⚠️ Risk: Very low. It strictly restructures existing helper patterns without breaking the public interface (removes internal CLI helper `_normalize_scopes`).

---
*PR created automatically by Jules for task [2348916277852407676](https://jules.google.com/task/2348916277852407676) started by @ToolchainLab*