### PR TITLE
∷ Vector: Extract pure helpers for adding/removing scopes

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-08-12 - Centralized functional transformation helpers for user scopes
+**Learning:** When dealing with parsed domains, prefer having functional `add_x` and `remove_x` transformation helpers centralized in the domain object representation rather than repeatedly relying on users to unpack, mutate via sets, and pack back to a string in their application boundaries.
+**Action:** Added `add_scopes` and `remove_scopes` pure functions to `h4ckath0n.auth.authz`.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,15 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(existing: str | Iterable[str], new: str | Iterable[str]) -> str:
+    """Add new scopes to the existing scopes, preserving order and removing duplicates."""
+    return serialize_scopes(parse_scopes(existing) + parse_scopes(new))
+
+
+def remove_scopes(existing: str | Iterable[str], to_remove: str | Iterable[str]) -> str:
+    """Remove scopes from the existing scopes."""
+    parsed_existing = parse_scopes(existing)
+    parsed_to_remove = set(parse_scopes(to_remove))
+    return serialize_scopes(s for s in parsed_existing if s not in parsed_to_remove)

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    remove_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +145,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +162,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -59,6 +61,18 @@ class TestScopes:
     def test_role_constants(self):
         assert USER == "user"
         assert ADMIN == "admin"
+
+    def test_add_scopes(self):
+        assert add_scopes("admin", "demo") == "admin,demo"
+        assert add_scopes("admin,demo", "reports,demo") == "admin,demo,reports"
+        assert add_scopes(["admin"], ["demo"]) == "admin,demo"
+        assert add_scopes("admin", "") == "admin"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("admin,demo", "demo") == "admin"
+        assert remove_scopes("admin,demo,reports", "demo,reports") == "admin"
+        assert remove_scopes(["admin", "demo"], ["demo"]) == "admin"
+        assert remove_scopes("admin", "demo") == "admin"
 
 
 class TestPasskeyErrors:


### PR DESCRIPTION
💡 What: Extracted `add_scopes` and `remove_scopes` into the `h4ckath0n.auth.authz` module and refactored CLI commands to use these instead of inline state parsing and manual transformation.
🎯 Why: To centralize scope modification semantics and avoid error-prone manual transformations (unpacking strings, manipulating lists/sets, serializing) in business and cli logic.
🧠 Design: Added pure functions that accept `str | Iterable[str]` and return a formatted string, relying on the robust `parse_scopes` already present for correctness. 
λ FP Angle: Centralises the transformation pipeline. Instead of modifying local data structures with sets, calling pipelines like `add_scopes` encapsulates the pure manipulation rules.
✅ Verification: Run `pytest -v` tests which confirm robust handling. Formatted with `ruff`.
🧪 Edge cases: Both empty modifications and iterables over strings are covered correctly through the underlying `parse_scopes`.
⚠️ Risk: Extremely low. The existing manual functionality simply migrated behind a helper boundary.

---
*PR created automatically by Jules for task [13164583136885332159](https://jules.google.com/task/13164583136885332159) started by @ToolchainLab*