### PR TITLE
∴ Vector: Centralize display name validation using Pydantic Annotated types

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Centralize Pydantic Validation with Annotated Types
+**Learning:** Duplicated `@field_validator` and `Field` constraints across multiple Pydantic V2 models for identical fields (like `display_name`) create drift risk and boilerplate.
+**Action:** Use `typing.Annotated` combined with `pydantic.Field` and `pydantic.AfterValidator` to create reusable, self-validating custom types (e.g., `DisplayNameField`), replacing repeated inline validation logic.

--- a/src/h4ckath0n/auth/passkeys/schemas.py
+++ b/src/h4ckath0n/auth/passkeys/schemas.py
@@ -5,28 +5,18 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
-from h4ckath0n.auth.schemas import (
-    DISPLAY_NAME_MAX_LENGTH,
-    DeviceBindingMixin,
-    normalize_display_name,
-)
+from h4ckath0n.auth.schemas import DeviceBindingMixin, DisplayNameField
 
 # -- Registration --
 
 
 class PasskeyRegisterStartRequest(BaseModel):
-    display_name: str = Field(
+    display_name: DisplayNameField = Field(
         ...,
         description="Human-facing display name for the new account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        return normalize_display_name(v)
 
 
 class PasskeyRegisterStartResponse(BaseModel):

--- a/src/h4ckath0n/auth/schemas.py
+++ b/src/h4ckath0n/auth/schemas.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import AfterValidator, BaseModel, EmailStr, Field
 
 # Maximum length for display names (shared across DB, schemas, and API).
 DISPLAY_NAME_MAX_LENGTH = 200
@@ -18,6 +18,13 @@ def normalize_display_name(value: str) -> str:
     return cleaned
 
 
+DisplayNameField = Annotated[
+    str,
+    Field(max_length=DISPLAY_NAME_MAX_LENGTH),
+    AfterValidator(normalize_display_name),
+]
+
+
 class DeviceBindingMixin(BaseModel):
     device_public_key_jwk: dict[str, Any] | None = Field(
         None,
@@ -29,16 +36,10 @@ class DeviceBindingMixin(BaseModel):
 class RegisterRequest(DeviceBindingMixin):
     email: EmailStr = Field(..., description="Account email for password-based signup.")
     password: str = Field(..., description="Plaintext password, hashed server-side.")
-    display_name: str = Field(
+    display_name: DisplayNameField = Field(
         ...,
         description="Human-facing display name for the account.",
-        max_length=DISPLAY_NAME_MAX_LENGTH,
     )
-
-    @field_validator("display_name")
-    @classmethod
-    def _clean_display_name(cls, v: str) -> str:
-        return normalize_display_name(v)
 
 
 class LoginRequest(DeviceBindingMixin):


### PR DESCRIPTION
💡 What: Replaced repeated `display_name` `@field_validator` logic across auth schemas with a single reusable `DisplayNameField` using Pydantic `Annotated` types.
🎯 Why: To remove duplicated transformation and validation logic across `RegisterRequest` and `PasskeyRegisterStartRequest`, improving maintainability and ensuring a single source of truth for display name rules.
🧠 Design: Leveraging Pydantic V2's `Annotated` combined with `AfterValidator` provides a composable, type-safe way to define custom types with embedded validation, eliminating the need for boilerplate validator class methods on every model using the field.
λ FP Angle: Centralises the normalization pipeline (`normalize_display_name`) into a reusable type definition, reducing ad hoc side effects (validator methods) and making the schema definitions more declarative.
✅ Verification: Ran ruff formatting, ruff linting, mypy type checks, and pytest to ensure behaviour is preserved.
🧪 Edge cases: `normalize_display_name` continues to trim whitespace and reject empty display names, preserving existing invariant handling.
⚠️ Risk: Extremely low. This is a purely structural refactor using standard Pydantic V2 features; external API schemas and validation behaviour remain strictly identical.

---
*PR created automatically by Jules for task [2368167670134408765](https://jules.google.com/task/2368167670134408765) started by @ToolchainLab*