### PR TITLE
🧭 Atlas: Replace hand-written API routes with generated OpenAPI docs

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,6 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+## 2026-02-28 - Replacing manual API routes with generated markers
+**Learning:** Hardcoded API route lists in README files drift quickly as the application evolves (e.g. password auth extra features). Using an automated generation script with HTML markers (`<!-- ROUTES:START -->`) paired with OpenAPI's robust schema representation provides a reliable, drift-proof documentation surface that can be validated in CI without complex regex matching logic.
+**Action:** When documenting API surfaces in Python apps (like FastAPI), always rely on generated schemas (like OpenAPI `app.openapi()['paths']`) dynamically replacing documentation via markers instead of manually updating static markdown lists.

--- a/README.md
+++ b/README.md
@@ -63,37 +63,52 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- ROUTES:START -->
+### Default
+- `GET /` — Welcome
+- `GET /health` — Health
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+### Auth
+- `GET /auth/session` — Current session
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+### Jobs
+- `GET /jobs` — List jobs
+- `POST /jobs` — Enqueue a job
+- `GET /jobs/{job_id}` — Get job
+
+### Llm
+- `POST /llm/chat` — Chat completion
+- `POST /llm/chat/stream` — Streaming chat completion
+
+### Passkey
+- `POST /auth/passkey/register/start` — Start passkey registration
+- `POST /auth/passkey/register/finish` — Finish passkey registration
+- `POST /auth/passkey/login/start` — Start passkey login
+- `POST /auth/passkey/login/finish` — Finish passkey login
+- `POST /auth/passkey/add/start` — Start adding a passkey
+- `POST /auth/passkey/add/finish` — Finish adding a passkey
+- `GET /auth/passkeys` — List passkeys
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey
+- `PATCH /auth/passkeys/{key_id}` — Rename a passkey
+
+### Password Auth
+- `POST /auth/register` — Register with password
+- `POST /auth/login` — Login with password
+- `POST /auth/password-reset/request` — Request a password reset
+- `POST /auth/password-reset/confirm` — Confirm password reset
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+- `GET /uploads` — List uploads
+- `POST /uploads` — Upload a file
+- `GET /uploads/{upload_id}` — Get upload metadata
+- `GET /uploads/{upload_id}/download` — Download a file
+<!-- ROUTES:END -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn). The core flows are documented in the built-in routes section above.
 
 ### Device signed JWTs
 
@@ -146,11 +161,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env -S uv run python
-"""Drift-prevention check: verify that every API route in the FastAPI app is documented.
+"""Drift-prevention check: generate and verify API route documentation.
 
 Usage (from repo root):
     uv run scripts/check_doc_routes.py
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, enumerates all routes from the OpenAPI schema,
+groups them by tags, and generates a markdown section.
+It then checks if README.md contains the exact generated section between
+<!-- ROUTES:START --> and <!-- ROUTES:END -->. If not, it updates README.md.
 """
 
 from __future__ import annotations
@@ -18,12 +19,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
 
-# FastAPI internal paths that we do not require in user docs.
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def generate_routes_markdown() -> str:
+    """Generate the markdown for API routes grouped by tags."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -32,59 +32,57 @@ def get_app_routes() -> list[tuple[str, str]]:
         password_auth_enabled=True,
     )
     app = create_app(settings)
+    schema = app.openapi()
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    routes_by_tag: dict[str, list[tuple[str, str, str]]] = {}
+    for path, path_item in schema.get("paths", {}).items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+        for method, op in path_item.items():
+            tags = op.get("tags", ["Default"])
+            tag = tags[0]
+            routes_by_tag.setdefault(tag, []).append((method.upper(), path, op.get("summary", "")))
 
+    lines = []
+    for tag in sorted(routes_by_tag.keys()):
+        lines.append(f"### {tag.replace('-', ' ').title()}")
+        for method, path, summary in routes_by_tag[tag]:
+            lines.append(f"- `{method} {path}` — {summary}")
+        lines.append("")
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+    # Remove the very last empty line to avoid extra trailing newline
+    if lines and lines[-1] == "":
+        lines.pop()
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    return "\n".join(lines)
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    readme_text = README.read_text()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    start_marker = "<!-- ROUTES:START -->"
+    end_marker = "<!-- ROUTES:END -->"
+
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print("❌ Could not find ROUTES:START or ROUTES:END markers in README.md.")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+    generated = generate_routes_markdown()
+
+    pattern = re.compile(f"{re.escape(start_marker)}.*{re.escape(end_marker)}", re.DOTALL)
+
+    replacement = f"{start_marker}\n{generated}\n{end_marker}"
+
+    new_readme_text = pattern.sub(replacement, readme_text)
+
+    if new_readme_text == readme_text:
+        print("✅ API routes in README.md are up to date.")
+        return 0
+
+    print("⚠️ API routes in README.md were out of date. Updating...")
+    README.write_text(new_readme_text)
+    print("✅ Updated README.md.")
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Replaced hand-written API routes with an OpenAPI-generated table grouped by tags.
🎯 Why: To eliminate drift risk between `README.md` and the application's actual routes, and to ensure complete documentation coverage for all endpoints including optional ones like password auth.
🧪 Verification: Run `uv run --locked scripts/check_doc_routes.py` to verify the generation matches the source.
🔒 Drift Prevention: `scripts/check_doc_routes.py` is now a generator script that validates against `<!-- ROUTES:START -->` and `<!-- ROUTES:END -->` markers, running in CI to fail on drift.
🗺️ Evidence: `src/h4ckath0n/app.py` and `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [18235492341174594894](https://jules.google.com/task/18235492341174594894) started by @ToolchainLab*