### PR TITLE
🧭 Atlas: Replace manual API routes list with generated OpenAPI table

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,37 +63,41 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- ROUTES_START -->
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/` | Welcome |
+| `POST` | `/auth/login` | Login with password |
+| `POST` | `/auth/passkey/add/finish` | Finish adding a passkey |
+| `POST` | `/auth/passkey/add/start` | Start adding a passkey |
+| `POST` | `/auth/passkey/login/finish` | Finish passkey login |
+| `POST` | `/auth/passkey/login/start` | Start passkey login |
+| `POST` | `/auth/passkey/register/finish` | Finish passkey registration |
+| `POST` | `/auth/passkey/register/start` | Start passkey registration |
+| `GET` | `/auth/passkeys` | List passkeys |
+| `PATCH` | `/auth/passkeys/{key_id}` | Rename a passkey |
+| `POST` | `/auth/passkeys/{key_id}/revoke` | Revoke a passkey |
+| `POST` | `/auth/password-reset/confirm` | Confirm password reset |
+| `POST` | `/auth/password-reset/request` | Request a password reset |
+| `POST` | `/auth/register` | Register with password |
+| `GET` | `/auth/session` | Current session |
+| `GET` | `/health` | Health |
+| `GET` | `/jobs` | List jobs |
+| `POST` | `/jobs` | Enqueue a job |
+| `GET` | `/jobs/{job_id}` | Get job |
+| `POST` | `/llm/chat` | Chat completion |
+| `POST` | `/llm/chat/stream` | Streaming chat completion |
+| `GET` | `/uploads` | List uploads |
+| `POST` | `/uploads` | Upload a file |
+| `GET` | `/uploads/{upload_id}` | Get upload metadata |
+| `GET` | `/uploads/{upload_id}/download` | Download a file |
+<!-- ROUTES_END -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn).
 
 ### Device signed JWTs
 
@@ -145,14 +149,7 @@ def refund(user=require_scopes("billing:refund")):
 ## Password auth (optional)
 
 Password routes mount only when the password extra is installed and
-`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
-
-Password auth is only an identity bootstrap. It binds a device key but does not return
+`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`. Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.
 
 ## Configuration

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -4,9 +4,9 @@
 Usage (from repo root):
     uv run scripts/check_doc_routes.py
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, enumerates all routes via OpenAPI, generates a
+Markdown table, and checks that README.md contains this exact table between
+<!-- ROUTES_START --> and <!-- ROUTES_END --> markers.
 """
 
 from __future__ import annotations
@@ -20,10 +20,11 @@ README = REPO_ROOT / "README.md"
 
 # FastAPI internal paths that we do not require in user docs.
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
+HTTP_VERBS = frozenset({"get", "post", "put", "delete", "options", "head", "patch", "trace"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def generate_route_table() -> str:
+    """Return a Markdown table of (method, path) pairs from the live FastAPI app."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -33,57 +34,60 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    routes: list[tuple[str, str, str]] = []
+    paths = app.openapi()["paths"]
+    for path, methods in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method, details in methods.items():
+            if method.lower() not in HTTP_VERBS:
                 continue
-            routes.append((method, path))
-    return sorted(routes)
+            if method.upper() == "HEAD":
+                continue
+            summary = details.get("summary", "")
+            routes.append((path, method.upper(), summary))
+
+    routes.sort(key=lambda x: (x[0], x[1]))
+
+    lines = [
+        "| Method | Path | Summary |",
+        "|---|---|---|",
+    ]
+    for path, method, summary in routes:
+        lines.append(f"| `{method}` | `{path}` | {summary} |")
+
+    return "\n".join(lines)
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
-
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
+def check_routes_in_readme(expected_table: str) -> bool:
+    """Check if README.md contains the exact expected table between markers."""
     readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+
+    pattern = re.compile(r"<!-- ROUTES_START -->\n(.*?)\n<!-- ROUTES_END -->", re.DOTALL)
+    match = pattern.search(readme_text)
+    if not match:
+        print(
+            "❌ Could not find <!-- ROUTES_START --> and <!-- ROUTES_END --> markers in README.md."
+        )
+        return False
+
+    actual_table = match.group(1).strip()
+    if actual_table != expected_table.strip():
+        print("❌ API route documentation in README.md is out of sync with the app.")
+        print("\nExpected table:\n")
+        print(expected_table)
+        return False
+
+    return True
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
-
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    expected_table = generate_route_table()
+    if not check_routes_in_readme(expected_table):
+        print("\nUpdate the section in README.md to match the expected table.")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    print("✅ API routes are correctly documented in README.md.")
     return 0
 
 


### PR DESCRIPTION
- 💡 What: Replaced hand-written API routes with a dynamically generated Markdown table based on the OpenAPI schema.
- 🎯 Why: Hand-written routes were disconnected from the app's real configuration, posing a high drift risk.
- 🧪 Verification: Run `uv run scripts/check_doc_routes.py`.
- 🔒 Drift Prevention: `scripts/check_doc_routes.py` now parses OpenAPI routes (using a strict HTTP verb filter) and verifies the markdown table between `<!-- ROUTES_START -->` and `<!-- ROUTES_END -->` perfectly matches.
- 🗺️ Evidence: `README.md`, `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [6326848717136085600](https://jules.google.com/task/6326848717136085600) started by @ToolchainLab*