### PR TITLE
🎨 Palette: Make passkey edit button visible on keyboard focus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-15 - Missing focus visibility on hover-only revealed elements
+**Learning:** The "edit passkey" button in the Settings page used `opacity-0 group-hover:opacity-100` to hide it until hovered. This pattern makes it invisible during keyboard navigation.
+**Action:** Always pair `opacity-0 group-hover:opacity-100` with `focus-visible:opacity-100` on interactive elements to ensure they become visible when receiving keyboard focus.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -149,7 +149,7 @@ function PasskeyName({
           variant="ghost"
           data-testid="passkey-edit-btn"
           onClick={startEdit}
-          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />


### PR DESCRIPTION
💡 What: Added `focus-visible:opacity-100` to the passkey edit button on the Settings page.
🎯 Why: The edit button was using `opacity-0 group-hover:opacity-100`, which made it completely invisible during keyboard navigation. This change ensures keyboard users can see the button when it receives focus.
📸 Before/After: N/A (Visual change on keyboard focus)
♿ Accessibility: Enhances keyboard accessibility by providing visual feedback when the hidden edit button is focused via tab navigation.

---
*PR created automatically by Jules for task [11613517656854584778](https://jules.google.com/task/11613517656854584778) started by @ToolchainLab*