### PR TITLE
∴ Vector: Centralize scope transformations into pure helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2025-02-15 - Prefer pure helpers over inline staging logic
+**Learning:** The CLI command handlers used ad-hoc inline multi-step parsing, deduplication, and set logic to combine or remove scopes. This obscured the core transformation and duplicated semantics logic inside side-effect-heavy command handlers.
+**Action:** When working with collections of domain types like scopes, define centralized pure functional transformations (like `add_scopes` and `remove_scopes`) alongside the types, rather than performing multi-step state mutations inline.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -41,3 +41,19 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(
+    current: str | Iterable[str], to_add: str | Iterable[str]
+) -> list[Scope]:
+    """Return a new list of scopes with the added scopes."""
+    return parse_scopes([*parse_scopes(current), *parse_scopes(to_add)])
+
+
+def remove_scopes(
+    current: str | Iterable[str], to_remove: str | Iterable[str]
+) -> list[Scope]:
+    """Return a new list of scopes with the specified scopes removed."""
+    existing = parse_scopes(current)
+    removing = set(parse_scopes(to_remove))
+    return [s for s in existing if s not in removing]

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    remove_scopes,
+    serialize_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +146,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = serialize_scopes(add_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +163,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = serialize_scopes(remove_scopes(user.scopes, args.scope))
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -55,6 +57,14 @@ class TestScopes:
         granted = parse_scopes("admin,demo,reports")
         required = parse_scopes("admin,demo")
         assert missing_scopes(granted, required) == set()
+
+    def test_add_scopes(self):
+        assert add_scopes("a,b", "c,a") == [Scope("a"), Scope("b"), Scope("c")]
+        assert add_scopes(["a", "b"], "c,a") == [Scope("a"), Scope("b"), Scope("c")]
+
+    def test_remove_scopes(self):
+        assert remove_scopes("a,b,c", "b,d") == [Scope("a"), Scope("c")]
+        assert remove_scopes(["a", "b", "c"], "b,d") == [Scope("a"), Scope("c")]
 
     def test_role_constants(self):
         assert USER == "user"


### PR DESCRIPTION
💡 What: Extracted inline scope addition/removal logic from `src/h4ckath0n/cli/users.py` into shared pure functional helpers `add_scopes` and `remove_scopes` in `src/h4ckath0n/auth/authz.py`.
🎯 Why: Centralizes authorization semantics and removes repeated, mutation-heavy inline parsing/staging logic from CLI command handlers.
🧠 Design: By defining `add_scopes` and `remove_scopes` directly alongside the `Scope` type and `parse_scopes` helper, we give callers explicit, reusable pure transformation pipelines instead of forcing them to perform ad-hoc staging.
λ FP Angle: Replaces inline, multi-step staging (parsing -> manipulating sets -> reserializing) with simple, explicit pure data-in/data-out transformation pipelines.
✅ Verification: Handled via `uv run pytest -v` and `uv run --locked mypy src`.
🧪 Edge cases: Edge cases like whitespace, ordering, and duplicate scopes are correctly handled since the new helpers delegate back to `parse_scopes`.
⚠️ Risk: Very low. Existing behavior is exactly preserved, but expressed as a centralized pure function.

---
*PR created automatically by Jules for task [3072640383262412669](https://jules.google.com/task/3072640383262412669) started by @ToolchainLab*