### PR TITLE
🧭 Atlas: Generate API route docs dynamically from OpenAPI

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-02-28 - Generating markdown docs from OpenAPI
+
+**Learning:** When generating markdown docs from OpenAPI, do not destroy context. Pulling `summary` and `description` from the OpenAPI schema and rendering them into the documentation preserves usability and ensures no regression in "time-to-understanding". Always match the expected markdown format of the repo's original drift check scripts.
+
+**Action:** When replacing hand-written route lists with dynamically generated ones, extract `summary` and `description` from `app.openapi().get("paths")` and format them to match the pre-existing structure (e.g. `- \`METHOD /path\` — summary. description.`).

--- a/README.md
+++ b/README.md
@@ -63,37 +63,39 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- BEGIN API ROUTES -->
+- `GET /` — welcome. Default root route provided by h4ckath0n.
+- `GET /auth/passkeys` — list passkeys. List all passkeys, including revoked entries, for the current user.
+- `GET /auth/session` — current session. Return information about the currently authenticated session.
+- `GET /health` — health. Basic health check for the app.
+- `GET /jobs` — list jobs. List recent jobs for the current user.
+- `GET /jobs/{job_id}` — get job. Get details of a specific job.
+- `GET /uploads` — list uploads. List uploads for the current user.
+- `GET /uploads/{upload_id}` — get upload metadata.
+- `GET /uploads/{upload_id}/download` — download a file. Stream the file back to the owner.
+- `PATCH /auth/passkeys/{key_id}` — rename a passkey. Update the user-facing name of a passkey.
+- `POST /auth/login` — login with password. Verify email and password, then bind an optional device key.
+- `POST /auth/passkey/add/finish` — finish adding a passkey. Verify the WebAuthn attestation and attach the new passkey to the user.
+- `POST /auth/passkey/add/start` — start adding a passkey. Begin adding a new passkey for the authenticated user and return registration options.
+- `POST /auth/passkey/login/finish` — finish passkey login. Finish passkey login by verifying the WebAuthn assertion for the flow and binding an optional device key.
+- `POST /auth/passkey/login/start` — start passkey login. Begin a username-less passkey login ceremony and return WebAuthn authentication options.
+- `POST /auth/passkey/register/finish` — finish passkey registration. Finish passkey registration by verifying the WebAuthn attestation for the flow and binding an optional device key.
+- `POST /auth/passkey/register/start` — start passkey registration. Begin a passkey registration ceremony. Creates a new user and a single-use challenge flow, then returns WebAuthn registration options.
+- `POST /auth/passkeys/{key_id}/revoke` — revoke a passkey. Revoke a passkey by its internal key ID. The last active passkey cannot be revoked and returns the LAST_PASSKEY error.
+- `POST /auth/password-reset/confirm` — confirm password reset. Confirm a password reset token, set a new password, and bind an optional device key.
+- `POST /auth/password-reset/request` — request a password reset. Request a password reset token for the account. Returns the same message even when the email is unknown.
+- `POST /auth/register` — register with password. Create a new account using email and password, then bind an optional device key.
+- `POST /jobs` — enqueue a job. Create a new background job.
+- `POST /llm/chat` — chat completion. Non-streaming chat completion. Requires OpenAI API key.
+- `POST /llm/chat/stream` — streaming chat completion. Stream LLM tokens via SSE. Requires OpenAI API key.
+- `POST /uploads` — upload a file. Upload a file (multipart/form-data).
+<!-- END API ROUTES -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn).
 
 ### Device signed JWTs
 
@@ -146,11 +148,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -11,6 +11,7 @@ README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.js
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -25,7 +26,7 @@ FRAMEWORK_PATHS = frozenset(
 
 
 def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+    """Return (method, path) pairs from the live FastAPI app's OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -36,17 +37,16 @@ def get_app_routes() -> list[tuple[str, str]]:
     app = create_app(settings)
 
     routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    openapi_schema = app.openapi()
+    paths = openapi_schema.get("paths", {})
+    for path, path_item in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method in path_item:
+            method_upper = method.upper()
+            if method_upper == "HEAD":
                 continue
-            routes.append((method, path))
+            routes.append((method_upper, path))
     return sorted(routes)
 
 
@@ -72,7 +72,68 @@ def check_routes_in_readme(
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check or fix API routes documentation in README.md."
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Automatically update the API routes in README.md.",
+    )
+    args = parser.parse_args()
+
     routes = get_app_routes()
+
+    if args.fix:
+        readme_text = README.read_text()
+
+        # Generate the routes table or list
+        from h4ckath0n.app import create_app
+        from h4ckath0n.config import Settings
+
+        app = create_app(
+            Settings(
+                database_url="sqlite+aiosqlite://",
+                password_auth_enabled=True,
+            )
+        )
+        paths = app.openapi().get("paths", {})
+
+        routes_md_lines = []
+        for method, path in routes:
+            method_lower = method.lower()
+            summary = paths.get(path, {}).get(method_lower, {}).get("summary", "")
+            description = (
+                paths.get(path, {}).get(method_lower, {}).get("description", "")
+            )
+
+            line = f"- `{method} {path}`"
+            if summary:
+                line += f" — {summary.lower()}"
+                if not line.endswith("."):
+                    line += "."
+            if description and description.lower() != summary.lower():
+                line += f" {description}"
+            routes_md_lines.append(line)
+
+        routes_md = "\n".join(routes_md_lines)
+
+        # Replace everything between the markers
+        pattern = re.compile(
+            r"(<!-- BEGIN API ROUTES -->).*?(<!-- END API ROUTES -->)", re.DOTALL
+        )
+        if not pattern.search(readme_text):
+            print(
+                "❌ Could not find <!-- BEGIN API ROUTES --> and "
+                "<!-- END API ROUTES --> markers in README.md."
+            )
+            return 1
+
+        new_readme_text = pattern.sub(rf"\g<1>\n{routes_md}\n\g<2>", readme_text)
+        README.write_text(new_readme_text)
+        print("✅ Fixed API routes in README.md.")
+        return 0
+
     missing = check_routes_in_readme(routes)
 
     if missing:
@@ -81,7 +142,8 @@ def main() -> int:
             print(f"  {method:6s} {path}")
         print(
             "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
+            "add them to FRAMEWORK_PATHS in this script.\n"
+            "Alternatively, run this script with --fix to automatically update README.md."
         )
         return 1
 


### PR DESCRIPTION
💡 What: Replaced hand-written endpoint lists in README.md with dynamically generated routes using `<!-- BEGIN API ROUTES -->` markers, pulling summaries and descriptions from the OpenAPI schema.
🎯 Why: Fixes false-positives and false-negatives due to nested routes missing paths in FastAPI internal representations, and eliminates risk of API docs drift.
🧪 Verification: Run `uv run scripts/check_doc_routes.py --fix` and `uv run scripts/check_doc_routes.py`.
🔒 Drift Prevention: Added `--fix` argument to `check_doc_routes.py` to auto-generate endpoint lists directly from the authoritative OpenAPI schema.
🗺️ Evidence: `h4ckath0n/app.py` OpenAPI schema and `README.md`.

---
*PR created automatically by Jules for task [17476082980945017714](https://jules.google.com/task/17476082980945017714) started by @ToolchainLab*