### PR TITLE
🧭 Atlas: Replace hand-written endpoint lists with generated list from OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,39 +61,37 @@ uv run uvicorn your_module:app --reload
 - Protected routes require an `Authorization: Bearer <device_jwt>` header that the web
   template can mint after login.
 
-## Built-in routes
+## API routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- BEGIN API ROUTES -->
+- `GET /` — Welcome
+- `POST /auth/login` — Login with password
+- `POST /auth/passkey/add/finish` — Finish adding a passkey
+- `POST /auth/passkey/add/start` — Start adding a passkey
+- `POST /auth/passkey/login/finish` — Finish passkey login
+- `POST /auth/passkey/login/start` — Start passkey login
+- `POST /auth/passkey/register/finish` — Finish passkey registration
+- `POST /auth/passkey/register/start` — Start passkey registration
+- `GET /auth/passkeys` — List passkeys
+- `PATCH /auth/passkeys/{key_id}` — Rename a passkey
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey
+- `POST /auth/password-reset/confirm` — Confirm password reset
+- `POST /auth/password-reset/request` — Request a password reset
+- `POST /auth/register` — Register with password
+- `GET /auth/session` — Current session
+- `GET /health` — Health
+- `GET /jobs` — List jobs
+- `POST /jobs` — Enqueue a job
+- `GET /jobs/{job_id}` — Get job
+- `POST /llm/chat` — Chat completion
+- `POST /llm/chat/stream` — Streaming chat completion
+- `GET /uploads` — List uploads
+- `POST /uploads` — Upload a file
+- `GET /uploads/{upload_id}` — Get upload metadata
+- `GET /uploads/{upload_id}/download` — Download a file
+<!-- END API ROUTES -->
 
 ## Auth model
-
-### Passkeys by default
-
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
 
 ### Device signed JWTs
 
@@ -146,11 +144,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env -S uv run python
-"""Drift-prevention check: verify that every API route in the FastAPI app is documented.
+"""Drift-prevention check: verify that the API routes in README.md perfectly match the app.
 
 Usage (from repo root):
-    uv run scripts/check_doc_routes.py
+    uv run scripts/check_doc_routes.py [--update]
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script generates the exact markdown block of routes from the OpenAPI schema.
+It enforces that the content between <!-- BEGIN API ROUTES --> and <!-- END API ROUTES -->
+is exactly this generated block. Use --update to automatically apply fixes.
 """
 
 from __future__ import annotations
 
-import re
+import argparse
 import sys
 from pathlib import Path
 
@@ -22,10 +22,10 @@ README = REPO_ROOT / "README.md"
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
-    from h4ckath0n.app import create_app  # noqa: E402
-    from h4ckath0n.config import Settings  # noqa: E402
+def get_generated_markdown() -> str:
+    """Generate the full markdown block for all documented API routes."""
+    from h4ckath0n.app import create_app
+    from h4ckath0n.config import Settings
 
     settings = Settings(
         database_url="sqlite+aiosqlite://",
@@ -33,58 +33,69 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    # Retrieve routes using the OpenAPI schema for reliable enumeration.
+    paths = app.openapi().get("paths", {})
+    routes: list[tuple[str, str, str]] = []
+
+    for path, methods in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+        for method, details in methods.items():
+            summary = details.get("summary", "")
+            routes.append((method.upper(), path, summary))
 
+    # Sort logically by path then method
+    routes.sort(key=lambda x: (x[1], x[0]))
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+    lines = ["<!-- BEGIN API ROUTES -->"]
+    for method, path, summary in routes:
+        if summary:
+            lines.append(f"- `{method} {path}` — {summary}")
+        else:
+            lines.append(f"- `{method} {path}`")
+    lines.append("<!-- END API ROUTES -->")
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    return "\n".join(lines)
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--update", action="store_true", help="Update the README in place")
+    args = parser.parse_args()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    readme_text = README.read_text()
+    generated_block = get_generated_markdown()
+
+    begin_marker = "<!-- BEGIN API ROUTES -->"
+    end_marker = "<!-- END API ROUTES -->"
+
+    start_idx = readme_text.find(begin_marker)
+    end_idx = readme_text.find(end_marker)
+
+    if start_idx == -1 or end_idx == -1:
+        print(f"❌ Missing markers '{begin_marker}' and '{end_marker}' in README.md")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+    # Extract existing block including markers
+    existing_block = readme_text[start_idx : end_idx + len(end_marker)]
+
+    if existing_block == generated_block:
+        print("✅ API routes in README.md match the live application.")
+        return 0
+
+    if args.update:
+        new_readme_text = (
+            readme_text[:start_idx] + generated_block + readme_text[end_idx + len(end_marker) :]
+        )
+        README.write_text(new_readme_text)
+        print("✅ README.md updated successfully with actual API routes.")
+        return 0
+    else:
+        print("❌ API routes in README.md are outdated.")
+        print("\nExpected block:\n")
+        print(generated_block)
+        print("\nRun `uv run scripts/check_doc_routes.py --update` to fix.")
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Replaced scattered hand-written API route lists in README.md with a single exact representation generated dynamically from the FastAPI OpenAPI schema.
🎯 Why: Reduces documentation drift. It guarantees that the route lists provided for new users correctly and completely reflect the repo codebase state.
🔬 Verification: Run `uv run scripts/check_doc_routes.py --update` locally.
🔒 Drift Prevention: Strengthened `scripts/check_doc_routes.py` to assert the markdown section in `README.md` exactly matches the dynamically generated string from the live OpenAPI schema. This fails the CI if any route deviates.
🗺️ Evidence: `README.md`, `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [15244278283764743282](https://jules.google.com/task/15244278283764743282) started by @ToolchainLab*