### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS vulnerability in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-07-26 - OOM DoS Vulnerability in File Uploads
+**Vulnerability:** Unbounded `await file.read()` in `src/h4ckath0n/uploads/router.py` loads the entire uploaded file into memory.
+**Learning:** By bypassing disk spooling and reading unconditionally, attackers can cause OOM crashes (DoS) by sending excessively large files.
+**Prevention:** Always validate size first (using `file.size`) and bound read calls (e.g., `await file.read(max_upload_bytes + 1)`).

--- a/src/h4ckath0n/uploads/router.py
+++ b/src/h4ckath0n/uploads/router.py
@@ -62,7 +62,15 @@ async def upload_file(
     db: AsyncSession = Depends(_db_dep),
 ) -> UploadResponse:
     settings = request.app.state.settings
-    data = await file.read()
+
+    # 🛡️ Sentinel: Bound the read to prevent OOM DoS vulnerabilities from excessively large files
+    if file.size is not None and file.size > settings.max_upload_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {settings.max_upload_bytes} bytes",
+        )
+
+    data = await file.read(settings.max_upload_bytes + 1)
     if len(data) > settings.max_upload_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unbounded file reading (`await file.read()`) loads the entire uploaded file into memory causing potential OOM DoS.
🎯 Impact: Attackers can crash the server by sending excessively large files.
🔧 Fix: Used `file.size` pre-validation and bounded `file.read` to safely enforce file size limits.
✅ Verification: Tested uploading valid files and ensuring large payloads are rejected safely. Tested via full application test suite (`uv run --locked pytest -v`).

---
*PR created automatically by Jules for task [12593670729873156992](https://jules.google.com/task/12593670729873156992) started by @ToolchainLab*