### PR TITLE
∴ Vector: Extract pure scope manipulation helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Extract Scope Operations
+**Learning:** The `h4ckath0n` codebase has an `authz.py` module containing pure scope parsing logic, but CLI commands in `src/h4ckath0n/cli/users.py` (and potentially other places) still manually manipulate scope lists via `parse_scopes` and `serialize_scopes`. We can extract pure helper functions `add_scopes` and `remove_scopes` to centralize this manipulation, improving composability and testability in line with FP principles, and eliminating the repeated transformation boilerplate.
+**Action:** Extract `add_scopes` and `remove_scopes` in `h4ckath0n.auth.authz`.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,15 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(existing: str, to_add: str | Iterable[str]) -> str:
+    """Add new scopes to an existing scope string, preserving order and removing duplicates."""
+    return serialize_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str, to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from an existing scope string."""
+    current = parse_scopes(existing)
+    removed = set(parse_scopes(to_remove))
+    return serialize_scopes(s for s in current if s not in removed)

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +159,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)


### PR DESCRIPTION
💡 What: Extract `add_scopes` and `remove_scopes` helpers in `h4ckath0n.auth.authz` and update the `users` CLI to use them.

🎯 Why: Centralizes duplicated manual scope string manipulation logic found in the CLI commands into testable, pure functional utilities. This reduces boilerplate and potential bugs at call sites.

🧠 Design: By building on the existing `parse_scopes` and `serialize_scopes`, `add_scopes` cleanly preserves order and implicitly dedupes, while `remove_scopes` clearly expresses intent. The logic safely parses inputs using `parse_scopes` before concatenating the tuples to ensure no mixing of raw strings and typed `Scope` lists. The `cli/users.py` commands are updated to use the direct API.

λ FP Angle: Moving state manipulation (parsing string -> mutating list -> serializing string) into pure `(string, add/remove) -> string` helpers increases composability, minimizes intermediate state visibility, and establishes a single source of truth for scope semantics.

✅ Verification: Ran ruff, mypy, and pytest to ensure `users` CLI and other behaviors are perfectly preserved without regressions.

🧪 Edge cases: `add_scopes` seamlessly handles the existing string deduplication, trimming, and commas. `remove_scopes` converts the scopes to remove into a `set` internally for O(1), duplicate-ignoring lookup against the current scopes.

⚠️ Risk: Very low. It just safely wraps existing, robust list conversions that were already present in the codebase inline.

---
*PR created automatically by Jules for task [14982879500255663622](https://jules.google.com/task/14982879500255663622) started by @ToolchainLab*