### PR TITLE
🧭 Atlas: Replace manual route lists with generated OpenAPI routes

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2025-07-25 - Prevent API Doc Drift via OpenAPI
+**Learning:** In FastAPI (v0.138+), iterating `app.routes` misses endpoints from included sub-routers (`_IncludedRouter`). Additionally, manual route lists in `README.md` drift quickly. To reliably extract all endpoints for route generation or drift checks, parse the OpenAPI schema via `app.openapi()['paths']` instead.
+**Action:** Prefer generating endpoint docs from source (using OpenAPI specification) and wrapping them in HTML comment markers rather than using regex parsing to verify manually maintained lists.

--- a/README.md
+++ b/README.md
@@ -61,39 +61,54 @@ uv run uvicorn your_module:app --reload
 - Protected routes require an `Authorization: Bearer <device_jwt>` header that the web
   template can mint after login.
 
-## Built-in routes
+## API Routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- ROUTE_LIST_START -->
+### Core
+- `GET /` — Welcome
+- `GET /health` — Health
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+### Auth
+- `GET /auth/session` — Current session
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+### Passkeys
+- `POST /auth/passkey/add/finish` — Finish adding a passkey
+- `POST /auth/passkey/add/start` — Start adding a passkey
+- `POST /auth/passkey/login/finish` — Finish passkey login
+- `POST /auth/passkey/login/start` — Start passkey login
+- `POST /auth/passkey/register/finish` — Finish passkey registration
+- `POST /auth/passkey/register/start` — Start passkey registration
+- `GET /auth/passkeys` — List passkeys
+- `PATCH /auth/passkeys/{key_id}` — Rename a passkey
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey
+
+### Password Auth
+- `POST /auth/login` — Login with password
+- `POST /auth/password-reset/confirm` — Confirm password reset
+- `POST /auth/password-reset/request` — Request a password reset
+- `POST /auth/register` — Register with password
+
+### Jobs
+- `GET /jobs` — List jobs
+- `POST /jobs` — Enqueue a job
+- `GET /jobs/{job_id}` — Get job
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
+- `GET /uploads` — List uploads
+- `POST /uploads` — Upload a file
+- `GET /uploads/{upload_id}` — Get upload metadata
+- `GET /uploads/{upload_id}/download` — Download a file
 
 ### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+- `POST /llm/chat` — Chat completion
+- `POST /llm/chat/stream` — Streaming chat completion
+<!-- ROUTE_LIST_END -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn). See the Passkeys section in [API Routes](#api-routes) for the core flows.
 
 ### Device signed JWTs
 
@@ -145,12 +160,7 @@ def refund(user=require_scopes("billing:refund")):
 ## Password auth (optional)
 
 Password routes mount only when the password extra is installed and
-`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
+`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`. See the Password Auth section in [API Routes](#api-routes) for available endpoints.
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -2,16 +2,16 @@
 """Drift-prevention check: verify that every API route in the FastAPI app is documented.
 
 Usage (from repo root):
-    uv run scripts/check_doc_routes.py
+    uv run scripts/check_doc_routes.py [--update]
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, enumerates all routes using the OpenAPI schema,
+and ensures that the generated routes exactly match the content between the
+<!-- ROUTE_LIST_START --> and <!-- ROUTE_LIST_END --> markers in README.md.
 """
 
 from __future__ import annotations
 
-import re
+import argparse
 import sys
 from pathlib import Path
 
@@ -22,8 +22,8 @@ README = REPO_ROOT / "README.md"
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_openapi_routes() -> dict[str, list[tuple[str, str, str]]]:
+    """Extract routes grouped by tag from the live FastAPI OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -32,58 +32,99 @@ def get_app_routes() -> list[tuple[str, str]]:
         password_auth_enabled=True,
     )
     app = create_app(settings)
+    paths = app.openapi().get("paths", {})
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    routes_by_tag: dict[str, list[tuple[str, str, str]]] = {}
+    for path, methods in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method, details in methods.items():
+            if method.upper() == "HEAD":
                 continue
-            routes.append((method, path))
-    return sorted(routes)
+            tags = details.get("tags", [])
+            tag = tags[0] if tags else "default"
+            if tag not in routes_by_tag:
+                routes_by_tag[tag] = []
+            routes_by_tag[tag].append((method.upper(), path, details.get("summary", "")))
+
+    return {k: sorted(v, key=lambda x: x[1]) for k, v in routes_by_tag.items()}
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+def generate_routes_markdown(routes_by_tag: dict[str, list[tuple[str, str, str]]]) -> str:
+    """Generate the markdown text for the routes."""
+    lines = []
+    tag_order = ["default", "auth", "passkey", "password-auth", "jobs", "uploads", "llm"]
+    tags = sorted(
+        routes_by_tag.keys(),
+        key=lambda t: tag_order.index(t) if t in tag_order else len(tag_order),
+    )
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
+    for tag in tags:
+        routes = routes_by_tag[tag]
+        tag_title = tag.replace("-", " ").title()
+        if tag.lower() == "default":
+            lines.append("### Core")
+        elif tag.lower() == "llm":
+            lines.append("### LLM Chat")
+        elif tag.lower() == "passkey":
+            lines.append("### Passkeys")
+        else:
+            lines.append(f"### {tag_title}")
+
+        for method, path, summary in routes:
+            description = f" — {summary}" if summary else ""
+            lines.append(f"- `{method} {path}`{description}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def extract_routes_from_readme() -> str:
     readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    start_marker = "<!-- ROUTE_LIST_START -->\n"
+    end_marker = "\n<!-- ROUTE_LIST_END -->"
+
+    start_idx = readme_text.find(start_marker)
+    end_idx = readme_text.find(end_marker)
+
+    if start_idx == -1 or end_idx == -1:
+        return None
+
+    return readme_text[start_idx + len(start_marker) : end_idx].strip()
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true", help="Update README.md in place.")
+    args = parser.parse_args()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    routes_by_tag = get_openapi_routes()
+    generated = generate_routes_markdown(routes_by_tag)
+    current = extract_routes_from_readme()
+
+    if current is None:
+        print("❌ Could not find markers.")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    if current != generated:
+        if args.update:
+            readme_text = README.read_text()
+            start_marker = "<!-- ROUTE_LIST_START -->\n"
+            end_marker = "\n<!-- ROUTE_LIST_END -->"
+            start_idx = readme_text.find(start_marker)
+            end_idx = readme_text.find(end_marker)
+
+            new_readme_text = (
+                readme_text[: start_idx + len(start_marker)] + generated + readme_text[end_idx:]
+            )
+            README.write_text(new_readme_text)
+            print("✅ Updated API routes in README.md.")
+            return 0
+        else:
+            print("❌ API routes in README.md are out of date or incorrectly formatted.")
+            print("Run `uv run scripts/check_doc_routes.py --update` to fix.")
+            return 1
+
+    print("✅ All API routes are documented correctly in README.md.")
     return 0
 
 


### PR DESCRIPTION
💡 What: Consolidated scattered, handwritten API route lists in README.md into a single `## API Routes` section generated directly from the FastAPI OpenAPI schema.
🎯 Why: Prevents documentation drift, ensures all routes (including sub-router paths) are documented, and makes the API easier to navigate for new contributors.
🧪 Verification: Run `uv run scripts/check_doc_routes.py` locally.
🔒 Drift Prevention: `scripts/check_doc_routes.py` now asserts that the content between `<!-- ROUTE_LIST_START -->` and `<!-- ROUTE_LIST_END -->` exactly matches the OpenAPI schema, failing CI if they drift.
🗺️ Evidence: `src/h4ckath0n/app.py` (authoritative OpenAPI source)

---
*PR created automatically by Jules for task [12620477845455208029](https://jules.google.com/task/12620477845455208029) started by @ToolchainLab*