### PR TITLE
🎨 Palette: Add keyboard focus ring to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Focus styles on absolute positioned input elements
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radius (`rounded-xl`) to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus-visible classes (`focus-visible:ring-2`, `focus-visible:outline-none`, `focus-visible:ring-primary`) and `rounded-xl` to the absolute positioned password visibility toggle button.
🎯 Why: To ensure keyboard users have a visible focus ring when tabbing into the password visibility toggle, improving keyboard navigation accessibility.
📸 Before/After: Before, tabbing to the toggle showed no outline. After, it shows a primary colored focus ring.
♿ Accessibility: Fixes a critical keyboard accessibility issue where an interactive element inside an input lacked focus indicators.

---
*PR created automatically by Jules for task [16621637793127917948](https://jules.google.com/task/16621637793127917948) started by @ToolchainLab*