### PR TITLE
🎨 Palette: Add focus visible styles to password toggle

### DIFF
--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/PasswordField.tsx
@@ -91,7 +91,7 @@ const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
             onClick={handleToggle}
             onPointerDown={handlePointerDown}
             onMouseDown={handlePointerDown}
-            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors disabled:pointer-events-none disabled:opacity-50"
+            className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-text-muted hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-xl disabled:pointer-events-none disabled:opacity-50"
             disabled={props.disabled}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added `focus-visible` ring styles to the show/hide password toggle button in `PasswordField`.
🎯 Why: The toggle button previously had no visual focus indicator, making it inaccessible for keyboard users navigating the form.
📸 Before/After: The button now matches the focus ring style of other interactive components.
♿ Accessibility: Improves keyboard navigation support by ensuring focus state is clearly visible.

---
*PR created automatically by Jules for task [13731093500520981748](https://jules.google.com/task/13731093500520981748) started by @ToolchainLab*