### PR TITLE
🎨 Palette: Add focus rings to absolute positioned toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Missing Focus Rings on Absolute Positioned Toggles
+**Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+**Action:** Always explicitly add focus ring styling (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`) and appropriate border radius to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-r-xl"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added explicitly styled focus rings and proper border radii to absolute positioned interactive elements (specifically, the password visibility toggle button).
🎯 Why: Absolute positioned interactive elements inside inputs often miss native focus rings or inherit clipped bounds, rendering them invisible during keyboard navigation. This change ensures proper visibility when tabbing to these elements.
📸 Before/After: Before, no focus indication was visible on the toggle button; after, a clear primary ring correctly hugs the element when focused via keyboard.
♿ Accessibility: Fixes a WCAG 2.4.7 (Focus Visible) violation, ensuring keyboard users can discern when the password toggle has focus.

---
*PR created automatically by Jules for task [11336981268927717072](https://jules.google.com/task/11336981268927717072) started by @ToolchainLab*