### PR TITLE
🎨 Palette: Add focus ring to password toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-20 - Focus Rings on Absolute Positioned Interactive Elements
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl`) to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added explicit focus-visible styles to the absolute positioned password visibility toggle button in `PasswordField`.
🎯 Why: The toggle button was missing keyboard focus indicators, making it inaccessible for keyboard users navigating through the form.
📸 Before/After: The button now shows a clear focus ring (using the primary brand color and border radius matching the input container) when focused via keyboard.
♿ Accessibility: Improved keyboard accessibility by ensuring interactive elements have a visible focus state.

---
*PR created automatically by Jules for task [4746462899209710297](https://jules.google.com/task/4746462899209710297) started by @ToolchainLab*