### PR TITLE
🧭 Atlas: Replace hand-written API route list with OpenAPI generated table

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -9,3 +9,9 @@ ideally inside backtick delimiters, to avoid this trap.
 
 **Action:** Always match method+path together in drift checks. Use `` `METHOD /path` `` patterns
 that mirror the actual markdown formatting.
+
+## 2026-03-01 - Generating OpenAPI route tables prevents missing nested routes
+
+**Learning:** Checking against `app.routes` misses routes mounted inside an `_IncludedRouter` (default behavior in FastAPI v0.115+), which can cause drift checks to falsely pass while missing the majority of routes. Generating markdown dynamically from `app.openapi().get("paths", {})` is both more accurate and completely removes the need for hand-maintained lists in README.md.
+
+**Action:** Consolidate multiple API route lists in markdown by injecting generated markdown tables bounded by `<!-- BEGIN API ROUTES -->` markers. Ensure the drift check tool both enforces and fixes the synchronization using the OpenAPI schema.

--- a/README.md
+++ b/README.md
@@ -63,26 +63,35 @@ uv run uvicorn your_module:app --reload
 
 ## Built-in routes
 
-- `GET /` — welcome message confirming the app is reachable.
-- `GET /health` — returns `{"status": "healthy"}` for load balancer and deployment checks.
-
-### Session
-- `GET /auth/session` — returns the current user session details.
-
-### Background Jobs
-- `GET /jobs` — list jobs.
-- `POST /jobs` — enqueue a background job.
-- `GET /jobs/{job_id}` — get the status and result of a job.
-
-### Uploads
-- `GET /uploads` — list uploaded files.
-- `POST /uploads` — upload a new file.
-- `GET /uploads/{upload_id}` — get metadata for a specific upload.
-- `GET /uploads/{upload_id}/download` — download the uploaded file.
-
-### LLM Chat
-- `POST /llm/chat` — send a message to the language model.
-- `POST /llm/chat/stream` — stream responses from the language model.
+<!-- BEGIN API ROUTES -->
+| Method | Path | Summary |
+|---|---|---|
+| `GET` | `/` | Welcome |
+| `POST` | `/auth/login` | Login with password |
+| `POST` | `/auth/passkey/add/finish` | Finish adding a passkey |
+| `POST` | `/auth/passkey/add/start` | Start adding a passkey |
+| `POST` | `/auth/passkey/login/finish` | Finish passkey login |
+| `POST` | `/auth/passkey/login/start` | Start passkey login |
+| `POST` | `/auth/passkey/register/finish` | Finish passkey registration |
+| `POST` | `/auth/passkey/register/start` | Start passkey registration |
+| `GET` | `/auth/passkeys` | List passkeys |
+| `PATCH` | `/auth/passkeys/{key_id}` | Rename a passkey |
+| `POST` | `/auth/passkeys/{key_id}/revoke` | Revoke a passkey |
+| `POST` | `/auth/password-reset/confirm` | Confirm password reset |
+| `POST` | `/auth/password-reset/request` | Request a password reset |
+| `POST` | `/auth/register` | Register with password |
+| `GET` | `/auth/session` | Current session |
+| `GET` | `/health` | Health |
+| `GET` | `/jobs` | List jobs |
+| `POST` | `/jobs` | Enqueue a job |
+| `GET` | `/jobs/{job_id}` | Get job |
+| `POST` | `/llm/chat` | Chat completion |
+| `POST` | `/llm/chat/stream` | Streaming chat completion |
+| `GET` | `/uploads` | List uploads |
+| `POST` | `/uploads` | Upload a file |
+| `GET` | `/uploads/{upload_id}` | Get upload metadata |
+| `GET` | `/uploads/{upload_id}/download` | Download a file |
+<!-- END API ROUTES -->
 
 ## Auth model
 
@@ -149,11 +158,6 @@ def refund(user=require_scopes("billing:refund")):
 
 Password routes mount only when the password extra is installed and
 `H4CKATH0N_PASSWORD_AUTH_ENABLED=true`.
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/password-reset/request`
-- `POST /auth/password-reset/confirm`
 
 Password auth is only an identity bootstrap. It binds a device key but does not return
 access tokens, refresh tokens, or cookies.

--- a/scripts/check_doc_routes.py
+++ b/scripts/check_doc_routes.py
@@ -2,30 +2,28 @@
 """Drift-prevention check: verify that every API route in the FastAPI app is documented.
 
 Usage (from repo root):
-    uv run scripts/check_doc_routes.py
+    uv run scripts/check_doc_routes.py [--fix]
 
-The script imports the h4ckath0n app, enumerates all routes, and checks that
-README.md mentions each one. Routes provided by FastAPI itself (e.g. /openapi.json,
-/docs, /redoc) are excluded from the check.
+The script imports the h4ckath0n app, enumerates all routes using the OpenAPI schema,
+and checks that README.md documents each one in a generated table between
+<!-- BEGIN API ROUTES --> and <!-- END API ROUTES -->.
 """
 
 from __future__ import annotations
 
-import re
+import argparse
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
 
-# FastAPI paths omitted from user docs.
-FRAMEWORK_PATHS = frozenset(
-    {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
-)
+MARKER_BEGIN = "<!-- BEGIN API ROUTES -->"
+MARKER_END = "<!-- END API ROUTES -->"
 
 
-def get_app_routes() -> list[tuple[str, str]]:
-    """Return (method, path) pairs from the live FastAPI app."""
+def get_app_routes() -> list[tuple[str, str, str]]:
+    """Return (method, path, summary) from the live FastAPI app's OpenAPI schema."""
     from h4ckath0n.app import create_app  # noqa: E402
     from h4ckath0n.config import Settings  # noqa: E402
 
@@ -35,57 +33,69 @@ def get_app_routes() -> list[tuple[str, str]]:
     )
     app = create_app(settings)
 
-    routes: list[tuple[str, str]] = []
-    for route in app.routes:
-        # Skip non-HTTP routes.
-        if not hasattr(route, "methods") or not hasattr(route, "path"):
-            continue
-        path: str = route.path  # type: ignore[union-attr]
-        if path in FRAMEWORK_PATHS:
-            continue
-        for method in sorted(route.methods):  # type: ignore[union-attr]
-            if method == "HEAD":
-                continue
-            routes.append((method, path))
-    return sorted(routes)
+    schema = app.openapi()
+    paths = schema.get("paths", {})
+
+    routes: list[tuple[str, str, str]] = []
+    for path, methods in paths.items():
+        for method, op in methods.items():
+            routes.append((method.upper(), path, op.get("summary", "")))
+    return sorted(routes, key=lambda x: (x[1], x[0]))
 
 
-def check_routes_in_readme(
-    routes: list[tuple[str, str]],
-) -> list[tuple[str, str]]:
-    """Return routes that are not mentioned anywhere in README.md.
+def generate_routes_table(routes: list[tuple[str, str, str]]) -> str:
+    """Generate the markdown table for routes."""
+    lines = [
+        "| Method | Path | Summary |",
+        "|---|---|---|",
+    ]
+    for method, path, summary in routes:
+        lines.append(f"| `{method}` | `{path}` | {summary} |")
+    return "\n".join(lines)
 
-    We look for ``METHOD /path`` (e.g. ``GET /health``) so that sub-path
-    matches like ``/auth/passkeys/{key_id}`` inside
-    ``/auth/passkeys/{key_id}/revoke`` are not false positives.
-    """
+
+def check_routes_in_readme(routes: list[tuple[str, str, str]], fix: bool) -> int:
+    """Check or fix the routes table in README.md."""
     readme_text = README.read_text()
-    missing: list[tuple[str, str]] = []
-    for method, path in routes:
-        # Match exact method/path tokens in README.
-        path_re = re.escape(path)
-        combined = rf"`{method}\s+{path_re}`"
-        if not re.search(combined, readme_text, re.IGNORECASE):
-            missing.append((method, path))
-    return missing
 
-
-def main() -> int:
-    routes = get_app_routes()
-    missing = check_routes_in_readme(routes)
-
-    if missing:
-        print("❌ The following API routes are NOT documented in README.md:\n")
-        for method, path in missing:
-            print(f"  {method:6s} {path}")
+    if MARKER_BEGIN not in readme_text or MARKER_END not in readme_text:
         print(
-            "\nAdd these routes to README.md or, if intentionally undocumented, "
-            "add them to FRAMEWORK_PATHS in this script."
+            "❌ Markers <!-- BEGIN API ROUTES --> and <!-- END API ROUTES --> "
+            "not found in README.md."
         )
         return 1
 
-    print(f"✅ All {len(routes)} API routes are documented in README.md.")
+    before_marker = readme_text.split(MARKER_BEGIN)[0]
+    after_marker = readme_text.split(MARKER_END)[1]
+
+    expected_table = generate_routes_table(routes)
+    expected_content = (
+        f"{before_marker}{MARKER_BEGIN}\n{expected_table}\n{MARKER_END}{after_marker}"
+    )
+
+    if readme_text != expected_content:
+        if fix:
+            README.write_text(expected_content)
+            print("✅ README.md has been updated with the latest API routes.")
+            return 0
+        else:
+            print("❌ README.md is out of sync with the API routes.")
+            print("Run `uv run scripts/check_doc_routes.py --fix` to update it.")
+            return 1
+
+    print(
+        f"✅ All {len(routes)} API routes are documented and up-to-date in README.md."
+    )
     return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check API routes drift in README.md")
+    parser.add_argument("--fix", action="store_true", help="Fix drift in README.md")
+    args = parser.parse_args()
+
+    routes = get_app_routes()
+    return check_routes_in_readme(routes, fix=args.fix)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: Replaced hand-written API route documentation in README with a generated markdown table dynamically populated from the OpenAPI schema.
🎯 Why: The previous validation script only detected 2 out of 23 routes due to a FastAPI nested routing change (`_IncludedRouter`). Consolidating the routes and dynamically generating them prevents drift and eliminates duplicate endpoint explanations (like the password auth list).
🧪 Verification: Run `uv run scripts/check_doc_routes.py`
🔒 Drift Prevention: Added `<!-- BEGIN API ROUTES -->` and `<!-- END API ROUTES -->` markers to the README and updated `scripts/check_doc_routes.py` with a `--fix` argument to generate the table dynamically.
🗺️ Evidence: `scripts/check_doc_routes.py`, `README.md`

---
*PR created automatically by Jules for task [4621220512121737225](https://jules.google.com/task/4621220512121737225) started by @ToolchainLab*