### PR TITLE
∷ Vector: Extract pure scope manipulation helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-07-31 - Centralizing Domain Operations
+**Learning:** The CLI tool repeated string-based manipulation of comma-separated "scopes" across sub-commands instead of treating them as value objects with centralized operations.
+**Action:** When extracting such logic, look for the lowest-level parsing utility (e.g., `parse_scopes` and `serialize_scopes` in `authz.py`) and compose new pure helpers on top of it.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -38,6 +38,23 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
     return ",".join(dict.fromkeys(str(s) for s in scopes if s))
 
 
+def normalize_scopes(raw: str | Iterable[str]) -> str:
+    """Normalize a raw scope string or iterable into a canonical comma-separated string."""
+    return serialize_scopes(parse_scopes(raw))
+
+
+def add_scopes(existing: str | Iterable[str], to_add: str | Iterable[str]) -> str:
+    """Return a new canonical scope string with additional scopes appended."""
+    return serialize_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> str:
+    """Return a new canonical scope string with specified scopes removed."""
+    current = parse_scopes(existing)
+    drop = set(parse_scopes(to_remove))
+    return serialize_scopes(s for s in current if s not in drop)
+
+
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)

--- a/src/h4ckath0n/cli/__init__.py
+++ b/src/h4ckath0n/cli/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 
+from h4ckath0n.auth.authz import normalize_scopes as _normalize_scopes
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
@@ -19,7 +20,6 @@ from h4ckath0n.cli._common import (
     EXIT_OK,
     EXIT_PROD_INIT,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from h4ckath0n.cli._parser import build_parser
 from h4ckath0n.cli.db import (

--- a/src/h4ckath0n/cli/_common.py
+++ b/src/h4ckath0n/cli/_common.py
@@ -14,7 +14,6 @@ from typing import Any
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
 from h4ckath0n.auth.models import User
 from h4ckath0n.db.migrations.runtime import (
     create_sync_engine,
@@ -141,11 +140,6 @@ def _sync_session(args: argparse.Namespace) -> Iterator[Session]:
             yield session
     finally:
         engine.dispose()
-
-
-def _normalize_scopes(raw: str) -> str:
-    """Normalize a comma-separated scopes string."""
-    return serialize_scopes(parse_scopes(raw))
 
 
 def _selection_provided(args: argparse.Namespace) -> bool:

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,12 +7,15 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    normalize_scopes,
+    remove_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
     EXIT_OK,
-    _normalize_scopes,
     _output,
     _require_yes,
     _sync_session,
@@ -142,8 +145,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +162,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -180,7 +179,7 @@ def _cmd_users_scopes_set(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        user.scopes = _normalize_scopes(args.scopes)
+        user.scopes = normalize_scopes(args.scopes)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,11 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
+    normalize_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -45,6 +48,23 @@ class TestScopes:
 
     def test_serialize_deduplicates(self):
         assert serialize_scopes([Scope("a"), Scope("a"), Scope("b")]) == "a,b"
+
+    def test_normalize_scopes_basic(self):
+        assert normalize_scopes("a,b,c") == "a,b,c"
+        assert normalize_scopes("a,b,a") == "a,b"
+        assert normalize_scopes(" a , b , c ") == "a,b,c"
+        assert normalize_scopes("a,,b,,") == "a,b"
+        assert normalize_scopes("") == ""
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", ["c", "d,e", "a"]) == "a,b,c,d,e"
+        assert add_scopes("a,b", "b,c") == "a,b,c"
+        assert add_scopes("", "a") == "a"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c,d", "b, d") == "a,c"
+        assert remove_scopes("a,b", "c") == "a,b"
+        assert remove_scopes("a", "a") == ""
 
     def test_missing_scopes_returns_difference(self):
         granted = parse_scopes("admin,demo")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from h4ckath0n.cli import (
     EXIT_BAD_ARGS,
     EXIT_LAST_PASSKEY,
     _normalize_db_url_for_sync,
-    _normalize_scopes,
 )
 from tests.conftest import run_cli as _run_cli
 
@@ -125,28 +124,6 @@ class TestAlembicUrlNormalization:
         exit_code = cli_module._cmd_db_migrate_current(args)
         assert exit_code == 0
         assert make_url(captured["sqlalchemy.url"]) == make_url("sqlite:///./test.db")
-
-
-# ---------------------------------------------------------------------------
-# Scopes normalization
-# ---------------------------------------------------------------------------
-
-
-class TestNormalizeScopes:
-    def test_basic(self):
-        assert _normalize_scopes("a,b,c") == "a,b,c"
-
-    def test_dedup(self):
-        assert _normalize_scopes("a,b,a") == "a,b"
-
-    def test_trim(self):
-        assert _normalize_scopes(" a , b , c ") == "a,b,c"
-
-    def test_empty_segments(self):
-        assert _normalize_scopes("a,,b,,") == "a,b"
-
-    def test_empty_string(self):
-        assert _normalize_scopes("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 💡 What: Extract string normalization, addition, and removal logic into pure helper functions in `authz.py` (`normalize_scopes`, `add_scopes`, `remove_scopes`) and replace manual mutation logic in `cli/users.py`.
- 🎯 Why: Repeated logic for parsing/serializing scopes ad-hoc across modules.
- 🧠 Design: Centralizes shared semantics about how to add or remove scopes, relying on the project's existing `parse_scopes` abstraction.
- λ FP Angle: Replaces scattered manual mutation in `users.py` with declarative pure transformation pipelines in `authz.py`.
- ✅ Verification: Run `uv run --locked pytest -v` and `uv run --locked ruff format --check .`.
- 🧪 Edge cases: Re-uses `parse_scopes` allowing `str | Iterable[str]` flexibly. Covers duplicates and removals safely.
- ⚠️ Risk: Very low, preserves exact behavior by abstracting identical logic.

---
*PR created automatically by Jules for task [15994884788281803900](https://jules.google.com/task/15994884788281803900) started by @ToolchainLab*