### PR TITLE
∴ Vector: Centralize scope transformations into pure functional helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-08-07 - Functional-style centralization of scope transformations
+**Learning:** In the authorization domain, user scopes are parsed and modified in command handlers inline, utilizing state mutation via multiple variables.
+**Action:** Moved the transformation logic (`add_scopes`, `remove_scopes`) into the `authz.py` module as centralized, deterministic, pure-functional helpers. This removes duplication and makes the API more composable.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -38,6 +38,17 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
     return ",".join(dict.fromkeys(str(s) for s in scopes if s))
 
 
+def add_scopes(existing: str | Iterable[str], to_add: str | Iterable[str]) -> list[Scope]:
+    """Add new scopes to existing scopes, preserving order and deduplicating."""
+    return parse_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> list[Scope]:
+    """Remove specific scopes from existing scopes, preserving remaining order."""
+    remove_set = set(parse_scopes(to_remove))
+    return [s for s in parse_scopes(existing) if s not in remove_set]
+
+
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import add_scopes, remove_scopes, serialize_scopes
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +142,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +159,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -60,6 +60,20 @@ class TestScopes:
         assert USER == "user"
         assert ADMIN == "admin"
 
+    def test_add_scopes(self):
+        from h4ckath0n.auth.authz import add_scopes
+
+        assert add_scopes("admin", "demo") == [Scope("admin"), Scope("demo")]
+        assert add_scopes("admin", "admin,demo") == [Scope("admin"), Scope("demo")]
+        assert add_scopes(["admin"], ["demo"]) == [Scope("admin"), Scope("demo")]
+
+    def test_remove_scopes(self):
+        from h4ckath0n.auth.authz import remove_scopes
+
+        assert remove_scopes("admin,demo", "demo") == [Scope("admin")]
+        assert remove_scopes("admin,demo", "reports") == [Scope("admin"), Scope("demo")]
+        assert remove_scopes(["admin", "demo"], ["admin"]) == [Scope("demo")]
+
 
 class TestPasskeyErrors:
     def test_hierarchy_subclasses_value_error(self):


### PR DESCRIPTION
💡 What: Extracted the mutation-heavy inline logic for adding and removing scopes from the CLI command handlers into centralized, pure functional transformations (`add_scopes` and `remove_scopes`) in `h4ckath0n.auth.authz`.
🎯 Why: To remove duplicated transformation logic, increase determinism, and prevent future bugs by centralizing the semantics of scope modification.
🧠 Design: Implemented `add_scopes` and `remove_scopes` as pure helpers that accept both strings and iterables, cleanly parse the inputs, and return properly ordered and deduplicated lists.
λ FP Angle: Replaced multi-step staging with temporary mutable containers in command handlers with a clear transformation pipeline, following the repository's preference for functional-programming style.
✅ Verification: Ran the linter, type checker, and test suite.
🧪 Edge cases: Added tests for the new helpers to explicitly handle string inputs, iterable inputs, and duplicate entries.
⚠️ Risk: Low. The logic was moved and encapsulated; external behavior of the CLI and system remains identical.

---
*PR created automatically by Jules for task [3571990388355936659](https://jules.google.com/task/3571990388355936659) started by @ToolchainLab*