### PR TITLE
🧭 Atlas: Replace manual API route docs with OpenAPI-generated section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Check doc routes
         run: uv run --locked scripts/check_doc_routes.py
 
+      - name: Verify README API routes generation
+        run: |
+          uv run --locked scripts/generate_doc_routes.py
+          git diff --exit-code README.md || { echo "::error::README API routes are out of date. Run scripts/generate_doc_routes.py and commit."; exit 1; }
+
       - name: Check documented environments
         run: uv run --locked scripts/check_doc_env.py
 

--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - FastAPI Router Enumeration and Automated Route Docs
+**Learning:** In FastAPI (v0.115+), nested routers hide their `.methods` and `.path` inside `_IncludedRouter` objects in `app.routes`, breaking manual iteration for doc drift checks. Additionally, hand-maintained route lists in README files frequently omit new routes.
+**Action:** To reliably enumerate all fully registered endpoints, always generate and inspect the OpenAPI schema via `app.openapi().get('paths', {})`. Use this OpenAPI truth not only to check drift, but to directly generate and inject the route documentation into the README using delimited markers.

--- a/README.md
+++ b/README.md
@@ -63,26 +63,48 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- api-routes-start -->
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+### Auth
+- `GET /auth/session` — current session
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+### Core
+- `GET /` — welcome
+- `GET /health` — health
+
+### Jobs
+- `GET /jobs` — list jobs
+- `POST /jobs` — enqueue a job
+- `GET /jobs/{job_id}` — get job
+
+### Llm
+- `POST /llm/chat` — chat completion
+- `POST /llm/chat/stream` — streaming chat completion
+
+### Passkey
+- `POST /auth/passkey/register/start` — start passkey registration
+- `POST /auth/passkey/register/finish` — finish passkey registration
+- `POST /auth/passkey/login/start` — start passkey login
+- `POST /auth/passkey/login/finish` — finish passkey login
+- `POST /auth/passkey/add/start` — start adding a passkey
+- `POST /auth/passkey/add/finish` — finish adding a passkey
+- `GET /auth/passkeys` — list passkeys
+- `POST /auth/passkeys/{key_id}/revoke` — revoke a passkey
+- `PATCH /auth/passkeys/{key_id}` — rename a passkey
+
+### Password Auth
+- `POST /auth/register` — register with password
+- `POST /auth/login` — login with password
+- `POST /auth/password-reset/request` — request a password reset
+- `POST /auth/password-reset/confirm` — confirm password reset
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
+- `GET /uploads` — list uploads
+- `POST /uploads` — upload a file
+- `GET /uploads/{upload_id}` — get upload metadata
+- `GET /uploads/{upload_id}/download` — download a file
 
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- api-routes-end -->
 
 ## Auth model
 

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -34,17 +34,15 @@ def get_app_routes() -> list[tuple[str, str]]:
     app = create_app(settings)
 
     routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    openapi_paths = app.openapi().get("paths", {})
+    for path, path_item in openapi_paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method in path_item:
+            method_upper = method.upper()
+            if method_upper == "HEAD":
                 continue
-            routes.append((method, path))
+            routes.append((method_upper, path))
     return sorted(routes)
 
 

--- a/scripts/generate_doc_routes.py
+++ b/scripts/generate_doc_routes.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S uv run python
+"""Update the API routes section in README.md from the OpenAPI schema."""
+
+from __future__ import annotations
+
+import collections
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+
+def get_openapi_routes() -> str:
+    """Generate Markdown for API routes from the live FastAPI app."""
+    from h4ckath0n.app import create_app
+    from h4ckath0n.config import Settings
+
+    settings = Settings(
+        database_url="sqlite+aiosqlite://",
+        password_auth_enabled=True,
+    )
+    app = create_app(settings)
+
+    openapi_paths = app.openapi().get("paths", {})
+
+    tags_to_routes = collections.defaultdict(list)
+
+    for path, path_item in openapi_paths.items():
+        if path in {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}:
+            continue
+        for method, op in path_item.items():
+            method_upper = method.upper()
+            if method_upper == "HEAD":
+                continue
+            tags = op.get("tags", ["default"])
+            summary = op.get("summary", "")
+            tags_to_routes[tags[0]].append((method_upper, path, summary))
+
+    lines = []
+    for tag, routes in sorted(tags_to_routes.items()):
+        tag_name = tag.replace("-", " ").title()
+        if tag == "default" or not tag:
+            tag_name = "Core"
+        lines.append(f"### {tag_name}")
+        for method, path, summary in routes:
+            if summary:
+                lines.append(f"- `{method} {path}` — {summary.lower()}")
+            else:
+                lines.append(f"- `{method} {path}`")
+        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def main() -> int:
+    readme_text = README.read_text()
+
+    start_marker = "<!-- api-routes-start -->"
+    end_marker = "<!-- api-routes-end -->"
+
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print(f"Error: Could not find {start_marker} and {end_marker} in README.md")
+        return 1
+
+    generated = get_openapi_routes()
+
+    pattern = re.compile(rf"{re.escape(start_marker)}.*?{re.escape(end_marker)}", re.DOTALL)
+    new_text = pattern.sub(f"{start_marker}\n\n{generated}\n\n{end_marker}", readme_text)
+
+    if new_text != readme_text:
+        README.write_text(new_text)
+        print("Updated README.md with generated API routes.")
+    else:
+        print("README.md API routes are already up to date.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
💡 What: Replace the manually maintained list of API routes in the `README.md` with a dynamically generated block based on the OpenAPI schema.
🎯 Why: The route list in the README frequently drifted and was missing recent endpoints. The previous drift check failed to catch this due to nested FastAPI routers hiding routes.
🔬 Verification: Run `uv run scripts/generate_doc_routes.py` to regenerate the docs, and `uv run scripts/check_doc_routes.py` to ensure all routes in the app are correctly documented. Tests and linters pass successfully.
🔒 Drift Prevention: Added a new CI step `Verify README API routes generation` that automatically regenerates the docs and fails if the `README.md` is modified, enforcing that the committed document matches the code output exactly. Fixed `scripts/check_doc_routes.py` to use OpenAPI parsing.
🗺️ Evidence: Replaced duplicate hand-written content in `README.md` based on source-of-truth routes registered in `src/h4ckath0n/app.py` via `app.openapi()`.

---
*PR created automatically by Jules for task [8693573456748760904](https://jules.google.com/task/8693573456748760904) started by @ToolchainLab*