### PR TITLE
🎨 Palette: Add focus ring to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility focus rings on absolute positioned elements
+ **Learning:** Absolute positioned interactive elements inside inputs (like password visibility toggles) in this design system miss native focus rings during keyboard navigation.
+ **Action:** Always explicitly add focus ring styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md`) to these elements to ensure they remain accessible to keyboard users.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md` to the password visibility toggle button in `PasswordField`.
🎯 Why: Absolute positioned interactive elements inside inputs often lack a visible focus indicator. This makes it impossible for keyboard users to know when they've tabbed to the toggle button.
📸 Before/After: Before, tabbing to the toggle showed no visible change. After, it shows a clear primary color ring.
♿ Accessibility: Improved keyboard navigation accessibility by providing a clear focus indicator.

---
*PR created automatically by Jules for task [3746348944357866538](https://jules.google.com/task/3746348944357866538) started by @ToolchainLab*