### PR TITLE
🎨 Palette: Add focus styles to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Add focus ring to absolute interactive elements inside inputs
+**Learning:** Absolute positioned interactive elements inside inputs (like password visibility toggles) often miss native focus rings or inherit clipped bounds in our component structure.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl`) to these elements to ensure keyboard accessibility.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring styles (`focus-visible:ring-2`) and border radius to the password show/hide toggle button in the `PasswordField` component.
🎯 Why: Without explicit focus styles, keyboard users cannot visually identify when they have tabbed to the visibility toggle, breaking keyboard navigation usability and hiding important state.
📸 Before/After: Before: Toggle has no visual indicator on focus. After: Toggle shows a clear primary ring on focus.
♿ Accessibility: Improved keyboard navigation accessibility by providing a clear visual focus indicator on an interactive, absolutely positioned element inside an input.

---
*PR created automatically by Jules for task [1147631990035595959](https://jules.google.com/task/1147631990035595959) started by @ToolchainLab*