### PR TITLE
🧭 Atlas: Generate API routes from OpenAPI to prevent drift

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,7 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-05 - FastAPI routing tree introspection misses nested endpoints
+**Learning:** In newer FastAPI versions (v0.115+), nested routers are wrapped internally as `_IncludedRouter` objects which hide their `.path` and `.methods` properties, breaking simple `app.routes` iteration when verifying endpoints.
+**Action:** When writing scripts to check endpoint drift or generate documentation, always parse the generated OpenAPI schema (`app.openapi().get('paths', {})`) instead of walking the routing tree manually.

--- a/README.md
+++ b/README.md
@@ -61,39 +61,41 @@ uv run uvicorn your_module:app --reload
 - Protected routes require an `Authorization: Bearer <device_jwt>` header that the web
   template can mint after login.
 
-## Built-in routes
+## API routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- BEGIN API ROUTES -->
+- `GET /` — Welcome
+- `POST /auth/login` — Login with password
+- `POST /auth/passkey/add/finish` — Finish adding a passkey
+- `POST /auth/passkey/add/start` — Start adding a passkey
+- `POST /auth/passkey/login/finish` — Finish passkey login
+- `POST /auth/passkey/login/start` — Start passkey login
+- `POST /auth/passkey/register/finish` — Finish passkey registration
+- `POST /auth/passkey/register/start` — Start passkey registration
+- `GET /auth/passkeys` — List passkeys
+- `PATCH /auth/passkeys/{key_id}` — Rename a passkey
+- `POST /auth/passkeys/{key_id}/revoke` — Revoke a passkey
+- `POST /auth/password-reset/confirm` — Confirm password reset
+- `POST /auth/password-reset/request` — Request a password reset
+- `POST /auth/register` — Register with password
+- `GET /auth/session` — Current session
+- `GET /health` — Health
+- `GET /jobs` — List jobs
+- `POST /jobs` — Enqueue a job
+- `GET /jobs/{job_id}` — Get job
+- `POST /llm/chat` — Chat completion
+- `POST /llm/chat/stream` — Streaming chat completion
+- `GET /uploads` — List uploads
+- `POST /uploads` — Upload a file
+- `GET /uploads/{upload_id}` — Get upload metadata
+- `GET /uploads/{upload_id}/download` — Download a file
+<!-- END API ROUTES -->
 
 ## Auth model
 
 ### Passkeys by default
 
-The default authentication path uses passkeys (WebAuthn). The core flows are:
-
-1. `POST /auth/passkey/register/start` and `POST /auth/passkey/register/finish`
-2. `POST /auth/passkey/login/start` and `POST /auth/passkey/login/finish`
-3. `POST /auth/passkey/add/start` and `POST /auth/passkey/add/finish` for adding devices
-4. `GET /auth/passkeys`, `POST /auth/passkeys/{key_id}/revoke`, and `PATCH /auth/passkeys/{key_id}` for management
+The default authentication path uses passkeys (WebAuthn).
 
 ### Device signed JWTs
 
@@ -146,11 +148,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -11,6 +11,7 @@ README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.js
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -18,14 +19,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
 
-# FastAPI internal paths that we do not require in user docs.
-FRAMEWORK_PATHS = frozenset(
-    {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
-)
 
-
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_app_routes() -> list[tuple[str, str, str]]:
+    """Return (method, path, summary) tuples from the live FastAPI app OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -35,58 +31,81 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Only check API routes (not Mount, WebSocket, etc.).
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
-        if path in FRAMEWORK_PATHS:
-            continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+    schema = app.openapi()
+    paths = schema.get("paths", {})
+
+    routes = []
+    for path, operations in paths.items():
+        for method, op in operations.items():
+            routes.append((method.upper(), path, op.get("summary", "")))
+
+    return sorted(routes, key=lambda x: (x[1], x[0]))
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+def generate_routes_section(routes: list[tuple[str, str, str]]) -> str:
+    """Generate the markdown section for routes."""
+    lines = ["<!-- BEGIN API ROUTES -->"]
+    for method, path, summary in routes:
+        lines.append(f"- `{method} {path}` — {summary}")
+    lines.append("<!-- END API ROUTES -->")
+    return "\n".join(lines)
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
+
+def update_readme(new_section: str) -> bool:
+    """Update README.md with the new routes section. Returns True if changed."""
     readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Build a pattern like "GET /health" or "PATCH /auth/passkeys/\{key_id\}"
-        # that must appear as a recognisable method+path token in the README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+    pattern = r"<!-- BEGIN API ROUTES -->.*?<!-- END API ROUTES -->"
+
+    match = re.search(pattern, readme_text, flags=re.DOTALL)
+    if not match:
+        print("❌ Could not find <!-- BEGIN API ROUTES --> markers in README.md.")
+        sys.exit(1)
+
+    old_section = match.group(0)
+    if old_section == new_section:
+        return False
+
+    updated_text = (
+        readme_text[: match.start()] + new_section + readme_text[match.end() :]
+    )
+    README.write_text(updated_text)
+    return True
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description="Check or fix documented API routes.")
+    parser.add_argument(
+        "--fix", action="store_true", help="Update README.md automatically."
+    )
+    args = parser.parse_args()
+
     routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    new_section = generate_routes_section(routes)
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
-        return 1
+    if args.fix:
+        changed = update_readme(new_section)
+        if changed:
+            print(f"✅ Updated README.md with {len(routes)} API routes.")
+        else:
+            print(f"✅ README.md is already up to date with {len(routes)} API routes.")
+        return 0
+    else:
+        readme_text = README.read_text()
+        pattern = r"<!-- BEGIN API ROUTES -->.*?<!-- END API ROUTES -->"
+        match = re.search(pattern, readme_text, flags=re.DOTALL)
+        if not match:
+            print("❌ Could not find <!-- BEGIN API ROUTES --> markers in README.md.")
+            return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+        old_section = match.group(0)
+        if old_section != new_section:
+            print(
+                "❌ API routes in README.md are out of date. Run with --fix to update."
+            )
+            return 1
+
+        print(f"✅ All {len(routes)} API routes are documented correctly in README.md.")
+        return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Replaced manually maintained and fragmented API route lists in the README with a single, auto-generated section based on the OpenAPI schema.
🎯 Why: FastAPI v0.115+ hides paths in nested routers, which caused the previous verification script to miss routes. Parsing the OpenAPI schema ensures all routes are reliably documented and prevents documentation drift for API endpoints.
🧪 Verification: Run `uv run scripts/check_doc_routes.py` to verify the documented routes match the application schema.
🔒 Drift Prevention: Added a `--fix` argument to `check_doc_routes.py` and structural markdown tags to `README.md` to guarantee the endpoint list accurately reflects the code and can be auto-remediated.
🗺️ Evidence: `README.md`, `scripts/check_doc_routes.py`

---
*PR created automatically by Jules for task [2688807148672473480](https://jules.google.com/task/2688807148672473480) started by @ToolchainLab*