### PR TITLE
∴ Vector: Extract pure scope addition and removal helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-08-05 - Centralize scope collection mutation helpers
+**Learning:** The application repeatedly parsed string scopes, manipulated them using python sets and comprehensions inline in command handlers, and reserialized them. This scattered domain knowledge into procedural mutation.
+**Action:** Centralize explicit transformations into `add_scopes` and `remove_scopes` functional helpers, which takes `str | Iterable[str]` for correctness and re-exports deterministic behaviour.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,14 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(existing: str | Iterable[str], to_add: str | Iterable[str]) -> list[Scope]:
+    """Return a new list of scopes combining existing and to_add, preserving order."""
+    return parse_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> list[Scope]:
+    """Return a new list of scopes with to_remove excluded from existing."""
+    remove_set = set(parse_scopes(to_remove))
+    return [s for s in parse_scopes(existing) if s not in remove_set]

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, remove_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +159,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +57,13 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", "c,d") == [Scope("a"), Scope("b"), Scope("c"), Scope("d")]
+        assert add_scopes("a,b", ["b", "c"]) == [Scope("a"), Scope("b"), Scope("c")]
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c", "b,d") == [Scope("a"), Scope("c")]
 
     def test_role_constants(self):
         assert USER == "user"


### PR DESCRIPTION
💡 What: Extracted `add_scopes` and `remove_scopes` pure functions into `authz.py` and refactored inline mutative logic in `cli/users.py` to use them. Added corresponding tests.
🎯 Why: Scope modification logic (parsing, set comprehension/deduplication, serialization) was duplicated and spread across CLI command handlers. Centralizing it reduces mutation-heavy local logic and provides a single source of truth for these operations.
🧠 Design: The `add_scopes` and `remove_scopes` helpers leverage the existing `parse_scopes` to safely handle strings or iterables while maintaining order and deduplication guarantees.
λ FP Angle: Replaces inline procedural mutation and ad-hoc set manipulations with a composable transformation pipeline, keeping the domain semantics purely functional.
✅ Verification: I ran `uv run --locked ruff format .`, `uv run --locked ruff check .`, `uv run --locked mypy src`, and `uv run --locked pytest -v`.
🧪 Edge cases: Tested adding disjoint scopes, adding overlapping scopes, and removing missing/existing scopes.
⚠️ Risk: Low risk. This purely replaces duplicated inline logic with central pure functions with identical behavior.

---
*PR created automatically by Jules for task [6713429606510511916](https://jules.google.com/task/6713429606510511916) started by @ToolchainLab*