### PR TITLE
⚡ Bolt: Avoid ORM hydration on user registration existence check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+## 2026-03-24 - Avoid ORM Hydration on Existence Checks
+
+**Learning:** When querying the database simply to check for the existence of a record by a secondary key (e.g., verifying if an email is already registered in `register_user`), executing a query for the entire model instance (e.g., `db.execute(select(User)).scalars().first()`) forces SQLAlchemy to parse and hydrate the full ORM object. This incurs unnecessary memory allocation and database bandwidth overhead for high-frequency operations.
+
+**Action:** Always fetch only the primary key column (e.g., `db.scalar(select(User.id).filter(...))`) when you only need to determine existence or fetch a foreign key reference. This bypasses the ORM hydration overhead entirely.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Fetch only the ID to avoid instantiating the full User ORM object
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(


### PR DESCRIPTION
💡 What: Replaced a full ORM object fetch (`db.execute(select(User)).scalars().first()`) with a targeted primary key fetch (`db.scalar(select(User.id))`) when checking if an email is already registered.
🎯 Why: The original implementation instantiated a complete `User` ORM instance only to check its existence, incurring unnecessary memory allocation, parsing overhead, and database bandwidth usage.
📊 Impact: Reduces memory allocation and speeds up the database query for a high-frequency authentication path.
🔬 Measurement: Run the test suite to verify no regressions in registration flows (`pytest tests/test_passkeys.py`).

---
*PR created automatically by Jules for task [13068259306326935513](https://jules.google.com/task/13068259306326935513) started by @ToolchainLab*