### PR TITLE
∷ Vector: Extract pure functional scope transformation helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-08-13 - Scope Transformation Refactoring
+**Learning:** When modifying data structures like user scopes, prefer calling centralized pure functional transformations (e.g., `add_scopes` and `remove_scopes` from `h4ckath0n.auth.authz`) rather than performing inline multi-step state mutations within command handlers or domain logic.
+**Action:** In the future, centralize domain model transformations into pure functional helpers before applying side effects like serialization or database commits.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,19 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(
+    current: str | Iterable[str], to_add: str | Iterable[str]
+) -> list[Scope]:
+    """Return a new list of scopes with *to_add* appended to *current*."""
+    return parse_scopes([*parse_scopes(current), *parse_scopes(to_add)])
+
+
+def remove_scopes(
+    current: str | Iterable[str], to_remove: str | Iterable[str]
+) -> list[Scope]:
+    """Return a new list of scopes with *to_remove* excluded from *current*."""
+    existing = parse_scopes(current)
+    removing = set(parse_scopes(to_remove))
+    return [s for s in existing if s not in removing]

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    remove_scopes,
+    serialize_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +146,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +163,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -59,6 +61,19 @@ class TestScopes:
     def test_role_constants(self):
         assert USER == "user"
         assert ADMIN == "admin"
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", "c,d") == [
+            Scope("a"),
+            Scope("b"),
+            Scope("c"),
+            Scope("d"),
+        ]
+        assert add_scopes(["a", "b"], "c,a") == [Scope("a"), Scope("b"), Scope("c")]
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c", "b,c") == [Scope("a")]
+        assert remove_scopes(["a", "b", "c"], ["a", "d"]) == [Scope("b"), Scope("c")]
 
 
 class TestPasskeyErrors:


### PR DESCRIPTION
💡 What: Extracted `add_scopes` and `remove_scopes` as centralized pure functions in `h4ckath0n.auth.authz`, replacing inline set comprehensions and list concatenations in CLI command handlers. Added comprehensive unit tests for the edge cases.
🎯 Why: Avoids duplicate parsing and serializing boilerplate scattered across command handlers. Centralizes the logic into testable helpers.
🧠 Design: Reused existing `parse_scopes` behavior safely inside `add_scopes` and `remove_scopes` functions, accepting strings or iterables transparently without touching core representations.
λ FP Angle: Replaced complex, multi-step inline state mutations with composable, deterministic, pure functional transformations.
✅ Verification: Ran `ruff check`, `ruff format`, `mypy src` and `pytest -v`.
🧪 Edge cases: Added unit tests ensuring the new transformations correctly preserve input orders, deduplicate cleanly, and properly filter missing scopes.
⚠️ Risk: Low risk, relies directly on existing parsing behaviors.

---
*PR created automatically by Jules for task [4508437394378099035](https://jules.google.com/task/4508437394378099035) started by @ToolchainLab*