### PR TITLE
∴ Vector: Centralize scope mutation into pure domain helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-08-01 - Centralize scope manipulations into pure functions
+ **Learning:** Scope manipulation (adding/removing) was scattered across the CLI code, leading to repeated parsing logic and potential ordering/deduplication bugs if concatenated wrongly.
+ **Action:** Extract scope mutations into composable, pure domain helpers (`add_scopes`, `remove_scopes`) that parse inputs before combining them. This keeps the domain semantics centralized in `authz.py` and leaves call sites as a clear transformation pipeline.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,14 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(existing: str | Iterable[str], to_add: str | Iterable[str]) -> list[Scope]:
+    """Add new scopes to existing scopes, preserving order and deduplicating."""
+    return parse_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> list[Scope]:
+    """Remove scopes from existing scopes, preserving order."""
+    targets = set(parse_scopes(to_remove))
+    return [s for s in parse_scopes(existing) if s not in targets]

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, remove_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +159,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -59,6 +61,25 @@ class TestScopes:
     def test_role_constants(self):
         assert USER == "user"
         assert ADMIN == "admin"
+
+    def test_add_scopes(self):
+        assert add_scopes("admin,demo", "reports,demo") == [
+            Scope("admin"),
+            Scope("demo"),
+            Scope("reports"),
+        ]
+        assert add_scopes(["admin", "demo"], "reports") == [
+            Scope("admin"),
+            Scope("demo"),
+            Scope("reports"),
+        ]
+
+    def test_remove_scopes(self):
+        assert remove_scopes("admin,demo,reports", "demo,other") == [
+            Scope("admin"),
+            Scope("reports"),
+        ]
+        assert remove_scopes(["admin", "demo"], "demo") == [Scope("admin")]
 
 
 class TestPasskeyErrors:


### PR DESCRIPTION
- 💡 What: Extracted `add_scopes` and `remove_scopes` pure functions to handle scope addition and removal securely.
- 🎯 Why: Repeated parsing and normalization logic was scattered in CLI mutation commands. This centralizes the domain semantics in `authz.py`.
- 🧠 Design: By defining `add_scopes` and `remove_scopes` next to `parse_scopes`, the exact mechanism of token handling is isolated.
- λ FP Angle: Replaces local ad hoc staging mutation and list comprehensions with declarative, composable pure transformations.
- ✅ Verification: Ran `pytest -v`, `mypy`, and `ruff`. Tests cover correct parsing and deduplication.
- 🧪 Edge cases: `add_scopes` naturally ensures deduplication and preserves order since it uses the robust `parse_scopes` internally. `remove_scopes` safely handles missing targets.
- ⚠️ Risk: Extremely low. Refactoring relies purely on pre-existing string operations in memory.

---
*PR created automatically by Jules for task [8508139834643057198](https://jules.google.com/task/8508139834643057198) started by @ToolchainLab*