### PR TITLE
🧭 Atlas: Replace hand-written API routes in README with auto-generated table

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,26 +63,37 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
+<!-- BEGIN API ROUTES -->
 
-### Session
-- `GET /auth/session` — returns the current user session details.
+| Method | Path | Summary |
+|---|---|---|
+| `POST` | `/auth/passkey/register/start` | Start passkey registration |
+| `POST` | `/auth/passkey/register/finish` | Finish passkey registration |
+| `POST` | `/auth/passkey/login/start` | Start passkey login |
+| `POST` | `/auth/passkey/login/finish` | Finish passkey login |
+| `POST` | `/auth/passkey/add/start` | Start adding a passkey |
+| `POST` | `/auth/passkey/add/finish` | Finish adding a passkey |
+| `GET` | `/auth/passkeys` | List passkeys |
+| `POST` | `/auth/passkeys/{key_id}/revoke` | Revoke a passkey |
+| `PATCH` | `/auth/passkeys/{key_id}` | Rename a passkey |
+| `GET` | `/auth/session` | Current session |
+| `GET` | `/jobs` | List jobs |
+| `POST` | `/jobs` | Enqueue a job |
+| `GET` | `/jobs/{job_id}` | Get job |
+| `GET` | `/uploads` | List uploads |
+| `POST` | `/uploads` | Upload a file |
+| `GET` | `/uploads/{upload_id}` | Get upload metadata |
+| `GET` | `/uploads/{upload_id}/download` | Download a file |
+| `POST` | `/llm/chat` | Chat completion |
+| `POST` | `/llm/chat/stream` | Streaming chat completion |
+| `POST` | `/auth/register` | Register with password |
+| `POST` | `/auth/login` | Login with password |
+| `POST` | `/auth/password-reset/request` | Request a password reset |
+| `POST` | `/auth/password-reset/confirm` | Confirm password reset |
+| `GET` | `/` | Welcome |
+| `GET` | `/health` | Health |
 
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- END API ROUTES -->
 
 ## Auth model
 
@@ -90,8 +101,8 @@ uv run uvicorn your_module:app --reload
 
 The default authentication path uses passkeys (WebAuthn). The core flows are:
 
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
+1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish` for registration
+2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish` for authentication
 3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
 4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
 
@@ -146,11 +157,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -11,6 +11,7 @@ README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.js
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -24,8 +25,8 @@ FRAMEWORK_PATHS = frozenset(
 )
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_app_routes_from_openapi() -> list[tuple[str, str, str]]:
+    """Return (method, path, summary) from the live FastAPI app's OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -34,55 +35,85 @@ def get_app_routes() -> list[tuple[str, str]]:
         password_auth_enabled=True,
     )
     app = create_app(settings)
+    openapi = app.openapi()
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    routes: list[tuple[str, str, str]] = []
+    for path, methods in openapi.get("paths", {}).items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+        for method, op in methods.items():
+            summary = op.get("summary", "")
+            routes.append((method.upper(), path, summary))
+    return routes
 
 
 def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
-
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
+    routes: list[tuple[str, str, str]],
+) -> bool:
+    """Check if the API routes table in README matches the generated table."""
     readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    expected_block = generate_routes_block(routes)
+
+    pattern = r"(<!-- BEGIN API ROUTES -->).*?(<!-- END API ROUTES -->)"
+    match = re.search(pattern, readme_text, flags=re.DOTALL)
+    if not match:
+        print("❌ Could not find <!-- BEGIN API ROUTES --> markers in README.md")
+        return False
+
+    actual_block = match.group(0)
+    return actual_block.strip() == expected_block.strip()
+
+
+def generate_routes_block(routes: list[tuple[str, str, str]]) -> str:
+    """Generate the markdown block for routes."""
+    lines = [
+        "<!-- BEGIN API ROUTES -->",
+        "",
+        "| Method | Path | Summary |",
+        "|---|---|---|",
+    ]
+    for method, path, summary in routes:
+        lines.append(f"| `{method}` | `{path}` | {summary} |")
+    lines.extend(["", "<!-- END API ROUTES -->"])
+    return "\n".join(lines)
+
+
+def fix_readme(routes: list[tuple[str, str, str]]) -> None:
+    """Rewrite the README to insert the correct routes block."""
+    readme_text = README.read_text()
+    expected_block = generate_routes_block(routes)
+
+    pattern = r"(<!-- BEGIN API ROUTES -->).*?(<!-- END API ROUTES -->)"
+    new_readme, count = re.subn(pattern, expected_block, readme_text, flags=re.DOTALL)
+
+    if count == 0:
+        print(
+            "❌ Could not find <!-- BEGIN API ROUTES --> markers in README.md to replace."
+        )
+        sys.exit(1)
+
+    README.write_text(new_readme)
+    print(f"✅ Updated README.md with {len(routes)} API routes.")
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    parser = argparse.ArgumentParser(
+        description="Check or fix API route documentation."
+    )
+    parser.add_argument(
+        "--fix", action="store_true", help="Update README.md with the latest routes."
+    )
+    args = parser.parse_args()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    routes = get_app_routes_from_openapi()
+
+    if args.fix:
+        fix_readme(routes)
+        return 0
+
+    if not check_routes_in_readme(routes):
+        print("❌ The API routes table in README.md is out of date.\n")
+        print("Run `uv run scripts/check_doc_routes.py --fix` to update it.")
         return 1
 
     print(f"✅ All {len(routes)} API routes are documented in README.md.")


### PR DESCRIPTION
💡 What: Replaced manually curated API routes in README.md with a generated markdown table injected between structural markers, powered by the OpenAPI schema. Updated the `check_doc_routes.py` script to enforce exactly this format and added a `--fix` flag to automatically populate it.
🎯 Why: API documentation for routes frequently drifts from the real implementation. Checking for substring mentions isn't enough, and manually writing out all routes is tedious and error-prone. This guarantees 100% parity with the app's real OpenAPI schema and provides an easy way for contributors to update the docs.
🧪 Verification: Run `uv run scripts/check_doc_routes.py --fix` to update, and `uv run scripts/check_doc_routes.py` to check for parity.
🔒 Drift Prevention: The `scripts/check_doc_routes.py` now parses the live FastAPI OpenAPI schema and enforces that the markdown table precisely matches the generated routes.
🗺️ Evidence: `README.md`, `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [9081724155552020861](https://jules.google.com/task/9081724155552020861) started by @ToolchainLab*