### PR TITLE
∴ Vector: Extract pure scope manipulation helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-07-30 - Centralise authorization scope manipulation
+**Learning:** CLI utilities manually deserialized, manipulated, and reserialized user scopes, duplicating string normalization logic and separating it from the core domain parsing functions in `h4ckath0n.auth.authz`.
+**Action:** Ensure scope string manipulations are abstracted as pure helper pipelines (`add_scopes`, `remove_scopes`) inside the `h4ckath0n.auth.authz` module, parsing all variadic or raw string inputs to apply unified deduplication and order-preservation before serialization.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,23 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def normalize_scopes(raw: str) -> str:
+    """Normalize a comma-separated scopes string."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(existing_raw: str, to_add_raw: str | Iterable[str]) -> str:
+    """Add scopes to an existing comma-separated string, returning a normalized string."""
+    existing = parse_scopes(existing_raw)
+    to_add = parse_scopes(to_add_raw)
+    return serialize_scopes((*existing, *to_add))
+
+
+def remove_scopes(existing_raw: str, to_remove_raw: str | Iterable[str]) -> str:
+    """Remove scopes from an existing comma-separated string, returning a normalized string."""
+    existing = parse_scopes(existing_raw)
+    to_remove = set(parse_scopes(to_remove_raw))
+    remaining = [s for s in existing if s not in to_remove]
+    return serialize_scopes(remaining)

--- a/src/h4ckath0n/cli/__init__.py
+++ b/src/h4ckath0n/cli/__init__.py
@@ -19,7 +19,6 @@ from h4ckath0n.cli._common import (
     EXIT_OK,
     EXIT_PROD_INIT,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from h4ckath0n.cli._parser import build_parser
 from h4ckath0n.cli.db import (
@@ -56,7 +55,6 @@ __all__ = [
     "build_parser",
     "alembic_command",
     "_normalize_db_url_for_sync",
-    "_normalize_scopes",
 ]
 
 # Backwards-compatible alias (the parser builder was previously private).

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -141,11 +140,6 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
             yield session
     finally:
         engine.dispose()
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,12 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, normalize_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_OK,
-    _normalize_scopes,
     _output,
     _require_yes,
     _sync_session,
@@ -142,8 +141,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +158,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -180,7 +175,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        user.scopes = _normalize_scopes(args.scopes)
+        user.scopes = normalize_scopes(args.scopes)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,11 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
+    normalize_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +58,22 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_normalize_scopes(self):
+        assert normalize_scopes("  demo, , admin") == "demo,admin"
+        assert normalize_scopes("") == ""
+
+    def test_add_scopes(self):
+        assert add_scopes("admin", "demo") == "admin,demo"
+        assert add_scopes("admin,demo", "reports") == "admin,demo,reports"
+        assert add_scopes("admin", "admin,demo") == "admin,demo"
+        assert add_scopes("admin,demo", ["reports", "admin"]) == "admin,demo,reports"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("admin,demo", "demo") == "admin"
+        assert remove_scopes("admin,demo", "reports") == "admin,demo"
+        assert remove_scopes("admin,demo,reports", ["admin", "demo"]) == "reports"
+        assert remove_scopes("admin,demo", "") == "admin,demo"
 
     def test_role_constants(self):
         assert USER == "user"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,12 +9,12 @@ import json
 from sqlalchemy.engine import make_url
 
 import h4ckath0n.cli as cli_module
+from h4ckath0n.auth.authz import normalize_scopes as _normalize_scopes
 from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
 )
-from h4ckath0n.auth.authz import normalize_scopes as _normalize_scopes
 from tests.conftest import run_cli as _run_cli
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,8 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
+from h4ckath0n.auth.authz import normalize_scopes as _normalize_scopes
 from tests.conftest import run_cli as _run_cli
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Centralised scope array manipulation (add/remove/set) out of CLI mutation logic into explicit pure helpers (`add_scopes`, `remove_scopes`, `normalize_scopes`) inside `h4ckath0n.auth.authz`.
🎯 Why: Prevents ad-hoc duplication of list manipulation logic, ensuring whitespace and trailing comma edge-cases are consistently normalized through one source of truth (`parse_scopes`).
🧠 Design: Moved logic into pure functional pipelines inside the core domain layer (`authz`) that operates entirely on deterministic immutable operations.
λ FP Angle: Replaced in-place mutable updates spread across CLI controllers with explicit composable data-in/data-out transformations, increasing testability and correctness.
✅ Verification: Unit tests added. Checked functionality across commands and verified via pytest.
🧪 Edge cases: Fully covers handling deduplication during additions, array input variances from CLI append args, and stability during removals.
⚠️ Risk: Low risk, maintains backwards compatible behaviors for scopes.

---
*PR created automatically by Jules for task [6827430339014023876](https://jules.google.com/task/6827430339014023876) started by @ToolchainLab*