### PR TITLE
🎨 Palette: [Make hover-revealed edit buttons keyboard accessible]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-15 - Make hover-revealed elements keyboard accessible
+**Learning:** When using Tailwind to hide interactive elements until hovered (e.g., `opacity-0 group-hover:opacity-100`), they remain invisible to keyboard users who navigate via Tab.
+**Action:** Always include `focus-visible:opacity-100` (or `group-focus-within:opacity-100`) alongside `group-hover:opacity-100` to ensure the element is visible to keyboard users when focused.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -149,7 +149,7 @@ function PasskeyName({
           variant="ghost"
           data-testid="passkey-edit-btn"
           onClick={startEdit}
-          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />


### PR DESCRIPTION
💡 What: Added `focus-visible:opacity-100` to the passkey edit button in `Settings.tsx`.
🎯 Why: The edit button used `opacity-0 group-hover:opacity-100`, making it invisible to keyboard-only users who navigate via `Tab`.
📸 Before/After: N/A (Visual change only visible via keyboard focus)
♿ Accessibility: Ensures that keyboard users can clearly see the edit button when it receives focus, adhering to WCAG focus visibility requirements.

---
*PR created automatically by Jules for task [12583501941152795148](https://jules.google.com/task/12583501941152795148) started by @ToolchainLab*