### PR TITLE
∴ Vector: Centralize scope manipulation domain logic

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Centralize scope manipulation domain logic
+**Learning:** Ad-hoc list comprehension and tuple unpacking for authorization scope modification (`add`, `remove`) leads to scattered, bug-prone state manipulation. Scope logic often requires deduping and order preservation, which shouldn't be re-implemented at call sites.
+**Action:** Extract list manipulation of custom value objects (like `Scope`) into pure functions (`add_scopes`, `remove_scopes`) alongside the parsing logic to centralize domain rules and improve composability, avoiding repeated serialization edge cases.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,15 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(existing: str | Iterable[str], to_add: str | Iterable[str]) -> list[Scope]:
+    """Add scopes to an existing collection, preserving order and removing duplicates."""
+    return parse_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> list[Scope]:
+    """Remove scopes from an existing collection, preserving order."""
+    parsed_existing = parse_scopes(existing)
+    parsed_remove = set(parse_scopes(to_remove))
+    return [s for s in parsed_existing if s not in parsed_remove]

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, remove_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +159,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +57,20 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_add_scopes(self):
+        assert add_scopes("admin", "demo,reports") == [
+            Scope("admin"),
+            Scope("demo"),
+            Scope("reports"),
+        ]
+        assert add_scopes(["admin"], ["demo"]) == [Scope("admin"), Scope("demo")]
+        assert add_scopes("a,b", "b,c") == [Scope("a"), Scope("b"), Scope("c")]
+
+    def test_remove_scopes(self):
+        assert remove_scopes("admin,demo,reports", "demo,admin") == [Scope("reports")]
+        assert remove_scopes(["a", "b", "c"], ["b"]) == [Scope("a"), Scope("c")]
+        assert remove_scopes("a,b", "c") == [Scope("a"), Scope("b")]
 
     def test_role_constants(self):
         assert USER == "user"


### PR DESCRIPTION
💡 What: Extracted scattered scope manipulation logic into pure `add_scopes` and `remove_scopes` helpers in `h4ckath0n/auth/authz.py`, updating `src/h4ckath0n/cli/users.py` to use them.

🎯 Why: To eliminate ad-hoc tuple unpacking, list comprehensions, and set manipulation at call sites, centralizing the domain logic (order preservation, deduplication) alongside the parsing.

🧠 Design: The new pure helpers accept either strings or iterables, parse them into uniform `Scope` objects, apply the required list operations deterministically, and return a cleanly processed list of scopes ready for serialization, strictly mirroring existing parsing behavior.

λ FP Angle: Replaces scattered mutation logic and procedural set operations with clean, composable data-in/data-out transformations.

✅ Verification: Modified code successfully passed static analysis (`ruff check`), formatting, and type-checking (`mypy`). Added dedicated assertions in `tests/test_authz.py` and ran the full `pytest` suite cleanly.

🧪 Edge cases: Tested order preservation on add, proper deduplication on add, graceful removal of multiple overlapping scopes, and handling of existing scopes vs single scope manipulation.

⚠️ Risk: Minimal. Replaces inline behavior with strictly equivalent extracted functions. Fully covered by existing tests.

---
*PR created automatically by Jules for task [986730138117693561](https://jules.google.com/task/986730138117693561) started by @ToolchainLab*