### PR TITLE
🎨 Palette: Add character count to limited inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,1 @@
+## 2024-08-14 - Character Count Indicator for Display Name\n **Learning:** Add a character count indicator for input fields with a strict max length like Display Name. This provides immediate feedback and prevents users from encountering errors upon submission.\n **Action:** Added a simple text indicator (e.g., `10/200`) below the input field for character count.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/components/Input.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/components/Input.tsx
@@ -5,17 +5,27 @@ import { Label } from "./Label";
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  showCount?: boolean;
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, label, error, id, ...props }, ref) => {
+  ({ className, type, label, error, showCount, id, ...props }, ref) => {
     const generatedId = useId();
     const inputId = id || generatedId;
     const errorId = `${inputId}-error`;
 
     return (
       <div className="space-y-2">
-        {label && <Label htmlFor={inputId}>{label}</Label>}
+        {(label || (showCount && props.maxLength)) && (
+          <div className="flex justify-between items-baseline">
+            {label ? <Label htmlFor={inputId}>{label}</Label> : <div />}
+            {showCount && props.maxLength && (
+              <span className="text-xs text-text-muted">
+                {String(props.value ?? "").length}/{props.maxLength}
+              </span>
+            )}
+          </div>
+        )}
         <input
           id={inputId}
           type={type}

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Register.tsx
@@ -92,6 +92,7 @@ export function Register() {
               data-testid="register-display-name"
               autoComplete="name"
               maxLength={DISPLAY_NAME_MAX_LENGTH}
+              showCount
               autoFocus
             />
 

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -97,6 +97,7 @@ function PasskeyName({
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             maxLength={MAX_NAME_LENGTH}
+            showCount
             className="h-8 w-48"
             autoFocus
             onKeyDown={(e) => {


### PR DESCRIPTION
💡 What: Added a `showCount` prop to the `Input` component to display a character count indicator when combined with `maxLength`, and enabled it for the Register display name field and Settings passkey name field.
🎯 Why: Provides users with immediate visual feedback on remaining character allowance for fields with strict length limits, preventing frustrating submission errors.
📸 Before/After: Before, no indication of length limits until error. After, a clear `current/max` indicator is shown on top right of the input label.
♿ Accessibility: The character count is presented as regular text within the form context, making the boundaries explicit.

---
*PR created automatically by Jules for task [13596484715811411034](https://jules.google.com/task/13596484715811411034) started by @ToolchainLab*