### PR TITLE
🎨 Palette: Add focus ring to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-27 - Focus Rings on Absolute Interactive Elements
+ **Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds, rendering them invisible during keyboard navigation.
+ **Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radius to these elements so keyboard users can track their focus state.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 rounded-r-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added explicit focus ring styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-r-xl`) to the password visibility toggle button in `PasswordField.tsx`.
🎯 Why: Absolute positioned interactive elements inside inputs often miss native focus rings or inherit clipped bounds. This makes them invisible during keyboard navigation, degrading accessibility for keyboard users.
📸 Before/After: Before, tabbing to the toggle showed no visible indicator. After, a clear primary-colored focus ring appears around the icon.
♿ Accessibility: Ensures keyboard users can track their focus state and know when they are focused on the toggle button.

---
*PR created automatically by Jules for task [17466129582620889806](https://jules.google.com/task/17466129582620889806) started by @ToolchainLab*