### PR TITLE
∴ Vector: Extract pure scope helpers to centralize authz string manipulation

### DIFF
--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,20 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def normalize_scopes(raw: str | Iterable[str]) -> str:
+    """Normalize scopes into a canonical comma-separated string."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(existing: str, to_add: str | Iterable[str]) -> str:
+    """Add new scopes to an existing scope string, returning a new normalized string."""
+    return serialize_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str, to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from an existing scope string, returning a new normalized string."""
+    current = parse_scopes(existing)
+    removals = set(parse_scopes(to_remove))
+    return serialize_scopes([s for s in current if s not in removals])

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,7 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import normalize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -145,7 +145,7 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
 
 def _normalize_scopes(raw: str) -> str:
     """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
+    return normalize_scopes(raw)
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +159,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,11 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
+    normalize_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -59,6 +62,21 @@ class TestScopes:
     def test_role_constants(self):
         assert USER == "user"
         assert ADMIN == "admin"
+
+    def test_normalize_scopes(self):
+        assert normalize_scopes("a,b,a, c ") == "a,b,c"
+        assert normalize_scopes(["a,b", "c"]) == "a,b,c"
+        assert normalize_scopes("") == ""
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", "c,a") == "a,b,c"
+        assert add_scopes("", "a,b") == "a,b"
+        assert add_scopes("a,b", "") == "a,b"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c", "b,d") == "a,c"
+        assert remove_scopes("a,b", "") == "a,b"
+        assert remove_scopes("", "a") == ""
 
 
 class TestPasskeyErrors:


### PR DESCRIPTION
- 💡 **What**: Extracted pure helpers `normalize_scopes`, `add_scopes`, and `remove_scopes` into `src/h4ckath0n/auth/authz.py`. Refactored ad-hoc scope string mutation in `src/h4ckath0n/cli/users.py` and `src/h4ckath0n/cli/_common.py` to use these helpers.
- 🎯 **Why**: Previously, scope parsing and re-serialization logic was duplicated across multiple call sites in the CLI, causing scattered staging variables and implicit string-to-list-to-string type mixing.
- 🧠 **Design**: Adding these 3 small helpers to `authz.py` establishes a single source of truth for scope string manipulation. The helpers reuse the existing strict `parse_scopes` logic, ensuring consistent deduplication and order-preservation, while completely hiding the underlying serialization steps from the caller.
- λ **FP Angle**: Replaces scattered local staging values (like `existing = parse_scopes(user.scopes)` and manual sets/comprehensions) with clean, declarative transformation functions: `user.scopes = add_scopes(user.scopes, args.scope)`.
- ✅ **Verification**: Ran the full test suite via `uv run --locked pytest -v`. Code formatted and linted with `ruff`. Type-checked with `mypy`.
- 🧪 **Edge cases**: The helpers gracefully handle empty strings, comma-heavy whitespace strings (via `parse_scopes`), and duplicate scope insertions natively, which is explicitly covered in new `test_authz.py` unit tests.
- ⚠️ **Risk**: Low. Existing parsing behavior remains untouched. Tests confirm exact functional parity.

---
*PR created automatically by Jules for task [10659224863770147847](https://jules.google.com/task/10659224863770147847) started by @ToolchainLab*