### PR TITLE
🧭 Atlas: [replace hand-written lists with generated sections from OpenAPI & settings]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Consolidate manual lists with auto-generated OpenAPI / Settings blocks
+**Learning:** Hand-written tables for configuration vars and hand-written lists for API routes reliably drift as new fields are added or path summaries change. Basic grep-based drift checks are hard to maintain and still allow out-of-order or duplicate entries.
+**Action:** Replace hand-written documentation lists with single, consolidated sections generated dynamically from the authoritative source (OpenAPI schema, config loader). Use structural markdown markers (e.g., `<!-- BEGIN API ROUTES -->`) and ensure the corresponding drift-check script includes a `--fix` flag to automatically populate and verify these sections.

--- a/README.md
+++ b/README.md
@@ -63,26 +63,28 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- BEGIN API ROUTES -->
+- `GET /` — Welcome.
+- `GET /health` — Health.
 
 ### Session
-- `GET /auth/session` — returns the current user session details.
+- `GET /auth/session` — Current session.
 
 ### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
+- `GET /jobs/{job_id}` — Get job.
+- `GET /jobs` — List jobs.
+- `POST /jobs` — Enqueue a job.
 
 ### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
+- `GET /uploads/{upload_id}/download` — Download a file.
+- `GET /uploads/{upload_id}` — Get upload metadata.
+- `GET /uploads` — List uploads.
+- `POST /uploads` — Upload a file.
 
 ### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+- `POST /llm/chat/stream` — Streaming chat completion.
+- `POST /llm/chat` — Chat completion.
+<!-- END API ROUTES -->
 
 ## Auth model
 
@@ -147,10 +149,16 @@ def refund(user=require_scopes("billing:refund")):
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
 
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
+<!-- BEGIN PASSWORD ROUTES -->
+- `POST /auth/login` — Login with password.
+- `POST /auth/passkey/login/finish` — Finish passkey login.
+- `POST /auth/passkey/login/start` — Start passkey login.
+- `POST /auth/passkey/register/finish` — Finish passkey registration.
+- `POST /auth/passkey/register/start` — Start passkey registration.
+- `POST /auth/password-reset/confirm` — Confirm password reset.
+- `POST /auth/password-reset/request` — Request a password reset.
+- `POST /auth/register` — Register with password.
+<!-- END PASSWORD ROUTES -->
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.
@@ -159,13 +167,14 @@ access tokens, refresh tokens, or cookies.
 
 All settings use the `H4CKATH0N_` prefix unless noted.
 
+<!-- BEGIN ENV VARS -->
 | Variable | Default | Description |
 |---|---|---|
 | `H4CKATH0N_ENV` | `development` | `development` or `production` |
 | `H4CKATH0N_DATABASE_URL` | `sqlite:///./h4ckath0n.db` | SQLAlchemy connection string |
 | `H4CKATH0N_AUTO_UPGRADE` | `false` | Auto-run packaged DB migrations to head on startup |
-| `H4CKATH0N_RP_ID` | `localhost` in development | WebAuthn relying party ID, required in production |
-| `H4CKATH0N_ORIGIN` | `http://localhost:8000` in development | WebAuthn origin, required in production |
+| `H4CKATH0N_RP_ID` | empty | WebAuthn relying party ID, required in production |
+| `H4CKATH0N_ORIGIN` | empty | WebAuthn origin, required in production |
 | `H4CKATH0N_WEBAUTHN_TTL_SECONDS` | `300` | WebAuthn challenge TTL in seconds |
 | `H4CKATH0N_USER_VERIFICATION` | `preferred` | WebAuthn user verification requirement |
 | `H4CKATH0N_ATTESTATION` | `none` | WebAuthn attestation preference |
@@ -173,8 +182,7 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_PASSWORD_RESET_EXPIRE_MINUTES` | `30` | Password reset token expiry in minutes |
 | `H4CKATH0N_BOOTSTRAP_ADMIN_EMAILS` | `[]` | JSON list of emails that become admin on password signup |
 | `H4CKATH0N_FIRST_USER_IS_ADMIN` | `false` | First password signup becomes admin |
-| `OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
-| `H4CKATH0N_OPENAI_API_KEY` | empty | Alternate OpenAI API key for the LLM wrapper |
+| `OPENAI_API_KEY / H4CKATH0N_OPENAI_API_KEY` | empty | OpenAI API key for the LLM wrapper |
 | `H4CKATH0N_REDIS_URL` | empty | Redis connection string |
 | `H4CKATH0N_JOBS_INLINE_IN_DEV` | `true` | Run background jobs inline in development mode |
 | `H4CKATH0N_JOBS_DEFAULT_QUEUE` | `default` | Default Redis queue for background jobs |
@@ -192,6 +200,7 @@ All settings use the `H4CKATH0N_` prefix unless noted.
 | `H4CKATH0N_SMTP_STARTTLS` | `true` | Enable SMTP STARTTLS |
 | `H4CKATH0N_SMTP_SSL` | `false` | Enable SMTP-over-SSL |
 | `H4CKATH0N_DEMO_MODE` | `false` | Enable demo mode |
+<!-- END ENV VARS -->
 
 In development, missing `RP_ID` and `ORIGIN` fall back to localhost defaults with
 warnings. In production, missing values raise a runtime error when passkey flows start.

--- a/scripts/check_doc_env.py
+++ b/scripts/check_doc_env.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env -S uv run python
-"""Verify that every ``Settings`` environment variable is documented in the README."""
-
-from __future__ import annotations
+"""Drift-prevention check: Verify and auto-update environment variables in README.md."""
 
 import re
 import sys
@@ -9,34 +7,60 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
-_DOCUMENTED_ENVIRONMENT = re.compile(r"^\|\s*`([A-Z][A-Z0-9_]*)`\s*\|", re.MULTILINE)
+MARKER_START = "<!-- BEGIN ENV VARS -->"
+MARKER_END = "<!-- END ENV VARS -->"
 
 
-def get_settings_environment_names() -> frozenset[str]:
-    """Return the environment variable name for each Settings field."""
+def get_env_table() -> str:
     from h4ckath0n.config import Settings
 
-    return frozenset(
-        f"H4CKATH0N_{field_name.upper()}" for field_name in Settings.model_fields
-    )
+    lines = ["| Variable | Default | Description |", "|---|---|---|"]
+    for name, field in Settings.model_fields.items():
+        name_upper = name.upper()
+        env_name = f"H4CKATH0N_{name_upper}"
+        if name == "openai_api_key":
+            env_name = "OPENAI_API_KEY / H4CKATH0N_OPENAI_API_KEY"
 
+        default = field.default if field.default != "" else "empty"
+        if default == []:
+            default = "`[]`"
+        elif isinstance(default, str) and default != "empty":
+            default = f"`{default}`"
+        elif isinstance(default, bool):
+            default = f"`{'true' if default else 'false'}`"
+        elif isinstance(default, int):
+            default = f"`{default}`"
 
-def get_documented_environment_names(readme_text: str) -> frozenset[str]:
-    """Return environment variable names from the first column of README tables."""
-    return frozenset(_DOCUMENTED_ENVIRONMENT.findall(readme_text))
+        desc = field.description or "TBD"
+        lines.append(f"| `{env_name}` | {default} | {desc} |")
+
+    return "\n".join(lines)
 
 
 def main() -> int:
-    documented = get_documented_environment_names(README.read_text())
-    missing = sorted(get_settings_environment_names().difference(documented))
-    if missing:
-        print("The following environment variables are not documented in README.md:\n")
-        for environment_name in missing:
-            print(f"  {environment_name}")
+    fix = "--fix" in sys.argv
+    readme_text = README.read_text()
+
+    if MARKER_START not in readme_text or MARKER_END not in readme_text:
+        print("❌ Markers not found in README.md")
         return 1
 
-    environment_count = len(get_settings_environment_names())
-    print(f"All {environment_count} Settings environment variables are documented.")
+    table = get_env_table()
+    replacement = f"{MARKER_START}\n{table}\n{MARKER_END}"
+
+    pattern = re.compile(rf"{MARKER_START}.*?{MARKER_END}", re.DOTALL)
+    new_text = pattern.sub(replacement, readme_text)
+
+    if new_text != readme_text:
+        if fix:
+            README.write_text(new_text)
+            print("✅ Updated environment variables in README.md")
+            return 0
+        else:
+            print("❌ README.md environment variables are out of date. Run with --fix.")
+            return 1
+
+    print("✅ Environment variables in README.md are up to date.")
     return 0
 
 

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -9,8 +9,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
 MARKER_API_START = "<!-- BEGIN API ROUTES -->"
 MARKER_API_END = "<!-- END API ROUTES -->"
-MARKER_PW_START = "<!-- BEGIN PASSWORD ROUTES -->"
-MARKER_PW_END = "<!-- END PASSWORD ROUTES -->"
+MARKER_PWD_START = "<!-- BEGIN PASSWORD ROUTES -->"
+MARKER_PWD_END = "<!-- END PASSWORD ROUTES -->"
 
 
 def categorize_route(path: str, route_str: str, routes: dict):
@@ -25,7 +25,7 @@ def categorize_route(path: str, route_str: str, routes: dict):
     elif path.startswith("/llm"):
         routes["llm"].append(route_str)
     elif "password" in path or "register" in path or "login" in path:
-        routes["password"].append(route_str)
+        routes["pwd_auth"].append(route_str)
     elif not path.startswith("/auth/passkey"):
         routes["other"].append(route_str)
 
@@ -44,7 +44,7 @@ def get_routes():
         "jobs": [],
         "uploads": [],
         "llm": [],
-        "password": [],
+        "pwd_auth": [],
         "other": [],
     }
 
@@ -83,16 +83,16 @@ def get_routes():
         )
     )
 
-    pw_content = "\n".join(sorted(routes["password"]))
+    pwd_auth_text = "\n".join(sorted(routes["pwd_auth"]))
 
-    return api_content, pw_content
+    return api_content, pwd_auth_text
 
 
 def main() -> int:
     fix = "--fix" in sys.argv
     readme_text = README.read_text()
 
-    api_content, pw_content = get_routes()
+    api_content, pwd_auth_text = get_routes()
 
     new_text = readme_text
 
@@ -101,9 +101,9 @@ def main() -> int:
         pattern = re.compile(rf"{MARKER_API_START}.*?{MARKER_API_END}", re.DOTALL)
         new_text = pattern.sub(replacement, new_text)
 
-    if MARKER_PW_START in new_text:
-        replacement = f"{MARKER_PW_START}\n{pw_content}\n{MARKER_PW_END}"
-        pattern = re.compile(rf"{MARKER_PW_START}.*?{MARKER_PW_END}", re.DOTALL)
+    if MARKER_PWD_START in new_text:
+        replacement = f"{MARKER_PWD_START}\n{pwd_auth_text}\n{MARKER_PWD_END}"
+        pattern = re.compile(rf"{MARKER_PWD_START}.*?{MARKER_PWD_END}", re.DOTALL)
         new_text = pattern.sub(replacement, new_text)
 
     if new_text != readme_text:

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env -S uv run python
-"""Drift-prevention check: verify that every API route in the FastAPI app is documented.
-
-Usage (from repo root):
-    uv run scripts/check_doc_routes.py
-
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
-"""
-
-from __future__ import annotations
+"""Drift-prevention check: Verify and auto-update API routes in README.md."""
 
 import re
 import sys
@@ -17,75 +7,115 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
+MARKER_API_START = "<!-- BEGIN API ROUTES -->"
+MARKER_API_END = "<!-- END API ROUTES -->"
+MARKER_PW_START = "<!-- BEGIN PASSWORD ROUTES -->"
+MARKER_PW_END = "<!-- END PASSWORD ROUTES -->"
 
-# FastAPI internal paths that we do not require in user docs.
-FRAMEWORK_PATHS = frozenset(
-    {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
-)
+
+def categorize_route(path: str, route_str: str, routes: dict):
+    if path in ["/", "/health"]:
+        routes["core"].append(route_str)
+    elif path.startswith("/auth/session"):
+        routes["session"].append(route_str)
+    elif path.startswith("/jobs"):
+        routes["jobs"].append(route_str)
+    elif path.startswith("/uploads"):
+        routes["uploads"].append(route_str)
+    elif path.startswith("/llm"):
+        routes["llm"].append(route_str)
+    elif "password" in path or "register" in path or "login" in path:
+        routes["password"].append(route_str)
+    elif not path.startswith("/auth/passkey"):
+        routes["other"].append(route_str)
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
-    from h4ckath0n.app import create_app  # noqa: E402
-    from h4ckath0n.config import Settings  # noqa: E402
+def get_routes():
+    from h4ckath0n.app import create_app
+    from h4ckath0n.config import Settings
 
-    settings = Settings(
-        database_url="sqlite+aiosqlite://",
-        password_auth_enabled=True,
-    )
+    settings = Settings(password_auth_enabled=True)
     app = create_app(settings)
+    schema = app.openapi()
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
-        if path in FRAMEWORK_PATHS:
-            continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+    routes = {
+        "core": [],
+        "session": [],
+        "jobs": [],
+        "uploads": [],
+        "llm": [],
+        "password": [],
+        "other": [],
+    }
 
+    for path, methods in schema.get("paths", {}).items():
+        for method, endpoint in methods.items():
+            summary = endpoint.get("summary", "")
+            route_str = f"- `{method.upper()} {path}` — {summary}."
+            categorize_route(path, route_str, routes)
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+    if routes["other"]:
+        # If there are uncategorized routes, the script should fail
+        # and require the developer to update it.
+        print(
+            "❌ Error: Uncategorized API routes found. "
+            "Please update scripts/check_doc_routes.py to categorize:"
+        )
+        for r in routes["other"]:
+            print(f"  {r}")
+        sys.exit(1)
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    def format_section(title, lst):
+        if not lst:
+            return ""
+        return f"### {title}\n" + "\n".join(sorted(lst))
+
+    api_content = "\n\n".join(
+        filter(
+            None,
+            [
+                "\n".join(sorted(routes["core"])),
+                format_section("Session", routes["session"]),
+                format_section("Background Jobs", routes["jobs"]),
+                format_section("Uploads", routes["uploads"]),
+                format_section("LLM Chat", routes["llm"]),
+            ],
+        )
+    )
+
+    pw_content = "\n".join(sorted(routes["password"]))
+
+    return api_content, pw_content
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    fix = "--fix" in sys.argv
+    readme_text = README.read_text()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
-        return 1
+    api_content, pw_content = get_routes()
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    new_text = readme_text
+
+    if MARKER_API_START in new_text:
+        replacement = f"{MARKER_API_START}\n{api_content}\n{MARKER_API_END}"
+        pattern = re.compile(rf"{MARKER_API_START}.*?{MARKER_API_END}", re.DOTALL)
+        new_text = pattern.sub(replacement, new_text)
+
+    if MARKER_PW_START in new_text:
+        replacement = f"{MARKER_PW_START}\n{pw_content}\n{MARKER_PW_END}"
+        pattern = re.compile(rf"{MARKER_PW_START}.*?{MARKER_PW_END}", re.DOTALL)
+        new_text = pattern.sub(replacement, new_text)
+
+    if new_text != readme_text:
+        if fix:
+            README.write_text(new_text)
+            print("✅ Updated API routes in README.md")
+            return 0
+        else:
+            print("❌ README.md API routes are out of date. Run with --fix.")
+            return 1
+
+    print("✅ API routes in README.md are up to date.")
     return 0
 
 

--- a/src/h4ckath0n/config.py
+++ b/src/h4ckath0n/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 UserVerification = Literal["required", "preferred", "discouraged"]
@@ -24,54 +25,99 @@ class Settings(BaseSettings):
     )
 
     # --- environment ---
-    env: str = "development"
+    env: str = Field(default="development", description="`development` or `production`")
 
     # --- database ---
-    database_url: str = "sqlite:///./h4ckath0n.db"
-    auto_upgrade: bool = False
+    database_url: str = Field(
+        default="sqlite:///./h4ckath0n.db", description="SQLAlchemy connection string"
+    )
+    auto_upgrade: bool = Field(
+        default=False, description="Auto-run packaged DB migrations to head on startup"
+    )
 
     # --- WebAuthn / Passkeys ---
-    rp_id: str = ""
-    origin: str = ""
-    webauthn_ttl_seconds: int = 300
-    user_verification: UserVerification = "preferred"
-    attestation: AttestationConveyance = "none"
+    rp_id: str = Field(
+        default="", description="WebAuthn relying party ID, required in production"
+    )
+    origin: str = Field(
+        default="", description="WebAuthn origin, required in production"
+    )
+    webauthn_ttl_seconds: int = Field(
+        default=300, description="WebAuthn challenge TTL in seconds"
+    )
+    user_verification: UserVerification = Field(
+        default="preferred", description="WebAuthn user verification requirement"
+    )
+    attestation: AttestationConveyance = Field(
+        default="none", description="WebAuthn attestation preference"
+    )
 
     # --- password auth (optional extra) ---
-    password_auth_enabled: bool = False
-    password_reset_expire_minutes: int = 30
+    password_auth_enabled: bool = Field(
+        default=False, description="Enable password routes when the extra is installed"
+    )
+    password_reset_expire_minutes: int = Field(
+        default=30, description="Password reset token expiry in minutes"
+    )
 
     # --- admin bootstrap ---
-    bootstrap_admin_emails: list[str] = []
-    first_user_is_admin: bool = False
+    bootstrap_admin_emails: list[str] = Field(
+        default=[],
+        description="JSON list of emails that become admin on password signup",
+    )
+    first_user_is_admin: bool = Field(
+        default=False, description="First password signup becomes admin"
+    )
 
     # --- LLM ---
-    openai_api_key: str = ""
+    openai_api_key: str = Field(
+        default="", description="OpenAI API key for the LLM wrapper"
+    )
 
     # --- Redis ---
-    redis_url: str = ""
-    jobs_inline_in_dev: bool = True
-    jobs_default_queue: str = "default"
+    redis_url: str = Field(default="", description="Redis connection string")
+    jobs_inline_in_dev: bool = Field(
+        default=True, description="Run background jobs inline in development mode"
+    )
+    jobs_default_queue: str = Field(
+        default="default", description="Default Redis queue for background jobs"
+    )
 
     # --- Storage ---
-    storage_backend: StorageBackend = "local"
-    storage_dir: str = "./.h4ckath0n_storage"
-    max_upload_bytes: int = 50 * 1024 * 1024  # 50 MB
+    storage_backend: StorageBackend = Field(
+        default="local", description="Storage backend"
+    )
+    storage_dir: str = Field(
+        default="./.h4ckath0n_storage", description="Local directory for uploaded files"
+    )
+    max_upload_bytes: int = Field(
+        default=50 * 1024 * 1024, description="Maximum upload size in bytes (50 MiB)"
+    )
 
     # --- Email ---
-    app_base_url: str = "http://localhost:5173"
-    email_backend: EmailBackend = "file"  # "file" or "smtp"
-    email_from: str = "noreply@localhost"
-    email_outbox_dir: str = "./.h4ckath0n_email_outbox"
-    smtp_host: str = ""
-    smtp_port: int = 587
-    smtp_username: str = ""
-    smtp_password: str = ""
-    smtp_starttls: bool = True
-    smtp_ssl: bool = False
+    app_base_url: str = Field(
+        default="http://localhost:5173",
+        description="Application base URL for email links",
+    )
+    email_backend: EmailBackend = Field(
+        default="file", description="Email backend: `file` or `smtp`"
+    )
+    email_from: str = Field(
+        default="noreply@localhost", description="Sender address for outgoing emails"
+    )
+    email_outbox_dir: str = Field(
+        default="./.h4ckath0n_email_outbox",
+        description="File-backend email output directory",
+    )
+    smtp_host: str = Field(default="", description="SMTP server host")
+    smtp_port: int = Field(default=587, description="SMTP server port")
+    smtp_username: str = Field(default="", description="SMTP authentication username")
+    smtp_password: str = Field(default="", description="SMTP authentication password")
+    smtp_starttls: bool = Field(default=True, description="Enable SMTP STARTTLS")
+    smtp_ssl: bool = Field(default=False, description="Enable SMTP-over-SSL")
 
     # --- Demo ---
-    demo_mode: bool = False
+    demo_mode: bool = Field(default=False, description="Enable demo mode")
 
     def effective_rp_id(self) -> str:
         """Return the WebAuthn relying party ID."""


### PR DESCRIPTION
💡 What: Replaced hand-written lists for API routes and environment variables in README.md with dynamically generated markdown blocks, powered by source-of-truth metadata (OpenAPI schema and `Settings` fields).
🎯 Why: These lists rapidly drift as new endpoints or config variables are added. Auto-generation completely eliminates duplicate explanations and outdated route definitions.
🧪 Verification: Run `uv run --locked scripts/check_doc_routes.py --fix` and `uv run --locked scripts/check_doc_env.py --fix` to verify and auto-update lists. Run `uv run pytest -v` to ensure tests pass.
🔒 Drift Prevention: CI runs both scripts without `--fix` flag, failing the build if manual edits drift from the OpenAPI schema or settings loader. Also updated `scripts/check_doc_routes.py` to hard fail if developers introduce uncategorized endpoints.
🗺️ Evidence: `README.md`, `src/h4ckath0n/config.py`, `src/h4ckath0n/app.py`, `scripts/check_doc_routes.py`, `scripts/check_doc_env.py`.

---
*PR created automatically by Jules for task [7436822369927525891](https://jules.google.com/task/7436822369927525891) started by @ToolchainLab*