### PR TITLE
🧭 Atlas: Replace hand-written endpoint lists with generated tables from OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,26 +63,33 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- BEGIN API ROUTES -->
+- `GET /` — welcome
+- `GET /auth/passkeys` — list passkeys
+- `GET /auth/session` — current session
+- `GET /health` — health
+- `GET /jobs` — list jobs
+- `GET /jobs/{job_id}` — get job
+- `GET /uploads` — list uploads
+- `GET /uploads/{upload_id}` — get upload metadata
+- `GET /uploads/{upload_id}/download` — download a file
+- `PATCH /auth/passkeys/{key_id}` — rename a passkey
+- `POST /auth/login` — login with password
+- `POST /auth/passkey/add/finish` — finish adding a passkey
+- `POST /auth/passkey/add/start` — start adding a passkey
+- `POST /auth/passkey/login/finish` — finish passkey login
+- `POST /auth/passkey/login/start` — start passkey login
+- `POST /auth/passkey/register/finish` — finish passkey registration
+- `POST /auth/passkey/register/start` — start passkey registration
+- `POST /auth/passkeys/{key_id}/revoke` — revoke a passkey
+- `POST /auth/password-reset/confirm` — confirm password reset
+- `POST /auth/password-reset/request` — request a password reset
+- `POST /auth/register` — register with password
+- `POST /jobs` — enqueue a job
+- `POST /llm/chat` — chat completion
+- `POST /llm/chat/stream` — streaming chat completion
+- `POST /uploads` — upload a file
+<!-- END API ROUTES -->
 
 ## Auth model
 

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -11,6 +11,7 @@ README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.js
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -24,8 +25,8 @@ FRAMEWORK_PATHS = frozenset(
 )
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_app_routes() -> list[tuple[str, str, str]]:
+    """Return (method, path, summary) pairs from the live FastAPI app's OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -35,57 +36,77 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Skip non-HTTP routes.
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
+    openapi_schema = app.openapi()
+    paths = openapi_schema.get("paths", {})
+    routes: list[tuple[str, str, str]] = []
+
+    for path, methods_dict in paths.items():
         if path in FRAMEWORK_PATHS:
             continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
+        for method, op in methods_dict.items():
+            if method.upper() == "HEAD":
                 continue
-            routes.append((method, path))
+            summary = op.get("summary", "")
+            if summary:
+                summary = summary[0].lower() + summary[1:]
+            routes.append((method.upper(), path, summary))
+
     return sorted(routes)
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
-
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
-    readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Match exact method/path tokens in README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
+def generate_routes_block(routes: list[tuple[str, str, str]]) -> str:
+    """Generate the markdown block for API routes."""
+    lines = ["<!-- BEGIN API ROUTES -->"]
+    for method, path, summary in routes:
+        suffix = f" — {summary}" if summary else ""
+        lines.append(f"- `{method} {path}`{suffix}")
+    lines.append("<!-- END API ROUTES -->")
+    return "\n".join(lines)
 
 
 def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
+    parser = argparse.ArgumentParser(
+        description="Check or fix API routes documentation."
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Fix README.md by updating the API routes block.",
+    )
+    args = parser.parse_args()
 
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
-        print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
-        )
+    routes = get_app_routes()
+    expected_block = generate_routes_block(routes)
+
+    readme_text = README.read_text()
+
+    start_marker = "<!-- BEGIN API ROUTES -->"
+    end_marker = "<!-- END API ROUTES -->"
+
+    if start_marker not in readme_text or end_marker not in readme_text:
+        print(f"❌ Missing {start_marker} or {end_marker} in README.md")
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
-    return 0
+    pattern = re.compile(rf"{start_marker}.*?{end_marker}", re.DOTALL)
+    current_block_match = pattern.search(readme_text)
+
+    if not current_block_match:
+        print("❌ Could not extract the current API routes block from README.md")
+        return 1
+
+    if current_block_match.group(0) == expected_block:
+        print(f"✅ All {len(routes)} API routes are correctly documented in README.md.")
+        return 0
+
+    if args.fix:
+        new_readme_text = pattern.sub(expected_block, readme_text)
+        README.write_text(new_readme_text)
+        print(f"✨ Updated README.md with {len(routes)} API routes.")
+        return 0
+
+    print("❌ The API routes in README.md do not match the expected output.")
+    print("Run `uv run scripts/check_doc_routes.py --fix` to update it.")
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Updated `scripts/check_doc_routes.py` to read API routes from the internal OpenAPI schema instead of `app.routes` and added a `--fix` flag. Replaced manual route lists in `README.md` with dynamic generation using `<!-- BEGIN API ROUTES -->` and `<!-- END API ROUTES -->`.
🎯 Why: The previous drift check missed endpoints nested in sub-routers (like the h4ckath0n passkey endpoints). Also, manual documentation creates heavy maintenance burden and easily goes out of sync with actual application behavior.
🧪 Verification: Run `uv run scripts/check_doc_routes.py` to verify no drift.
🔒 Drift Prevention: The CI test using `check_doc_routes.py` will now properly fail if the OpenAPI schema changes without re-running the script with `--fix`.
🗺️ Evidence: Verified against `src/h4ckath0n/app.py` and `scripts/check_doc_routes.py`.

---
*PR created automatically by Jules for task [9075114029335895066](https://jules.google.com/task/9075114029335895066) started by @ToolchainLab*