### PR TITLE
🎨 Palette: Add focus ring to password toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-02 - Focus rings for absolute positioned input elements
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radius to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 **What**: Added Tailwind focus-visible classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and `rounded-xl` to the password visibility toggle button in `PasswordField.tsx`.

🎯 **Why**: The absolute positioned icon button inside the password input lacked a native focus ring when navigated to via keyboard. This made it difficult for keyboard users to track focus location within the form.

📸 **Before/After**: See attached visual verification (recorded via playwright) where the toggle button now displays a clear blue focus ring matching the primary input.

♿ **Accessibility**: Significant improvement to keyboard accessibility by providing visual feedback when the visibility toggle receives focus, ensuring compliance with focus visibility standards.

---
*PR created automatically by Jules for task [13248214285188612127](https://jules.google.com/task/13248214285188612127) started by @ToolchainLab*