### PR TITLE
⚡ Bolt: Use limit(1) for O(1) user table existence check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2024-07-25 - Use limit(1) instead of count() for existence checks
+**Learning:** When checking if a database table is empty (like the User table), `select(func.count())` forces the database to scan all rows. This scales poorly as the table grows.
+**Action:** Use `await db.scalar(select(Model.id).limit(1))` and check for `None`. This creates an O(1) query instead of O(N).

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -11,7 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -41,9 +41,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Use limit(1) instead of count() for O(1) existence check
+        user_id = await db.scalar(select(User.id).limit(1))
+        if user_id is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What:
Replaced the `select(func.count())` database operation in `register_user`'s admin initialization check with an existence check using `select(User.id).limit(1)`. Unused `func` import was also removed.

🎯 Why:
The original code was querying for a full table scan and aggregation count of the `User` table just to determine if it was empty. This causes a major scalability issue: as the number of users grows, the query becomes slower and consumes more resources unnecessarily.

📊 Impact:
The query complexity drops from O(N) to O(1). This makes the first user initialization check consistently fast regardless of the database size and prevents potential performance bottlenecks when setting up or validating bootstrap users on a production-sized database.

🔬 Measurement:
Run the test suite (which passes fully) to ensure that the logic checking `first_user_is_admin` still operates perfectly for `0` users and `>0` users.

---
*PR created automatically by Jules for task [16481452601841581958](https://jules.google.com/task/16481452601841581958) started by @ToolchainLab*