### PR TITLE
🎨 Palette: Add character count indicator to bounded inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Adding character counts to limited inputs
+**Learning:** Users often lack context on form input length restrictions until they hit arbitrary limits or trigger validation errors. Adding a subtle, accessible inline character counter directly driven by the `maxLength` attribute leverages existing validation constraints for immediate UX feedback.
+**Action:** Whenever introducing a `maxLength` property to a text input component, automatically expose a visual counter (and `aria-live="polite"` region) so screen reader and sighted users get real-time feedback on length limits.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Input.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Input.tsx
@@ -15,7 +15,19 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     return (
       <div className="space-y-2">
-        {label && <Label htmlFor={inputId}>{label}</Label>}
+        {(label || (props.maxLength && typeof props.value === "string")) && (
+          <div className="flex items-center justify-between">
+            {label && <Label htmlFor={inputId}>{label}</Label>}
+            {props.maxLength && typeof props.value === "string" && (
+              <span
+                className="text-xs text-text-muted"
+                aria-live="polite"
+              >
+                {props.value.length} / {props.maxLength}
+              </span>
+            )}
+          </div>
+        )}
         <input
           id={inputId}
           type={type}


### PR DESCRIPTION
💡 What: Added an automatic, inline character count indicator to the `Input` component that displays when a `maxLength` prop is present and the value is a string.
🎯 Why: To prevent user frustration by providing immediate, real-time feedback on character limits before they hit the boundary or trigger a validation error (e.g. for display names).
📸 Before/After: Before, hitting the limit silently blocked typing. After, a subtle text counter (e.g. "15 / 200") appears opposite the label.
♿ Accessibility: Included `aria-live="polite"` on the counter so screen readers are gently notified of the character count updates as users approach the limit.

---
*PR created automatically by Jules for task [345519119852848425](https://jules.google.com/task/345519119852848425) started by @ToolchainLab*