### PR TITLE
∷ Vector: Extract shared pure helpers for adding and removing scopes

### DIFF
--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,16 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(existing: str | Iterable[str], to_add: str | Iterable[str]) -> str:
+    """Add new scopes to an existing scopes collection and return the serialized result."""
+    return serialize_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from an existing scopes collection and return the serialized result."""
+    parsed_existing = parse_scopes(existing)
+    parsed_to_remove = set(parse_scopes(to_remove))
+    remaining = [s for s in parsed_existing if s not in parsed_to_remove]
+    return serialize_scopes(remaining)

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, remove_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +159,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -45,6 +47,15 @@ class TestScopes:
 
     def test_serialize_deduplicates(self):
         assert serialize_scopes([Scope("a"), Scope("a"), Scope("b")]) == "a,b"
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", "c") == "a,b,c"
+        assert add_scopes("a,b", "b,c") == "a,b,c"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c", "b") == "a,c"
+        assert remove_scopes("a,b", "c") == "a,b"
+        assert remove_scopes("a,b", ["b", "c"]) == "a"
 
     def test_missing_scopes_returns_difference(self):
         granted = parse_scopes("admin,demo")


### PR DESCRIPTION
💡 What: Extract `add_scopes` and `remove_scopes` pure functions into `h4ckath0n.auth.authz`.
🎯 Why: The logic for adding and removing scopes was duplicated in the CLI (and possibly elsewhere in the future). Centralizing it removes repeated parsing/set manipulation/reserializing, creating a single source of truth for scope transformations.
🧠 Design: I added two small helpers that leverage the existing `parse_scopes` and `serialize_scopes` functions. This keeps the transformation logic explicit and pure.
λ FP Angle: Transforms scattered, mutation-heavy inline data shaping (parsing, list comprehensions, sets, reserializing) into composable pure functions with clear type boundaries.
✅ Verification: Ran format, lint, typecheck, and unit tests. Added explicit tests for `add_scopes` and `remove_scopes`.
🧪 Edge cases: Tested deduplication and preservation of existing scopes when adding, as well as safe handling when removing non-existent scopes or collections.
⚠️ Risk: Low risk. This preserves the exact behavior previously inlined in the CLI commands.

---
*PR created automatically by Jules for task [11870477977591638167](https://jules.google.com/task/11870477977591638167) started by @ToolchainLab*