### PR TITLE
🗺️ Atlas: Auto-generate API routes in README from OpenAPI schema

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2024-08-10 - Replace hand-written API docs with OpenAPI generation
+**Learning:** Hand-written API route documentation inevitably drifts. Simple substring checks or basic regexes often fail due to missing routes or changes in summaries. The most reliable verification technique is to parse the authoritative OpenAPI schema, use structural markdown markers (e.g., `<!-- BEGIN API ROUTES -->`), and inject the generated section directly.
+**Action:** Replace manual API lists with consolidated, dynamically generated sections from OpenAPI and update drift-check scripts to include a `--fix` flag for automatic alignment.

--- a/README.md
+++ b/README.md
@@ -63,26 +63,33 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- BEGIN API ROUTES -->
+- `GET /` — Welcome
+- `POST /auth/login` — Login with password
+- `POST /auth/passkey/add/finish` — Finish adding a passkey
+- `POST /auth/passkey/add/start` — Start adding a passkey
+- `POST /auth/passkey/login/finish` — Finish passkey login
+- `POST /auth/passkey/login/start` — Start passkey login
+- `POST /auth/passkey/register/finish` — Finish passkey registration
+- `POST /auth/passkey/register/start` — Start passkey registration
+- `GET /auth/passkeys` — List passkeys
+- `PATCH /auth/passkeys/{key_id}` — Rename a passkey
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey
+- `POST /auth/password-reset/confirm` — Confirm password reset
+- `POST /auth/password-reset/request` — Request a password reset
+- `POST /auth/register` — Register with password
+- `GET /auth/session` — Current session
+- `GET /health` — Health
+- `GET /jobs` — List jobs
+- `POST /jobs` — Enqueue a job
+- `GET /jobs/{job_id}` — Get job
+- `POST /llm/chat` — Chat completion
+- `POST /llm/chat/stream` — Streaming chat completion
+- `GET /uploads` — List uploads
+- `POST /uploads` — Upload a file
+- `GET /uploads/{upload_id}` — Get upload metadata
+- `GET /uploads/{upload_id}/download` — Download a file
+<!-- END API ROUTES -->
 
 ## Auth model
 

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -2,16 +2,15 @@
 """Drift-prevention check: verify that every API route in the FastAPI app is documented.
 
 Usage (from repo root):
-    uv run scripts/check_doc_routes.py
+    uv run scripts/check_doc_routes.py [--fix]
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, generates the OpenAPI schema, and checks that
+README.md contains the exact API routes section. Use --fix to rewrite README.md.
 """
 
 from __future__ import annotations
 
-import re
+import argparse
 import sys
 from pathlib import Path
 
@@ -24,8 +23,8 @@ FRAMEWORK_PATHS = frozenset(
 )
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_app_routes() -> list[tuple[str, str, str]]:
+    """Return (method, path, summary) from the live FastAPI app's OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -35,58 +34,70 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    paths = app.openapi().get("paths", {})
+    routes: list[tuple[str, str, str]] = []
+
+    for path, ops in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method, op in ops.items():
+            method_upper = method.upper()
+            if method_upper == "HEAD":
                 continue
-            routes.append((method, path))
-    return sorted(routes)
+            summary = op.get("summary", "")
+            routes.append((method_upper, path, summary))
+
+    # Sort by path first, then method
+    return sorted(routes, key=lambda x: (x[1], x[0]))
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
-
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+def generate_routes_markdown(routes: list[tuple[str, str, str]]) -> str:
+    lines = []
+    for method, path, summary in routes:
+        desc = f" — {summary}" if summary else ""
+        lines.append(f"- `{method} {path}`{desc}")
+    return "\n".join(lines) + "\n"
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    parser = argparse.ArgumentParser(description="Check or fix API routes in README.md")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Fix README.md by updating the API routes section",
+    )
+    args = parser.parse_args()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    routes = get_app_routes()
+    routes_md = generate_routes_markdown(routes)
+
+    readme_text = README.read_text()
+
+    start_marker = "<!-- BEGIN API ROUTES -->\n"
+    end_marker = "<!-- END API ROUTES -->\n"
+
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print("❌ Structural markers not found in README.md")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+    start_idx = readme_text.find(start_marker) + len(start_marker)
+    end_idx = readme_text.find(end_marker)
+
+    current_section = readme_text[start_idx:end_idx]
+
+    if current_section == routes_md:
+        print(f"✅ All {len(routes)} API routes are correctly documented in README.md.")
+        return 0
+
+    if args.fix:
+        new_readme_text = readme_text[:start_idx] + routes_md + readme_text[end_idx:]
+        README.write_text(new_readme_text)
+        print(f"✅ Updated README.md with {len(routes)} API routes.")
+        return 0
+    else:
+        print("❌ API routes in README.md are out of date or incorrectly formatted.")
+        print("Run `uv run scripts/check_doc_routes.py --fix` to update it.")
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Replaced manually maintained API route documentation in README.md with an auto-generated section derived from the OpenAPI schema and updated `check_doc_routes.py` to ensure exact parity using structural markers.
🎯 Why: Hand-written documentation inevitably drifts. It was missing some API routes and summaries, and substring checks were prone to false positives/negatives.
🔭 Verification: Locally tested using `uv run scripts/check_doc_routes.py --fix` to populate `README.md` and verify exact match.
🔒 Drift Prevention: Updated `scripts/check_doc_routes.py` logic to parse the OpenAPI schema, strictly check bounded markers `<!-- BEGIN API ROUTES -->`, and explicitly enforce exact synchronization in CI.
🖼️ Evidence: `README.md`, `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [17442213115835089112](https://jules.google.com/task/17442213115835089112) started by @ToolchainLab*