### PR TITLE
🎨 Palette: [UX improvement] Make passkey edit button keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-16 - Keyboard visibility for hover-only actions
+**Learning:** When using Tailwind to hide interactive elements until hovered (e.g., `opacity-0 group-hover:opacity-100`), keyboard users cannot see the element when they focus it via Tab.
+**Action:** Always include `focus-visible:opacity-100` (or `group-focus-within:opacity-100`) when using `opacity-0 group-hover:opacity-100` to ensure the element becomes visible when receiving keyboard focus.

--- a/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
+++ b/packages/create-h4ckath0n/templates/fullstack/web/src/pages/Settings.tsx
@@ -149,7 +149,7 @@ function PasskeyName({
           variant="ghost"
           data-testid="passkey-edit-btn"
           onClick={startEdit}
-          className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+          className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           aria-label="Edit passkey name"
         >
           <Pencil className="w-3 h-3" />


### PR DESCRIPTION
💡 What: Added `focus-visible:opacity-100` to the passkey edit button.
🎯 Why: The edit button was completely hidden (`opacity-0`) unless hovered (`group-hover:opacity-100`). This made it inaccessible for keyboard users navigating via Tab, as the button would receive focus but remain invisible.
📸 Before/After: Before: Button invisible on focus. After: Button visible on focus.
♿ Accessibility: Ensures the edit button is visible to screen readers and keyboard navigators when focused.

---
*PR created automatically by Jules for task [10122794834283461647](https://jules.google.com/task/10122794834283461647) started by @ToolchainLab*