### PR TITLE
∴ Vector: Centralize scope manipulation logic into pure functional helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-08-09 - Scope string concatenation type mixing
+ **Learning:** When creating scope manipulation helpers in `h4ckath0n.auth.authz`, combining raw iterables of strings with parsed `list[Scope]` without explicitly re-parsing all arguments causes type-mixing which eventually breaks serialization.
+ **Action:** Always parse arguments (e.g. `parse_scopes(existing)` and `parse_scopes(to_add)`) before unpacking them together into a tuple for the final deduplicating `parse_scopes` call.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,20 @@
+1. **Explore `h4ckath0n.auth.authz`**: Look at `src/h4ckath0n/auth/authz.py`. We have `parse_scopes`, `serialize_scopes`, and `missing_scopes`.
+2. **Review `src/h4ckath0n/cli/users.py` and `src/h4ckath0n/auth/dependencies.py`**:
+   - In `cli/users.py`, there is a lot of ad-hoc mutative logic to add, remove, and set scopes:
+     ```python
+     existing = parse_scopes(user.scopes)
+     user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+     ```
+     and
+     ```python
+     existing = parse_scopes(user.scopes)
+     to_remove = set(parse_scopes(args.scope))
+     remaining = [s for s in existing if s not in to_remove]
+     user.scopes = serialize_scopes(remaining)
+     ```
+   - These could be centralized in `authz.py` as pure helper functions, `add_scopes` and `remove_scopes`.
+   - Also note from memory: "Project Context / Scope Handling: When implementing or modifying scope helpers (like `add_scopes`) in `h4ckath0n.auth.authz`, always parse all inputs using `parse_scopes` before combining them... Concatenating raw strings or iterables directly with parsed `Scope` lists before serialization will cause type mixing and functional regressions."
+
+3. **Plan**:
+   - Extract `add_scopes` and `remove_scopes` into `src/h4ckath0n/auth/authz.py`. Both should accept `existing: str | Iterable[str]` and `to_add/to_remove: str | Iterable[str]`. Both should parse the inputs, perform the pure functional transformation, and return a `list[Scope]`. Actually, better if they return the string representation directly (or not, `parse_scopes` returns `list[Scope]`. The CLI does `user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))`). Let's make them return `list[Scope]` for composability or `str`. I will make them return `list[Scope]`. Wait, maybe even better if `add_scopes` and `remove_scopes` just do the list transformation, and CLI still does serialization, or wait, it's better if the helpers return `list[Scope]` so they can be serialized easily.
+   - Wait, `authz.py` is about domain types. `add_scopes(existing, to_add) -> list[Scope]` and `remove_scopes(existing, to_remove) -> list[Scope]`. Let's implement these two helpers.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,22 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(
+    existing: str | Iterable[str], to_add: str | Iterable[str]
+) -> list[Scope]:
+    """Return a new list of scopes combining *existing* and *to_add*.
+
+    Duplicates are removed and order is preserved.
+    """
+    return parse_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(
+    existing: str | Iterable[str], to_remove: str | Iterable[str]
+) -> list[Scope]:
+    """Return a new list of scopes with *to_remove* omitted from *existing*."""
+    existing_parsed = parse_scopes(existing)
+    remove_set = set(parse_scopes(to_remove))
+    return [s for s in existing_parsed if s not in remove_set]

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    remove_scopes,
+    serialize_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +146,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +163,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +57,25 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_add_scopes(self):
+        assert add_scopes("admin,demo", "reports") == [
+            Scope("admin"),
+            Scope("demo"),
+            Scope("reports"),
+        ]
+        assert add_scopes("admin", "admin,demo") == [
+            Scope("admin"),
+            Scope("demo"),
+        ]
+
+    def test_remove_scopes(self):
+        assert remove_scopes("admin,demo,reports", "demo") == [
+            Scope("admin"),
+            Scope("reports"),
+        ]
+        assert remove_scopes("admin", "demo") == [Scope("admin")]
+        assert remove_scopes("admin,demo", "admin,demo") == []
 
     def test_role_constants(self):
         assert USER == "user"


### PR DESCRIPTION
- 💡 What: Extracted `add_scopes` and `remove_scopes` into `h4ckath0n.auth.authz` as pure functional helpers and refactored `h4ckath0n.cli.users` to use them.
- 🎯 Why: Scope manipulation logic was duplicated and lived in CLI command handlers as ad-hoc mutation pipelines. Centralizing it in `authz.py` provides a single source of truth for authorization domain logic.
- 🧠 Design: The new helpers `add_scopes` and `remove_scopes` use the existing `parse_scopes` to safely handle inputs, perform list transformations, and return `list[Scope]`. This leaves CLI handlers only responsible for reading args and updating the DB.
- λ FP Angle: Ad-hoc staging pipelines in `cli/users.py` were replaced with simple composition `serialize_scopes(add_scopes(...))`. The domain logic is now exposed as pure, side-effect-free helpers which are easy to test.
- ✅ Verification: Ran ruff format, ruff check, mypy src, and pytest -v.
- 🧪 Edge cases: Tested idempotency of `add_scopes` (handling duplicates) and `remove_scopes` (handling removing scopes that do or do not exist).
- ⚠️ Risk: Very low. The behavior is exactly identical but easier to test in isolation.

---
*PR created automatically by Jules for task [11959651139353398309](https://jules.google.com/task/11959651139353398309) started by @ToolchainLab*