### PR TITLE
⚡ Bolt: Avoid ORM hydration for user existence check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+## 2024-08-06 - Avoid ORM hydration for existence checks
+**Learning:** When checking for the existence of a row by secondary keys (like email) in SQLAlchemy, using `select(Model).filter(...)` and fetching the full object via `.scalars().first()` is inefficient. It incurs unnecessary memory allocation and database bandwidth overhead to hydrate an object we don't actually need.
+**Action:** Use `await db.scalar(select(Model.id).filter(...))` to fetch only the ID for existence checks.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Fetch only the ID to avoid instantiating the full User ORM object.
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(


### PR DESCRIPTION
💡 What: Optimize the email existence check in `register_user` by selecting only the `User.id` instead of fetching the full `User` ORM object.
🎯 Why: Fetching a full ORM object just to check for existence incurs unnecessary database bandwidth and memory allocation overhead.
📊 Impact: Faster registration attempts and reduced memory footprint by avoiding ORM hydration.
🔬 Measurement: Verify tests pass with `uv run --locked pytest -v` and inspect the SQL query via SQLAlchemy echo logs.

---
*PR created automatically by Jules for task [4759005036040213405](https://jules.google.com/task/4759005036040213405) started by @ToolchainLab*