### PR TITLE
🧭 Atlas: Replace manual API routes with generated OpenAPI table

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2024-07-28 - Generated Route Documentation
+**Learning:** In FastAPI, iterating `app.routes` misses endpoints from included sub-routers. Manually maintained route lists in README drift easily.
+**Action:** Use OpenAPI (`app.openapi()['paths']`) to extract reliable route data, and use `check_doc_routes.py` as a generator that enforces parity in CI.

--- a/README.md
+++ b/README.md
@@ -61,39 +61,63 @@ uv run uvicorn your_module:app --reload
 - Protected routes require an `Authorization: Bearer <device_jwt>` header that the web
   template can mint after login.
 
-## Built-in routes
+## API Routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- API_ROUTES_START -->
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+### Auth
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+- `GET /auth/session` — Current session. Return information about the currently authenticated session.
+
+### Default
+
+- `GET /` — Welcome. Default root route provided by h4ckath0n.
+- `GET /health` — Health. Basic health check for the app.
+
+### Jobs
+
+- `GET /jobs` — List jobs. List recent jobs for the current user.
+- `POST /jobs` — Enqueue a job. Create a new background job.
+- `GET /jobs/{job_id}` — Get job. Get details of a specific job.
+
+### Llm
+
+- `POST /llm/chat` — Chat completion. Non-streaming chat completion. Requires OpenAI API key.
+- `POST /llm/chat/stream` — Streaming chat completion. Stream LLM tokens via SSE. Requires OpenAI API key.
+
+### Passkey
+
+- `POST /auth/passkey/add/finish` — Finish adding a passkey. Verify the WebAuthn attestation and attach the new passkey to the user.
+- `POST /auth/passkey/add/start` — Start adding a passkey. Begin adding a new passkey for the authenticated user and return registration options.
+- `POST /auth/passkey/login/finish` — Finish passkey login. Finish passkey login by verifying the WebAuthn assertion for the flow and binding an optional device key.
+- `POST /auth/passkey/login/start` — Start passkey login. Begin a username-less passkey login ceremony and return WebAuthn authentication options.
+- `POST /auth/passkey/register/finish` — Finish passkey registration. Finish passkey registration by verifying the WebAuthn attestation for the flow and binding an optional device key.
+- `POST /auth/passkey/register/start` — Start passkey registration. Begin a passkey registration ceremony. Creates a new user and a single-use challenge flow, then returns WebAuthn registration options.
+- `GET /auth/passkeys` — List passkeys. List all passkeys, including revoked entries, for the current user.
+- `PATCH /auth/passkeys/{key_id}` — Rename a passkey. Update the user-facing name of a passkey.
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey. Revoke a passkey by its internal key ID. The last active passkey cannot be revoked and returns the LAST_PASSKEY error.
+
+### Password Auth
+
+- `POST /auth/login` — Login with password. Verify email and password, then bind an optional device key.
+- `POST /auth/password-reset/confirm` — Confirm password reset. Confirm a password reset token, set a new password, and bind an optional device key.
+- `POST /auth/password-reset/request` — Request a password reset. Request a password reset token for the account. Returns the same message even when the email is unknown.
+- `POST /auth/register` — Register with password. Create a new account using email and password, then bind an optional device key.
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
 
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+- `GET /uploads` — List uploads. List uploads for the current user.
+- `POST /uploads` — Upload a file. Upload a file (multipart/form-data).
+- `GET /uploads/{upload_id}` — Get upload metadata.
+- `GET /uploads/{upload_id}/download` — Download a file. Stream the file back to the owner.
+
+<!-- API_ROUTES_END -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn).
 
 ### Device signed JWTs
 
@@ -146,11 +170,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -4,9 +4,9 @@
 Usage (from repo root):
     uv run scripts/check_doc_routes.py
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, enumerates all routes via OpenAPI, and injects
+the documentation into README.md between <!-- API_ROUTES_START --> and
+<!-- API_ROUTES_END -->. It fails if the file needs to be updated (drift detection).
 """
 
 from __future__ import annotations
@@ -17,73 +17,69 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
-
-# FastAPI internal paths that we do not require in user docs.
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
-    from h4ckath0n.app import create_app  # noqa: E402
-    from h4ckath0n.config import Settings  # noqa: E402
+def get_openapi_routes() -> list[tuple[str, str, str, str]]:
+    """Return (tag, method, path, description) from the live FastAPI app."""
+    from h4ckath0n.app import create_app
+    from h4ckath0n.config import Settings
 
     settings = Settings(
         database_url="sqlite+aiosqlite://",
         password_auth_enabled=True,
     )
     app = create_app(settings)
+    openapi_schema = app.openapi()
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    routes = []
+    for path, path_item in openapi_schema.get("paths", {}).items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+        for method, operation in path_item.items():
+            tag = operation.get("tags", ["default"])[0]
+            summary = operation.get("summary", "")
+            desc = operation.get("description", "")
+            full_desc = f"{summary}. {desc}".strip(" .") + "."
+            routes.append((tag, method.upper(), path, full_desc))
+
+    # Sort by tag then path
+    routes.sort(key=lambda r: (r[0], r[2], r[1]))
+    return routes
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
-
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+def generate_markdown(routes: list[tuple[str, str, str, str]]) -> str:
+    lines = ["<!-- API_ROUTES_START -->\n"]
+    current_tag = None
+    for tag, method, path, desc in routes:
+        if tag != current_tag:
+            lines.append(f"\n### {tag.title().replace('-', ' ')}\n\n")
+            current_tag = tag
+        lines.append(f"- `{method} {path}` — {desc}\n")
+    lines.append("\n<!-- API_ROUTES_END -->")
+    return "".join(lines)
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    routes = get_openapi_routes()
+    new_block = generate_markdown(routes)
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    readme_text = README.read_text()
+    pattern = re.compile(r"<!-- API_ROUTES_START -->.*?<!-- API_ROUTES_END -->", re.DOTALL)
+
+    if not pattern.search(readme_text):
+        print("❌ Could not find API_ROUTES markers in README.md")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    updated_text = pattern.sub(new_block, readme_text)
+
+    if updated_text != readme_text:
+        README.write_text(updated_text)
+        print("❌ README.md was out of date. It has been updated automatically.")
+        print("Please review and commit the changes.")
+        return 1
+
+    print(f"✅ All {len(routes)} API routes are documented and up to date in README.md.")
     return 0
 
 


### PR DESCRIPTION
💡 What: Replaces hand-written endpoint lists in README.md with an auto-generated list using OpenAPI schema.
🎯 Why: The manual list in README.md is prone to drifting from the real backend API. The previous check script missed routes from sub-routers because it iterated `app.routes`.
🧪 Verification: Run `uv run scripts/check_doc_routes.py` to regenerate the documentation and see if it fails. Check with `uv run pytest -v`.
🔒 Drift Prevention: `scripts/check_doc_routes.py` now generates the accurate route list and fails if the README diverges. This script runs in CI.
🗺️ Evidence: `src/h4ckath0n/app.py` OpenAPI generation is used as the single source of truth.

---
*PR created automatically by Jules for task [32379630470931155](https://jules.google.com/task/32379630470931155) started by @ToolchainLab*