### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS vulnerability in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-26 - Unbounded FastAPI UploadFile Read OOM DoS
+**Vulnerability:** FastAPI `await file.read()` loads the entire file into memory as bytes before checking the size, leading to an Out-Of-Memory (OOM) Denial of Service vulnerability on upload endpoints.
+**Learning:** FastAPI's `UploadFile` uses SpooledTemporaryFile for disk spooling, but `file.read()` returns all bytes into memory at once. Checking size *after* this read is too late.
+**Prevention:** Always check `file.size` first (if provided) and bound the read call using `await file.read(max_bytes + 1)`. If the bounded read returns more than `max_bytes`, throw a 413 error.

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,14 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    # 🛡️ Sentinel: Prevent OOM DoS by bounding the read
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: OOM DoS via unbounded `await file.read()` on file uploads.
🎯 Impact: Attackers can send massive files that consume all available server memory before size validation occurs.
🔧 Fix: Checked `file.size` beforehand and implemented bounded reading using `await file.read(max_upload_bytes + 1)`.
✅ Verification: Handled via automated test suite runs ensuring 413 responses trigger correctly.

---
*PR created automatically by Jules for task [11845939834938923124](https://jules.google.com/task/11845939834938923124) started by @ToolchainLab*