### PR TITLE
⚡ Bolt: Use limit(1) for faster table existence check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2025-01-20 - Use limit(1) instead of count() for existence checks
+**Learning:** When checking if a database table is empty or has any rows matching a condition using SQLAlchemy, using `select(func.count())` forces the database to count all matching rows.
+**Action:** Use `await db.scalar(select(Model.id).limit(1))` and check if the result is `None` instead of using `func.count()`. This turns it into a much faster O(1) existence check.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -11,7 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -41,9 +41,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # Fast existence check rather than counting all rows.
+        first_user_id = await db.scalar(select(User.id).limit(1))
+        if first_user_id is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: Replace `select(func.count())` with `select(User.id).limit(1)` in `_is_bootstrap_admin` existence check.
🎯 Why: When checking if the `User` table is empty during initial user registration, `COUNT(*)` forces the database to evaluate all rows or index entries. Checking `LIMIT 1` transforms it into a fast O(1) operation.
📊 Impact: Speeds up the first user check during registration. While the table is small initially, this avoids unnecessary scanning overhead.
🔬 Measurement: Verify by registering a new user with password auth enabled or logging in via passkey. It continues to successfully promote the first user to `admin`. The unit test suite confirms no regressions in expected behavior.

---
*PR created automatically by Jules for task [1502755660152751220](https://jules.google.com/task/1502755660152751220) started by @ToolchainLab*