### PR TITLE
∴ Vector: Centralize scope mutations with pure functional helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2025-02-17 - Centralize scope mutations with pure functional helpers
+**Learning:** In `h4ckath0n.auth.authz`, when adding or removing scopes, multiple places were re-implementing parsing, concatenating, set filtering, and serializing. Additionally, manual concatenations bypassing `parse_scopes` on collections may cause bugs.
+**Action:** Use functional pure helpers like `add_scopes` and `remove_scopes` directly, rather than inline mutations across call sites.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,19 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(
+    existing: str | Iterable[str], to_add: str | Iterable[str]
+) -> list[Scope]:
+    """Return a new list of scopes combining the existing scopes and the ones to add."""
+    return parse_scopes((*parse_scopes(existing), *parse_scopes(to_add)))
+
+
+def remove_scopes(
+    existing: str | Iterable[str], to_remove: str | Iterable[str]
+) -> list[Scope]:
+    """Return a new list of scopes removing the scopes to drop from the existing ones."""
+    current = parse_scopes(existing)
+    drop = set(parse_scopes(to_remove))
+    return [s for s in current if s not in drop]

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    remove_scopes,
+    serialize_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +146,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +163,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +57,21 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_add_scopes_combines_and_deduplicates(self):
+        assert add_scopes("admin", "demo,admin") == [Scope("admin"), Scope("demo")]
+        assert add_scopes(["admin"], ["demo", "reports"]) == [
+            Scope("admin"),
+            Scope("demo"),
+            Scope("reports"),
+        ]
+
+    def test_remove_scopes_filters_out_unwanted(self):
+        assert remove_scopes("admin,demo,reports", "demo") == [
+            Scope("admin"),
+            Scope("reports"),
+        ]
+        assert remove_scopes(["admin", "demo"], ["demo", "reports"]) == [Scope("admin")]
 
     def test_role_constants(self):
         assert USER == "user"


### PR DESCRIPTION
💡 What: Extracted `add_scopes` and `remove_scopes` pure functions to `h4ckath0n.auth.authz`, moving scope manipulation logic out of `h4ckath0n.cli.users`.
🎯 Why: Scope mutations (parsing, iterating, deduping) were ad-hoc in the CLI code. Centralizing them reduces duplicated normalization logic.
🧠 Design: Used functional FP style, composing `parse_scopes` rather than writing inline staging logic to parse, set-compare, list-comprehend, and serialize.
λ FP Angle: Transforms mutable, procedural staging inside CLI handlers into clean, composable data-in/data-out functions with strong guarantees.
✅ Verification: Visual verification, Ruff, Mypy, and Pytest.
🧪 Edge cases: Tested deduplication when adding duplicate scopes, and removing missing/overlapping scopes.
⚠️ Risk: Low, simple pure transformation logic replacements.

---
*PR created automatically by Jules for task [10023294484138571094](https://jules.google.com/task/10023294484138571094) started by @ToolchainLab*