### PR TITLE
🎨 Palette: Add keyboard focus to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Add focus rings to absolute positioned interactive elements
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds during keyboard navigation.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radius to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added focus ring and border-radius styles to the absolute positioned password visibility toggle button in PasswordField.
🎯 Why: Absolute positioned interactive elements often miss native focus rings or get clipped, causing poor keyboard navigation accessibility. Adding explicit focus styles makes it clear when the element has focus.
📸 Before/After: Not applicable, minor CSS state change.
♿ Accessibility: Improved keyboard navigation accessibility by ensuring the password visibility toggle button has a clear, visible focus state.

---
*PR created automatically by Jules for task [3717298838250825547](https://jules.google.com/task/3717298838250825547) started by @ToolchainLab*