### PR TITLE
🧭 Atlas: Replace hand-written API routes with OpenAPI-generated docs

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - OpenAPI schema generation prevents duplicate doc drift
+**Learning:** Scattered handwritten lists of API endpoints in the README (e.g., separate sections for Passkeys, Password auth, and built-in routes) invariably drift from the actual code.
+**Action:** Consolidate API endpoint documentation into a single markdown section generated directly from the live OpenAPI schema, using script markers and a `--fix` drift prevention check to guarantee parity.

--- a/README.md
+++ b/README.md
@@ -61,39 +61,56 @@ uv run uvicorn your_module:app --reload
 - Protected routes require an `Authorization: Bearer <device_jwt>` header that the web
   template can mint after login.
 
-## Built-in routes
+## API Routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- BEGIN API ROUTES -->
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+### General
+- `` `GET /` `` — welcome
+- `` `GET /health` `` — health
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+### auth
+- `` `GET /auth/session` `` — current session
 
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
+### jobs
+- `` `GET /jobs` `` — list jobs
+- `` `POST /jobs` `` — enqueue a job
+- `` `GET /jobs/{job_id}` `` — get job
 
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+### llm
+- `` `POST /llm/chat` `` — chat completion
+- `` `POST /llm/chat/stream` `` — streaming chat completion
+
+### passkey
+- `` `POST /auth/passkey/add/finish` `` — finish adding a passkey
+- `` `POST /auth/passkey/add/start` `` — start adding a passkey
+- `` `POST /auth/passkey/login/finish` `` — finish passkey login
+- `` `POST /auth/passkey/login/start` `` — start passkey login
+- `` `POST /auth/passkey/register/finish` `` — finish passkey registration
+- `` `POST /auth/passkey/register/start` `` — start passkey registration
+- `` `GET /auth/passkeys` `` — list passkeys
+- `` `PATCH /auth/passkeys/{key_id}` `` — rename a passkey
+- `` `POST /auth/passkeys/{key_id}/revoke` `` — revoke a passkey
+
+### password-auth
+- `` `POST /auth/login` `` — login with password
+- `` `POST /auth/password-reset/confirm` `` — confirm password reset
+- `` `POST /auth/password-reset/request` `` — request a password reset
+- `` `POST /auth/register` `` — register with password
+
+### uploads
+- `` `GET /uploads` `` — list uploads
+- `` `POST /uploads` `` — upload a file
+- `` `GET /uploads/{upload_id}` `` — get upload metadata
+- `` `GET /uploads/{upload_id}/download` `` — download a file
+
+<!-- END API ROUTES -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn). Core flows involve registration, login, adding devices, and management. See the API Routes section for specific endpoints.
 
 ### Device signed JWTs
 
@@ -145,12 +162,7 @@ def refund(user=require_scopes("billing:refund")):
 ## Password auth (optional)
 
 Password routes mount only when the password extra is installed and
-`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
+`H4CKATH0N_PASSWORD_AUTH_ENABLED=true`. See the API Routes section for specific endpoints.
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -2,16 +2,11 @@
 """Drift-prevention check: verify that every API route in the FastAPI app is documented.
 
 Usage (from repo root):
-    uv run scripts/check_doc_routes.py
-
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+    uv run scripts/check_doc_routes.py [--fix]
 """
 
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 
@@ -22,68 +17,67 @@ README = REPO_ROOT / "README.md"
 FRAMEWORK_PATHS = frozenset({"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"})
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
-    from h4ckath0n.app import create_app  # noqa: E402
-    from h4ckath0n.config import Settings  # noqa: E402
+def generate_routes_markdown() -> str:
+    from h4ckath0n.app import create_app
+    from h4ckath0n.config import Settings
 
-    settings = Settings(
-        database_url="sqlite+aiosqlite://",
-        password_auth_enabled=True,
-    )
+    settings = Settings(database_url="sqlite+aiosqlite://", password_auth_enabled=True)
     app = create_app(settings)
+    openapi = app.openapi()
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    routes_by_tag = {}
+    for path, methods in openapi.get("paths", {}).items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+        for method, details in methods.items():
+            tag = details.get("tags", ["General"])[0]
+            if tag not in routes_by_tag:
+                routes_by_tag[tag] = []
+            routes_by_tag[tag].append((method.upper(), path, details.get("summary", "")))
 
-
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
-
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    lines = []
+    for tag in sorted(routes_by_tag.keys()):
+        lines.append(f"### {tag}")
+        for method, path, summary in sorted(routes_by_tag[tag], key=lambda x: x[1]):
+            lines.append(f"- `` `{method} {path}` `` — {summary.lower()}")
+        lines.append("")
+    return "\n".join(lines).strip()
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    expected_markdown = generate_routes_markdown()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    readme_text = README.read_text()
+
+    start_marker = "<!-- BEGIN API ROUTES -->"
+    end_marker = "<!-- END API ROUTES -->"
+
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print("❌ Markers not found in README.md")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    start_idx = readme_text.find(start_marker) + len(start_marker)
+    end_idx = readme_text.find(end_marker)
+
+    current_markdown = readme_text[start_idx:end_idx].strip()
+
+    if current_markdown != expected_markdown:
+        if "--fix" in sys.argv:
+            new_readme = (
+                readme_text[:start_idx]
+                + "\n\n"
+                + expected_markdown
+                + "\n\n"
+                + readme_text[end_idx:]
+            )
+            README.write_text(new_readme)
+            print("✅ Updated README.md with generated routes.")
+            return 0
+        else:
+            print("❌ README.md routes do not match generated routes. Run with --fix to update.")
+            return 1
+
+    print("✅ API routes in README.md are up to date.")
     return 0
 
 


### PR DESCRIPTION
💡 What: Consolidated scattered API route documentation into a single, dynamically-generated markdown list.
🎯 Why: Hand-written lists of endpoints in the README were duplicating logic and prone to drift when routes are added/modified.
🔬 Verification: Run `uv run scripts/check_doc_routes.py` to verify the generated routes match the README.
🔒 Drift Prevention: Strengthened the drift-prevention script to actively generate and compare the README section rather than just doing a regex search. The script can auto-fix the README with `--fix`.
🗺️ Evidence: Checked against the live OpenAPI schema generated from `h4ckath0n.app.create_app` in `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [521971708880179699](https://jules.google.com/task/521971708880179699) started by @ToolchainLab*