### PR TITLE
🎨 Palette: Add focus ring to password toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Missing Focus Rings on Absolute Positioned Inputs
+ **Learning:** Absolute positioned interactive elements inside inputs (like password toggles) often miss native focus rings and fail keyboard accessibility.
+ **Action:** Always explicitly add focus ring styling (e.g., focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary) to these inner elements.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-r-xl text-text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring utilities (`focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none`) and rounded corners to the password toggle button in `PasswordField.tsx`.
🎯 Why: To ensure keyboard users can easily identify when the password toggle button has focus. Absolute positioned interactive elements inside inputs often lack native focus indicators.
📸 Before/After: See frontend verification screenshot.
♿ Accessibility: Improves keyboard navigation and complies with WCAG focus visibility guidelines.

---
*PR created automatically by Jules for task [1434947845306281928](https://jules.google.com/task/1434947845306281928) started by @ToolchainLab*