### PR TITLE
🎨 Palette: Add keyboard focus ring to password toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-26 - Add focus rings to absolute positioned interactive elements
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds, making them invisible during keyboard navigation.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2`) to these elements to ensure they are visible and accessible to keyboard users.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-colors disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added `focus-visible:outline-none`, `focus-visible:ring-2`, and `focus-visible:ring-primary` utility classes to the password visibility toggle button in `PasswordField.tsx`.
🎯 Why: Absolutely positioned interactive elements often miss native focus rings, making them invisible during keyboard navigation. This ensures users can see when the toggle button is focused.
📸 Before/After: Before, tabbing to the toggle showed no visual indicator. After, a primary-colored ring appears upon focus. (See Playwright verification screenshot).
♿ Accessibility: Improved keyboard navigation accessibility by providing clear visual focus state for screen reader and keyboard-only users.

---
*PR created automatically by Jules for task [17938250706056276692](https://jules.google.com/task/17938250706056276692) started by @ToolchainLab*