### PR TITLE
∴ Vector: Centralize scope mutations into pure functional helpers

### DIFF
--- a/.jules/vector.md
+++ b/.jules/vector.md
@@ -1,0 +1,3 @@
+## 2024-03-22 - Centralize Scopes Transformations
+**Learning:** The codebase has functional primitives like `parse_scopes`, `serialize_scopes`, and `missing_scopes` for scopes processing. However, mutating scope transformations are still manually written in multiple places, such as CLI add/remove commands, rather than relying on pure functional transformation helpers.
+**Action:** Centralize data mutation by adding composable, pure functional helpers `add_scopes(existing, new)` and `remove_scopes(existing, to_remove)` to `authz.py`.

--- a/src/h4ckath0n/auth/authz.py
+++ b/src/h4ckath0n/auth/authz.py
@@ -40,3 +40,17 @@ def serialize_scopes(scopes: Iterable[Scope]) -> str:
 def missing_scopes(granted: Iterable[Scope], required: Iterable[Scope]) -> set[Scope]:
     """Return the required scopes that are not present in *granted*."""
     return set(required).difference(granted)
+
+
+def add_scopes(existing_raw: str | Iterable[str], new_raw: str | Iterable[str]) -> str:
+    """Combine and deduplicate existing and new scopes into a canonical string."""
+    return serialize_scopes(parse_scopes(existing_raw) + parse_scopes(new_raw))
+
+
+def remove_scopes(
+    existing_raw: str | Iterable[str], remove_raw: str | Iterable[str]
+) -> str:
+    """Remove specific scopes from an existing set and return a canonical string."""
+    existing = parse_scopes(existing_raw)
+    to_remove = set(parse_scopes(remove_raw))
+    return serialize_scopes(s for s in existing if s not in to_remove)

--- a/src/h4ckath0n/cli/users.py
+++ b/src/h4ckath0n/cli/users.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 
-from h4ckath0n.auth.authz import parse_scopes, serialize_scopes
+from h4ckath0n.auth.authz import (
+    add_scopes,
+    remove_scopes,
+)
 from h4ckath0n.auth.models import Device, User, WebAuthnCredential
 from h4ckath0n.cli._common import (
     EXIT_BAD_ARGS,
@@ -142,8 +145,7 @@ def _cmd_users_scopes_add(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        user.scopes = serialize_scopes((*existing, *parse_scopes(args.scope)))
+        user.scopes = add_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)
@@ -160,10 +162,7 @@ def _cmd_users_scopes_remove(args: argparse.Namespace) -> int:
             return err
         assert user is not None
 
-        existing = parse_scopes(user.scopes)
-        to_remove = set(parse_scopes(args.scope))
-        remaining = [s for s in existing if s not in to_remove]
-        user.scopes = serialize_scopes(remaining)
+        user.scopes = remove_scopes(user.scopes, args.scope)
         session.commit()
         session.refresh(user)
         _output(_user_dict(user), fmt=args.format, pretty=args.pretty)

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -8,8 +8,10 @@ from h4ckath0n.auth.authz import (
     ADMIN,
     USER,
     Scope,
+    add_scopes,
     missing_scopes,
     parse_scopes,
+    remove_scopes,
     serialize_scopes,
 )
 from h4ckath0n.auth.passkeys.errors import (
@@ -42,6 +44,14 @@ class TestScopes:
     def test_serialize_roundtrips(self):
         raw = "admin,demo,reports"
         assert serialize_scopes(parse_scopes(raw)) == raw
+
+    def test_add_scopes(self):
+        assert add_scopes("admin,demo", "reports") == "admin,demo,reports"
+        assert add_scopes("admin", "admin,demo") == "admin,demo"
+
+    def test_remove_scopes(self):
+        assert remove_scopes("admin,demo,reports", "demo,admin") == "reports"
+        assert remove_scopes("admin,demo", "reports") == "admin,demo"
 
     def test_serialize_deduplicates(self):
         assert serialize_scopes([Scope("a"), Scope("a"), Scope("b")]) == "a,b"


### PR DESCRIPTION
- 💡 What: Extract `add_scopes` and `remove_scopes` pure functions to `authz.py` and replace inline mutations in `cli/users.py`.
- 🎯 Why: Scope addition/removal logic was manually implemented inline across CLI handlers. Centralizing it reduces duplicated parsing logic and potential bugs.
- 🧠 Design: By defining `add_scopes` and `remove_scopes` next to `parse_scopes`, all logic around canonical representation (comma-separated, deduplicated) stays encapsulated in one place.
- λ FP Angle: Transforms multiple inline imperative parsing and filtering steps into single composable, pure function calls.
- ✅ Verification: Added explicit tests for `add_scopes` and `remove_scopes`. Formatter, linter, mypy, and test suite pass.
- 🧪 Edge cases: `add_scopes` automatically handles duplicate incoming scopes. `remove_scopes` cleanly ignores non-existent scopes.
- ⚠️ Risk: Low risk; logic is behaviorally identical and backed by tests.

---
*PR created automatically by Jules for task [10631865721534893527](https://jules.google.com/task/10631865721534893527) started by @ToolchainLab*