### PR TITLE
🎨 Palette: Add focus ring to password toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-04 - Missing Focus Rings on Absolute Positioned Elements
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radius to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-r-xl text-text-muted hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-colors disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and right border radius (`rounded-r-xl`) to the password visibility toggle button.
🎯 Why: Absolute positioned interactive elements inside inputs often miss native focus rings, making them invisible during keyboard navigation. This ensures users relying on keyboard navigation can see when the toggle button is focused.
📸 Before/After: N/A (Visual focus state only)
♿ Accessibility: Improves keyboard accessibility by ensuring the password visibility toggle has a clear, visible focus indicator matching the design system.

---
*PR created automatically by Jules for task [13518001545895291076](https://jules.google.com/task/13518001545895291076) started by @ToolchainLab*