### PR TITLE
🎨 Palette: Add focus ring to password visibility toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Added focus ring to password toggle button
+ **Learning:** Absolute positioned interactive elements inside inputs (such as password visibility toggles) often miss native focus rings or inherit clipped bounds.
+ **Action:** Always explicitly add focus ring styling (e.g., focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary) and appropriate border radius to these elements to ensure they are visible during keyboard navigation.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-xl text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added explicit focus ring styling (`focus-visible:ring-2 focus-visible:ring-primary`) and border radius (`rounded-xl`) to the password visibility toggle button in `PasswordField.tsx`.
🎯 Why: Absolute positioned interactive elements inside inputs often miss native focus rings or inherit clipped bounds. This ensures the toggle is clearly visible during keyboard navigation.
📸 Before/After: N/A (Visual focus state change)
♿ Accessibility: Improved keyboard accessibility by ensuring the interactive password visibility toggle has a clear and visible focus indicator.

---
*PR created automatically by Jules for task [1694722438328966393](https://jules.google.com/task/1694722438328966393) started by @ToolchainLab*