### PR TITLE
⚡ Bolt: Avoid ORM hydration when checking user existence

### DIFF
--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,9 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Avoid ORM hydration when only checking for existence
+    existing_id = await db.scalar(select(User.id).filter(User.email == email))
+    if existing_id is not None:
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(


### PR DESCRIPTION
💡 What: Changed the user existence check in `register_user` to select only the `User.id` instead of fetching the entire ORM `User` model.
🎯 Why: When checking if an email is already registered, fetching the entire ORM model triggers parsing, allocation, and hydration of the model, which includes all fields. This incurs unnecessary memory allocation and database bandwidth overhead since we only need to know if a record exists.
📊 Impact: Reduces memory overhead and database transfer size during user registration by avoiding ORM hydration.
🔬 Measurement: Can be verified by profiling the memory allocations during consecutive user registration attempts.

---
*PR created automatically by Jules for task [4006745388956859248](https://jules.google.com/task/4006745388956859248) started by @ToolchainLab*