### PR TITLE
⚡ Bolt: optimize existence checks to avoid ORM hydration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+
+## 2024-08-08 - Optimize existence checks by avoiding ORM hydration
+
+**Learning:** When querying the database purely to check for existence by a secondary key (e.g. email during registration), fetching the entire model instance (using `select(Model)` and `.scalars().first()`) incurs unnecessary memory allocation and database bandwidth overhead due to ORM hydration.
+
+**Action:** Always use `db.scalar(select(Model.id).filter(...))` to fetch only the ID instead of instantiating the full ORM model object when performing existence checks.

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Fetch only ID to avoid instantiating full User ORM object during registration check.
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(


### PR DESCRIPTION
💡 What: Changed the existence check in `register_user` to select only `User.id` instead of fetching the entire `User` object.
🎯 Why: When checking if an email is already registered, hydrating the full `User` ORM object causes unnecessary database bandwidth and memory allocation overhead. Selecting only the ID is sufficient for an existence check.
📊 Impact: Avoids unnecessary instantiation of a `User` ORM object per registration attempt, reducing memory overhead and improving query performance slightly.
🔬 Measurement: The `h4ckath0n` test suite (`uv run --locked pytest -v`) passes, ensuring functionality is preserved while relying purely on an ID check.

---
*PR created automatically by Jules for task [14603401160762904122](https://jules.google.com/task/14603401160762904122) started by @ToolchainLab*