### PR TITLE
🎨 Palette: Add focus ring to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Missing focus rings on absolute positioned inputs
+ **Learning:** Absolute positioned interactive elements inside inputs (like password visibility toggles) in this app's components miss native focus rings and inherit clipped bounds, making them invisible during keyboard navigation.
+ **Action:** Always explicitly add focus ring styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radius to these elements.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added `focus-visible:ring-2 focus-visible:ring-primary` and `rounded-xl` to the password visibility toggle button in `PasswordField.tsx`.
🎯 Why: Absolute positioned interactive elements inside inputs often miss native focus rings and inherit clipped bounds. This change ensures the toggle button is clearly visible and usable during keyboard navigation.
📸 Before/After: See the generated screenshot and video verifying the focus ring.
♿ Accessibility: Improves keyboard navigation support by providing clear visual focus indicators for interactive elements.

---
*PR created automatically by Jules for task [9395876540153120437](https://jules.google.com/task/9395876540153120437) started by @ToolchainLab*