### PR TITLE
⚡ Bolt: Optimize database existence checks by avoiding full ORM hydration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 **Learning:** When retrieving objects by primary key, using `db.execute(select(Model).filter(Model.id == pk)).scalars().first()` bypasses the SQLAlchemy identity map and always triggers a database query, in addition to carrying the overhead of parsing and hydration. Since this is often used in high-frequency hot paths (like device JWT authentication), it becomes a measurable performance bottleneck.
 
 **Action:** Always use `await db.get(Model, pk)` when looking up a single record by its primary key. This checks the current session's identity map first, avoiding a roundtrip to the database and bypassing parsing overhead if the object is already loaded.
+## 2026-03-18 - Avoid ORM Hydration for Existence Checks
+**Learning:** When checking for existence (e.g., verifying an email is not already registered) or fetching an ID, using `db.execute(select(Model)).scalars().first()` forces SQLAlchemy to parse and hydrate the entire model instance. This incurs unnecessary memory allocation and database bandwidth overhead, especially if the model has large fields (like scopes, text blobs, or JSON).
+**Action:** Use `await db.scalar(select(Model.id).filter(...))` to fetch only the identifier. This is faster, consumes less memory, and clearly communicates intent (that only existence/ID is needed).

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,8 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
-    if result.scalars().first():
+    # ⚡ Bolt: Fetch only the ID to avoid full ORM model hydration when checking existence.
+    if await db.scalar(select(User.id).filter(User.email == email)):
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"
     user = User(


### PR DESCRIPTION
💡 What: Replaced `result = await db.execute(select(User)...); if result.scalars().first():` with a direct `await db.scalar(select(User.id)...)` in the user registration flow.
🎯 Why: When checking if a record exists (like an email during registration), querying the entire model object forces SQLAlchemy to allocate memory and hydrate the full instance (including potentially large text/JSON fields). Querying just the primary key ID avoids this overhead.
📊 Impact: Reduces memory allocation and database bandwidth during new user registrations by avoiding full model hydration for the existence check.
🔬 Measurement: Verified that duplicate email registrations are still correctly rejected with `ValueError` and tests pass, while the trace confirms fewer object instantiations.

---
*PR created automatically by Jules for task [13054539646478869261](https://jules.google.com/task/13054539646478869261) started by @ToolchainLab*