### PR TITLE
🧭 Atlas: Fix API route documentation check by reading from OpenAPI schema

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-06-25 - FastAPI nested routers cause missed API routes in drift checks
+**Learning:** `app.routes` in FastAPI includes nested `APIRouter` objects (represented internally as `_IncludedRouter`), which do not expose `.path` and `.methods` directly. Iterating over `app.routes` and skipping items without `.path` silently misses all endpoints mounted via nested routers (e.g. `/auth/passkey/*`).
+**Action:** When validating or extracting API routes in FastAPI, always generate and inspect the OpenAPI schema (`app.openapi()["paths"]`) instead of recursively walking the internal routing tree, as it is a more reliable source of truth for the fully registered endpoints.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -33,18 +33,13 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
+    schema = app.openapi()
     routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    for path, item in schema.get("paths", {}).items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
+        for method in item:
+            routes.append((method.upper(), path))
     return sorted(routes)
 
 


### PR DESCRIPTION
💡 What: Refactored `scripts/check_doc_routes.py` to retrieve the registered API routes from the generated OpenAPI schema (`app.openapi()`) rather than iterating through `app.routes`.
🎯 Why: The original check missed endpoints registered within nested `APIRouter`s (represented internally as `_IncludedRouter` without `.path` attributes). It gave a false positive "All 2 API routes are documented" instead of finding the 25 actual routes, missing significant doc drift.
🧪 Verification: Run `PYTHONPATH=src uv run scripts/check_doc_routes.py`. Note it now correctly identifies 25 routes and asserts they are properly documented.
🔒 Drift Prevention: This strengthens the existing `check_doc_routes.py` drift prevention script, making it resilient to FastAPI's internal nested router data structures by relying on the stable OpenAPI contract as the source of truth.
🗺️ Evidence: Examined `scripts/check_doc_routes.py` and compared `app.routes` contents to `app.openapi()["paths"]`.

---
*PR created automatically by Jules for task [16106153204051648963](https://jules.google.com/task/16106153204051648963) started by @ToolchainLab*