### PR TITLE
🎨 Palette: Add keyboard focus ring to password toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-03 - Missing Focus Rings on Absolute Positioned Elements
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radius to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-r-xl text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring styles (`focus-visible:ring-2 focus-visible:ring-primary`) and border radius (`rounded-r-xl`) to the password toggle button.
🎯 Why: The absolute positioned visibility toggle lacked native focus indication, making it difficult for keyboard users to track focus state when tabbing through the login form.
📸 Before/After: Visual focus state is now clearly rendered with a primary color ring when tabbing to the toggle, matching the input's focus state.
♿ Accessibility: Dramatically improves keyboard navigation visibility for the interactive password toggle.

---
*PR created automatically by Jules for task [5943823283835698912](https://jules.google.com/task/5943823283835698912) started by @ToolchainLab*