### PR TITLE
⚡ Bolt: Avoid ORM hydration for ID-only existence and collection queries

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -262,18 +262,19 @@ async def start_add_credential(
     origin = settings.effective_origin()
 
     # Build excludeCredentials from user's existing active credentials
+    # ⚡ Bolt: Fetch only the credential_id to avoid instantiating full ORM objects.
     result = await db.execute(
-        select(WebAuthnCredential).filter(
+        select(WebAuthnCredential.credential_id).filter(
             WebAuthnCredential.user_id == user.id,
             WebAuthnCredential.revoked_at.is_(None),
         )
     )
-    existing = result.scalars().all()
+    existing_ids = result.scalars().all()
     from webauthn.helpers.structs import PublicKeyCredentialDescriptor
 
     exclude = [
-        PublicKeyCredentialDescriptor(id=base64url_to_bytes(c.credential_id))
-        for c in existing
+        PublicKeyCredentialDescriptor(id=base64url_to_bytes(cid))
+        for cid in existing_ids
     ]
 
     challenge_bytes = _new_challenge()

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Fetch only the ID to avoid instantiating the full User ORM object.
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(


### PR DESCRIPTION
💡 What
Updated `register_user` in `src/h4ckath0n/auth/service.py` to query for `User.id` instead of the full `User` object when checking if an email is already registered.
Updated `start_add_credential` in `src/h4ckath0n/auth/passkeys/service.py` to query for `WebAuthnCredential.credential_id` instead of the full `WebAuthnCredential` object.

🎯 Why
Querying for full ORM objects incurs overhead associated with loading the full model instance and identity map hydration, slowing down queries and increasing memory allocation. For checking existence or reading a single attribute (like id or credential_id), using `db.scalar(select(Model.id))` or `db.execute(select(Model.id)).scalars().all()` is significantly faster.

📊 Impact
Improves efficiency by avoiding full ORM object hydration in performance-critical paths (e.g. registration and passkey additions), reducing both execution time and memory footprint during these operations.

🔬 Measurement
Measure execution time and memory allocation using `pytest` or load tests for the registration and add-credential endpoints before and after the change. Memory profiling will show fewer `User` and `WebAuthnCredential` objects instantiated during these queries.

---
*PR created automatically by Jules for task [15781235036858861170](https://jules.google.com/task/15781235036858861170) started by @ToolchainLab*