### PR TITLE
⚡ Bolt: Use limit(1) for O(1) existence check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2026-03-24 - Avoid O(N) Table Scans for Existence Checks
+
+**Learning:** When checking if a table is empty (or has any rows matching a condition) in SQLAlchemy, using `select(func.count()).select_from(Model)` forces the database to count all matching rows, which is an O(N) operation. This is especially slow on large tables or unindexed queries.
+
+**Action:** Always use `await db.scalar(select(Model.id).limit(1))` and check if the result is `None` for existence checks. The `limit(1)` modifier turns the query into a fast O(1) operation by stopping at the first matched row.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -11,7 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from h4ckath0n.auth.models import Device, PasswordResetToken, User
@@ -41,9 +41,9 @@ async def _is_bootstrap_admin(email: str, settings: Settings, db: AsyncSession) 
     if email in settings.bootstrap_admin_emails:
         return True
     if settings.first_user_is_admin:
-        result = await db.execute(select(func.count()).select_from(User))
-        count = result.scalar()
-        if count == 0:
+        # ⚡ Bolt: Use .limit(1) for O(1) existence check rather than O(N) table count.
+        existing = await db.scalar(select(User.id).limit(1))
+        if existing is None:
             return True
     return False
 


### PR DESCRIPTION
💡 What: Replaced `func.count()` with `limit(1)` in `_is_bootstrap_admin`.
🎯 Why: To avoid an O(N) full table count operation when checking if the User table is empty.
📊 Impact: Turns an O(N) count operation into an O(1) existence check.
🔬 Measurement: Run the test suite (`uv run --locked pytest -v`) to verify behavior remains correct.

---
*PR created automatically by Jules for task [15466438497194706134](https://jules.google.com/task/15466438497194706134) started by @ToolchainLab*