### PR TITLE
🎨 Palette: Add focus ring styling to PasswordField toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-01 - Missing Focus Rings on Absolute Positioned Inputs
+ **Learning:** Interactive elements positioned absolutely inside inputs (like the password visibility toggle) often inherit clipped bounds or miss native focus rings, making keyboard navigation confusing because focus state becomes invisible.
+ **Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radii to such nested interactive elements.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring classes (`focus-visible:ring-2`, `focus-visible:ring-primary`, `rounded-xl`) to the password visibility toggle button within `PasswordField.tsx`.

🎯 Why: The absolute positioning of the visibility toggle (the 'eye' icon) caused it to lack clear visual feedback when receiving keyboard focus, making navigation confusing for users relying on keyboards or screen readers.

📸 Before/After: The button now matches the primary visual focus ring style found on inputs, showing a clear blue ring when focused.

♿ Accessibility: Ensures that keyboard navigation through the login form provides clear focus indicators for interactive elements inside the inputs.

---
*PR created automatically by Jules for task [10259959015956613498](https://jules.google.com/task/10259959015956613498) started by @ToolchainLab*