### PR TITLE
∴ Vector: Extract pure helpers for user scope transformations

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2025-08-03 - Centralizing pure scope transformations
+**Learning:** The logic for adding and removing scopes was duplicated and mixed with database mutation logic in the CLI. By centralizing it into `add_scopes` and `remove_scopes` within the authz domain, the semantics are explicit and simpler to test.
+**Action:** Prefer extracting pure functional transformations over performing multi-step state mutations within command handlers.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,15 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(existing: str, to_add: str | Iterable[str]) -> str:
+    """Add new scopes to an existing scopes string, returning the updated string."""
+    return serialize_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str, to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from an existing scopes string, returning the updated string."""
+    current = parse_scopes(existing)
+    drop = set(parse_scopes(to_remove))
+    return serialize_scopes([s for s in current if s not in drop])

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +159,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +57,16 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_add_scopes(self):
+        assert add_scopes("admin", "demo, reports") == "admin,demo,reports"
+        assert add_scopes("admin,demo", ["admin", "reports"]) == "admin,demo,reports"
+        assert add_scopes("", "admin") == "admin"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("admin,demo,reports", "demo") == "admin,reports"
+        assert remove_scopes("admin,demo", ["demo", "reports"]) == "admin"
+        assert remove_scopes("admin", "") == "admin"
 
     def test_role_constants(self):
         assert USER == "user"


### PR DESCRIPTION
💡 What: Extract inline scope parsing and serializing logic from CLI handlers into pure domain helpers (`add_scopes`, `remove_scopes`) in `h4ckath0n.auth.authz`.
🎯 Why: The logic for safely adding or removing a scope from the comma-separated string representation was duplicated across several command handlers, mixing state mutation with data shaping.
🧠 Design: Move the parsing/set-logic/serialization into pure functions that take and return strings (or iterables), keeping side effects (session.commit) tightly contained in the CLI.
λ FP Angle: Replaces inline, stateful mutations (e.g., list comprehensions parsing and updating `user.scopes` directly) with explicit transformation pipelines that are deterministic and side-effect free.
✅ Verification: `uv run --locked pytest -v` (added full test coverage for the new helpers), `uv run --locked ruff check --fix .`, `uv run --locked ruff format .`, `uv run --locked mypy src`.
🧪 Edge cases: Added explicit test cases ensuring that adding to empty scope lists, adding duplicates, and removing non-existent scopes all handle gracefully without trailing commas or empty spaces.
⚠️ Risk: Low; the underlying string formatting logic is unchanged, just relocated and tested.

---
*PR created automatically by Jules for task [13975078600053702610](https://jules.google.com/task/13975078600053702610) started by @ToolchainLab*