### PR TITLE
∴ Vector: Centralize scope transformation logic

### DIFF
--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,15 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(current: str | Iterable[str], to_add: str | Iterable[str]) -> str:
+    """Add new scopes to an existing set of scopes, returning a serialized string."""
+    return serialize_scopes([*parse_scopes(current), *parse_scopes(to_add)])
+
+
+def remove_scopes(current: str | Iterable[str], to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from an existing set of scopes, returning a serialized string."""
+    existing = parse_scopes(current)
+    removing = set(parse_scopes(to_remove))
+    return serialize_scopes(s for s in existing if s not in removing)

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    remove_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +145,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +162,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -60,6 +60,18 @@ class TestScopes:
         assert USER == "user"
         assert ADMIN == "admin"
 
+    def test_add_scopes(self):
+        from h4ckath0n.auth.authz import add_scopes
+
+        assert add_scopes("admin", "demo") == "admin,demo"
+        assert add_scopes("admin,demo", "reports,demo") == "admin,demo,reports"
+
+    def test_remove_scopes(self):
+        from h4ckath0n.auth.authz import remove_scopes
+
+        assert remove_scopes("admin,demo,reports", "demo,admin") == "reports"
+        assert remove_scopes("admin,demo", "reports") == "admin,demo"
+
 
 class TestPasskeyErrors:
     def test_hierarchy_subclasses_value_error(self):


### PR DESCRIPTION
💡 What: Extracted `add_scopes` and `remove_scopes` helpers into `h4ckath0n.auth.authz` and refactored the CLI to use them instead of inline parsing/reserializing.
🎯 Why: Replaces repeated, mutation-heavy inline logic (parsing strings, doing list operations, reserializing) with a single source of truth for scope transformations.
🧠 Design: The functions act as pure functional wrappers around existing parsing/serialization primitives, returning the final computed string, making caller logic much cleaner.
λ FP Angle: Transforms scattered imperative staging logic into clean data-in/data-out transformation pipelines.
✅ Verification: Checked with `uv run --locked pytest -v`, `mypy src`, and `ruff`. Added explicit unit tests for both helpers.
🧪 Edge cases: Tested idempotence when adding existing scopes, and removal of non-existent scopes.
⚠️ Risk: Low; behavior is identical, just centralized.

---
*PR created automatically by Jules for task [10260813094376759685](https://jules.google.com/task/10260813094376759685) started by @ToolchainLab*