### PR TITLE
∷ Vector: Extract pure functional helpers for scope transformation pipelines

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-08-14 - Centralized pure functional transformations over local multi-step mutations
+**Learning:** Inhaling and manually processing scopes (parsing, filtering via comprehensions, re-serializing) inline within command handlers or domain logic obscures the actual transformation intent and duplicates edge-case handling logic across the repo.
+**Action:** Instead, centralize functional data-structure transformations like `add_scopes` and `remove_scopes` directly in the `authz` module. They should accept flexible inputs (`str | Iterable[str]`), use existing parsers, perform the logical transformation, and return the clear domain object array (`list[Scope]`). Callers then only handle one clean pipeline stage before persistence.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,17 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(current: str | Iterable[str], new: str | Iterable[str]) -> list[Scope]:
+    """Parse and combine two sets of scopes, preserving order and removing duplicates."""
+    return parse_scopes([*parse_scopes(current), *parse_scopes(new)])
+
+
+def remove_scopes(
+    current: str | Iterable[str], to_remove: str | Iterable[str]
+) -> list[Scope]:
+    """Parse and remove scopes from the current set, preserving order."""
+    existing = parse_scopes(current)
+    remove_set = set(parse_scopes(to_remove))
+    return [s for s in existing if s not in remove_set]

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    remove_scopes,
+    serialize_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +146,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +163,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +57,24 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_add_scopes(self):
+        assert add_scopes("admin", "demo") == [Scope("admin"), Scope("demo")]
+        assert add_scopes("admin,demo", ["reports", "demo"]) == [
+            Scope("admin"),
+            Scope("demo"),
+            Scope("reports"),
+        ]
+
+    def test_remove_scopes(self):
+        assert remove_scopes("admin,demo,reports", "demo") == [
+            Scope("admin"),
+            Scope("reports"),
+        ]
+        assert remove_scopes(["admin", "demo"], "reports") == [
+            Scope("admin"),
+            Scope("demo"),
+        ]
 
     def test_role_constants(self):
         assert USER == "user"


### PR DESCRIPTION
💡 What: Added `add_scopes` and `remove_scopes` pure functions to `authz.py` and refactored inline scope mutations in `cli/users.py` to use them.
🎯 Why: Centralizes data structure transformation logic instead of repeating parse-mutate-serialize pipelines inside command handlers. Reduces multi-step state mutations.
🧠 Design: `add_scopes` and `remove_scopes` operate on the flexible `str | Iterable[str]` inputs and utilize `parse_scopes` to maintain order and uniqueness invariants centrally, returning a safe `list[Scope]`.
λ FP Angle: Replaces inline, mutable staging operations (like local sets and comprehensions) with centralized, pure, declarative transformation functions.
✅ Verification: Tests run successfully via `pytest`, static checks pass with `ruff` and `mypy`.
🧪 Edge cases: Both single-string and list-of-strings inputs are elegantly handled and accurately parsed, ensuring duplicate scopes are safely ignored during addition or correctly handled during removal.
⚠️ Risk: Low risk, preserves existing behavior exactly while clarifying semantic intent.

---
*PR created automatically by Jules for task [10855998430823566926](https://jules.google.com/task/10855998430823566926) started by @ToolchainLab*