### PR TITLE
⚡ Bolt: Avoid ORM hydration for existence checks and field fetches

### DIFF
--- a/src/h4ckath0n/auth/passkeys/service.py
+++ b/src/h4ckath0n/auth/passkeys/service.py
@@ -262,18 +262,20 @@ async def start_add_credential(
     origin = settings.effective_origin()
 
     # Build excludeCredentials from user's existing active credentials
+    # ⚡ Bolt: Fetch only the credential_id to avoid instantiating
+    # the full WebAuthnCredential ORM objects.
     result = await db.execute(
-        select(WebAuthnCredential).filter(
+        select(WebAuthnCredential.credential_id).filter(
             WebAuthnCredential.user_id == user.id,
             WebAuthnCredential.revoked_at.is_(None),
         )
     )
-    existing = result.scalars().all()
+    existing_ids = result.scalars().all()
     from webauthn.helpers.structs import PublicKeyCredentialDescriptor
 
     exclude = [
-        PublicKeyCredentialDescriptor(id=base64url_to_bytes(c.credential_id))
-        for c in existing
+        PublicKeyCredentialDescriptor(id=base64url_to_bytes(cred_id))
+        for cred_id in existing_ids
     ]
 
     challenge_bytes = _new_challenge()

--- a/src/h4ckath0n/auth/service.py
+++ b/src/h4ckath0n/auth/service.py
@@ -57,7 +57,8 @@ async def register_user(
     display_name: str | None = None,
 ) -> User:
     hash_password, _verify = _require_password_extra()
-    result = await db.execute(select(User).filter(User.email == email))
+    # ⚡ Bolt: Fetch only the ID to avoid instantiating the full User ORM object.
+    result = await db.execute(select(User.id).filter(User.email == email))
     if result.scalars().first():
         raise ValueError("Email already registered")
     role = "admin" if await _is_bootstrap_admin(email, settings, db) else "user"


### PR DESCRIPTION
💡 What: Replaced full ORM object fetches with single-column queries (`User.id` and `WebAuthnCredential.credential_id`) in `register_user` and `start_add_credential`.
🎯 Why: When only checking for existence or needing a single field, retrieving the full model forces SQLAlchemy to parse and hydrate the entire instance, which carries unnecessary overhead. This optimizes performance in these paths.
📊 Impact: Reduces memory allocation and DB bandwidth during user registration and when starting the add-credential passkey flow by avoiding full ORM instance hydration.
🔬 Measurement: Review memory usage and execution time of the `/auth/register` and `/auth/passkeys/register/start` endpoints. Ensure the tests continue to pass via `uv run pytest`.

---
*PR created automatically by Jules for task [11446189912886266693](https://jules.google.com/task/11446189912886266693) started by @ToolchainLab*